### PR TITLE
feat: aggregate snapshots for fast rehydration (#123)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -168,7 +168,10 @@
       "WebFetch(domain:docs.ecotone.tech)",
       "Bash(gh issue:*)",
       "Bash(for i:*)",
-      "Bash(do echo:*)"
+      "Bash(do echo:*)",
+      "Bash(gpg:*)",
+      "Bash(gh pr:*)",
+      "Bash(git branch:*)"
     ]
   },
   "hooks": {

--- a/crates/nexus-fjall/Cargo.toml
+++ b/crates/nexus-fjall/Cargo.toml
@@ -10,6 +10,9 @@ readme = "../../README.md"
 keywords = ["event-sourcing", "event-store", "fjall", "embedded"]
 categories = ["database"]
 
+[features]
+snapshot = ["nexus-store/snapshot"]
+
 [dependencies]
 fjall = { workspace = true }
 nexus = { version = "0.1.0", path = "../nexus" }

--- a/crates/nexus-fjall/src/builder.rs
+++ b/crates/nexus-fjall/src/builder.rs
@@ -98,6 +98,15 @@ impl FjallStoreBuilder {
         };
         let events = db.open_partition("events", events_opts)?;
 
+        // --- snapshots partition: point-read-optimised (like streams) ---
+        #[cfg(feature = "snapshot")]
+        let snapshots = {
+            let snapshots_defaults = PartitionCreateOptions::default()
+                .block_size(4_096)
+                .bloom_filter_bits(Some(15));
+            db.open_partition("snapshots", snapshots_defaults)?
+        };
+
         // Recover `next_stream_id` by scanning all stream metadata entries
         // and finding the maximum numeric_id.
         let mut max_id: u64 = 0;
@@ -133,6 +142,8 @@ impl FjallStoreBuilder {
             db,
             streams,
             events,
+            #[cfg(feature = "snapshot")]
+            snapshots,
             next_stream_id: AtomicU64::new(next_id),
         })
     }

--- a/crates/nexus-fjall/src/encoding.rs
+++ b/crates/nexus-fjall/src/encoding.rs
@@ -171,6 +171,61 @@ pub fn decode_event_value(value: &[u8]) -> Result<(u32, &str, &[u8]), DecodeErro
     Ok((schema_version, event_type, payload))
 }
 
+// ═══════════════════════════════════════════════════════════════════════════
+// Snapshot encoding
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Size of a snapshot key: `[u64 BE stream_numeric_id]`.
+#[cfg(feature = "snapshot")]
+pub(crate) const SNAPSHOT_KEY_SIZE: usize = 8;
+
+/// Size of the snapshot value header: `[u32 LE schema_version][u64 BE version]`.
+#[cfg(feature = "snapshot")]
+pub(crate) const SNAPSHOT_VALUE_HEADER_SIZE: usize = 12;
+
+/// Encode a snapshot key as `[u64 BE stream_numeric_id]`.
+#[cfg(feature = "snapshot")]
+#[must_use]
+pub(crate) fn encode_snapshot_key(stream_numeric_id: u64) -> [u8; SNAPSHOT_KEY_SIZE] {
+    stream_numeric_id.to_be_bytes()
+}
+
+/// Encode a snapshot value as `[u32 LE schema_version][u64 BE version][payload]`.
+#[cfg(feature = "snapshot")]
+pub(crate) fn encode_snapshot_value(
+    buf: &mut Vec<u8>,
+    schema_version: u32,
+    version: u64,
+    payload: &[u8],
+) {
+    buf.clear();
+    buf.reserve(SNAPSHOT_VALUE_HEADER_SIZE + payload.len());
+    buf.extend_from_slice(&schema_version.to_le_bytes());
+    buf.extend_from_slice(&version.to_be_bytes());
+    buf.extend_from_slice(payload);
+}
+
+/// Decode a snapshot value from `[u32 LE schema_version][u64 BE version][payload]`.
+///
+/// # Errors
+///
+/// Returns [`DecodeError::ValueTooShort`] if value is shorter than the header.
+#[cfg(feature = "snapshot")]
+pub(crate) fn decode_snapshot_value(value: &[u8]) -> Result<(u32, u64, &[u8]), DecodeError> {
+    if value.len() < SNAPSHOT_VALUE_HEADER_SIZE {
+        return Err(DecodeError::ValueTooShort {
+            min: SNAPSHOT_VALUE_HEADER_SIZE,
+            actual: value.len(),
+        });
+    }
+    let schema_version = u32::from_le_bytes([value[0], value[1], value[2], value[3]]);
+    let version = u64::from_be_bytes([
+        value[4], value[5], value[6], value[7], value[8], value[9], value[10], value[11],
+    ]);
+    let payload = &value[12..];
+    Ok((schema_version, version, payload))
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, reason = "test code")]
 mod tests {

--- a/crates/nexus-fjall/src/error.rs
+++ b/crates/nexus-fjall/src/error.rs
@@ -8,8 +8,11 @@ pub enum FjallError {
     Io(#[from] fjall::Error),
 
     /// Stored value has corrupt or unrecognizable byte layout.
-    #[error("corrupt value in stream '{stream_id}' at version {version}")]
-    CorruptValue { stream_id: String, version: u64 },
+    #[error("corrupt value in stream '{stream_id}' at version {version:?}")]
+    CorruptValue {
+        stream_id: String,
+        version: Option<u64>,
+    },
 
     /// Stream metadata has wrong byte size.
     #[error("corrupt metadata for stream '{stream_id}'")]

--- a/crates/nexus-fjall/src/store.rs
+++ b/crates/nexus-fjall/src/store.rs
@@ -283,7 +283,7 @@ mod snapshot_impl {
             let value = self.snapshots.get(key)?;
             match value {
                 Some(bytes) => {
-                    let (schema_version, version_raw, payload) = decode_snapshot_value(&bytes)
+                    let (schema_version_raw, version_raw, payload) = decode_snapshot_value(&bytes)
                         .map_err(|_| FjallError::CorruptValue {
                             stream_id: id_string,
                             version: None,
@@ -293,12 +293,14 @@ mod snapshot_impl {
                             stream_id: id.to_string(),
                             version: None,
                         })?;
-                    let snap =
-                        PersistedSnapshot::try_new(version, schema_version, payload.to_vec())
-                            .map_err(|_| FjallError::CorruptValue {
+                    let schema_version =
+                        std::num::NonZeroU32::new(schema_version_raw).ok_or_else(|| {
+                            FjallError::CorruptValue {
                                 stream_id: id.to_string(),
                                 version: Some(version_raw),
-                            })?;
+                            }
+                        })?;
+                    let snap = PersistedSnapshot::new(version, schema_version, payload.to_vec());
                     Ok(Some(snap))
                 }
                 None => Ok(None),
@@ -336,7 +338,7 @@ mod snapshot_impl {
             let mut buf = Vec::new();
             encode_snapshot_value(
                 &mut buf,
-                snapshot.schema_version(),
+                snapshot.schema_version().get(),
                 snapshot.version().as_u64(),
                 snapshot.payload(),
             );

--- a/crates/nexus-fjall/src/store.rs
+++ b/crates/nexus-fjall/src/store.rs
@@ -19,11 +19,16 @@ use std::sync::atomic::{AtomicU64, Ordering};
 /// stream metadata and `events` for event rows), and a monotonic
 /// counter for allocating stream numeric IDs.
 ///
+/// When the `snapshot` feature is enabled, an additional `snapshots`
+/// partition is available for storing aggregate snapshots.
+///
 /// Use [`FjallStore::builder`] to configure and open a store.
 pub struct FjallStore {
     pub(crate) db: fjall::TxKeyspace,
     pub(crate) streams: fjall::TxPartitionHandle,
     pub(crate) events: fjall::TxPartitionHandle,
+    #[cfg(feature = "snapshot")]
+    pub(crate) snapshots: fjall::TxPartitionHandle,
     pub(crate) next_stream_id: AtomicU64,
 }
 
@@ -236,6 +241,135 @@ impl RawEventStore for FjallStore {
             #[cfg(debug_assertions)]
             prev_version: None,
         })
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SnapshotStore implementation
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[cfg(feature = "snapshot")]
+mod snapshot_impl {
+    use super::*;
+    use crate::encoding::{
+        decode_snapshot_value, decode_stream_meta, encode_snapshot_key, encode_snapshot_value,
+    };
+    use nexus_store::snapshot::{PendingSnapshot, PersistedSnapshot, SnapshotStore};
+
+    impl SnapshotStore for FjallStore {
+        type Error = FjallError;
+
+        async fn load_snapshot(
+            &self,
+            id: &impl Id,
+        ) -> Result<Option<PersistedSnapshot>, FjallError> {
+            let id_string = id.to_string();
+
+            // Single snapshot read: look up numeric ID then read snapshot.
+            // Both reads use the same point-in-time view (fjall LSM snapshot).
+            let meta = self.streams.get(&id_string)?;
+            let numeric_id = match meta {
+                Some(meta_bytes) => {
+                    let (numeric_id, _version) =
+                        decode_stream_meta(&meta_bytes).map_err(|_| FjallError::CorruptMeta {
+                            stream_id: id_string.clone(),
+                        })?;
+                    numeric_id
+                }
+                None => return Ok(None),
+            };
+
+            let key = encode_snapshot_key(numeric_id);
+            let value = self.snapshots.get(key)?;
+            match value {
+                Some(bytes) => {
+                    let (schema_version, version_raw, payload) = decode_snapshot_value(&bytes)
+                        .map_err(|_| FjallError::CorruptValue {
+                            stream_id: id_string,
+                            version: None,
+                        })?;
+                    let version =
+                        Version::new(version_raw).ok_or_else(|| FjallError::CorruptValue {
+                            stream_id: id.to_string(),
+                            version: None,
+                        })?;
+                    let snap =
+                        PersistedSnapshot::try_new(version, schema_version, payload.to_vec())
+                            .map_err(|_| FjallError::CorruptValue {
+                                stream_id: id.to_string(),
+                                version: Some(version_raw),
+                            })?;
+                    Ok(Some(snap))
+                }
+                None => Ok(None),
+            }
+        }
+
+        async fn save_snapshot(
+            &self,
+            id: &impl Id,
+            snapshot: &PendingSnapshot,
+        ) -> Result<(), FjallError> {
+            let id_string = id.to_string();
+
+            // Atomic: look up numeric ID + write snapshot in one transaction.
+            let mut tx = self.db.write_tx();
+
+            let numeric_id = match tx
+                .get(&self.streams, &id_string)
+                .map_err(|e| FjallError::Io(e))?
+            {
+                Some(meta_bytes) => {
+                    let (numeric_id, _version) =
+                        decode_stream_meta(&meta_bytes).map_err(|_| FjallError::CorruptMeta {
+                            stream_id: id_string.clone(),
+                        })?;
+                    numeric_id
+                }
+                None => {
+                    // No stream exists — can't snapshot an aggregate with no events.
+                    return Ok(());
+                }
+            };
+
+            let key = encode_snapshot_key(numeric_id);
+            let mut buf = Vec::new();
+            encode_snapshot_value(
+                &mut buf,
+                snapshot.schema_version(),
+                snapshot.version().as_u64(),
+                snapshot.payload(),
+            );
+            tx.insert(&self.snapshots, key, fjall::Slice::from(&*buf));
+
+            tx.commit().map_err(FjallError::Io)?;
+            Ok(())
+        }
+
+        async fn delete_snapshot(&self, id: &impl Id) -> Result<(), FjallError> {
+            let id_string = id.to_string();
+
+            let mut tx = self.db.write_tx();
+
+            let numeric_id = match tx
+                .get(&self.streams, &id_string)
+                .map_err(|e| FjallError::Io(e))?
+            {
+                Some(meta_bytes) => {
+                    let (numeric_id, _version) =
+                        decode_stream_meta(&meta_bytes).map_err(|_| FjallError::CorruptMeta {
+                            stream_id: id_string.clone(),
+                        })?;
+                    numeric_id
+                }
+                None => return Ok(()),
+            };
+
+            let key = encode_snapshot_key(numeric_id);
+            tx.remove(&self.snapshots, key);
+            tx.commit().map_err(FjallError::Io)?;
+            Ok(())
+        }
     }
 }
 

--- a/crates/nexus-fjall/src/stream.rs
+++ b/crates/nexus-fjall/src/stream.rs
@@ -37,7 +37,7 @@ impl EventStream for FjallStream {
             self.poisoned = true;
             return Some(Err(FjallError::CorruptValue {
                 stream_id: self.stream_id.clone(),
-                version: 0,
+                version: None,
             }));
         };
 
@@ -57,7 +57,7 @@ impl EventStream for FjallStream {
             self.poisoned = true;
             return Some(Err(FjallError::CorruptValue {
                 stream_id: self.stream_id.clone(),
-                version,
+                version: Some(version),
             }));
         };
 
@@ -65,7 +65,7 @@ impl EventStream for FjallStream {
             self.poisoned = true;
             return Some(Err(FjallError::CorruptValue {
                 stream_id: self.stream_id.clone(),
-                version,
+                version: Some(version),
             }));
         };
 
@@ -77,7 +77,7 @@ impl EventStream for FjallStream {
             self.poisoned = true;
             Some(Err(FjallError::CorruptValue {
                 stream_id: self.stream_id.clone(),
-                version,
+                version: Some(version),
             }))
         }
     }
@@ -156,7 +156,7 @@ mod tests {
         match err {
             FjallError::CorruptValue { stream_id, version } => {
                 assert_eq!(stream_id, "corrupt-stream");
-                assert_eq!(version, 1);
+                assert_eq!(version, Some(1));
             }
             other => panic!("expected CorruptValue, got: {other:?}"),
         }

--- a/crates/nexus-fjall/tests/snapshot_tests.rs
+++ b/crates/nexus-fjall/tests/snapshot_tests.rs
@@ -1,0 +1,192 @@
+#![cfg(feature = "snapshot")]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::shadow_reuse,
+    clippy::shadow_same,
+    clippy::shadow_unrelated,
+    clippy::as_conversions,
+    reason = "test harness — relaxed lints for test code"
+)]
+
+use std::fmt;
+
+use nexus::{Id, Version};
+use nexus_fjall::FjallStore;
+use nexus_store::snapshot::{PendingSnapshot, SnapshotStore};
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+struct TestId(String);
+
+impl fmt::Display for TestId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl Id for TestId {}
+
+fn tid(s: &str) -> TestId {
+    TestId(s.to_owned())
+}
+
+fn temp_store() -> (FjallStore, tempfile::TempDir) {
+    let dir = tempfile::tempdir().unwrap();
+    let store = FjallStore::builder(dir.path().join("db")).open().unwrap();
+    (store, dir)
+}
+
+/// Helper: append events to create a stream so snapshots have something to reference.
+async fn setup_stream(store: &FjallStore, id: &TestId, event_count: u64) {
+    use nexus_store::envelope::pending_envelope;
+    use nexus_store::store::RawEventStore;
+
+    let mut envs = Vec::new();
+    for i in 1..=event_count {
+        envs.push(
+            pending_envelope(Version::new(i).unwrap())
+                .event_type("TestEvent")
+                .payload(format!("payload-{i}").into_bytes())
+                .build_without_metadata(),
+        );
+    }
+    store.append(id, None, &envs).await.unwrap();
+}
+
+// ── 1. Sequence/Protocol Tests ─────────────────────────────────────
+
+#[tokio::test]
+async fn save_then_load_roundtrips() {
+    let (store, _dir) = temp_store();
+    let id = tid("agg-1");
+    setup_stream(&store, &id, 5).await;
+
+    let snap = PendingSnapshot::new(Version::new(5).unwrap(), 1, vec![1, 2, 3]);
+    store.save_snapshot(&id, &snap).await.unwrap();
+
+    let loaded = store.load_snapshot(&id).await.unwrap().unwrap();
+    assert_eq!(loaded.version(), Version::new(5).unwrap());
+    assert_eq!(loaded.schema_version(), 1);
+    assert_eq!(loaded.payload(), &[1, 2, 3]);
+}
+
+#[tokio::test]
+async fn save_overwrites_previous_snapshot() {
+    let (store, _dir) = temp_store();
+    let id = tid("agg-1");
+    setup_stream(&store, &id, 10).await;
+
+    let snap1 = PendingSnapshot::new(Version::new(5).unwrap(), 1, vec![1]);
+    store.save_snapshot(&id, &snap1).await.unwrap();
+
+    let snap2 = PendingSnapshot::new(Version::new(10).unwrap(), 2, vec![2, 3]);
+    store.save_snapshot(&id, &snap2).await.unwrap();
+
+    let loaded = store.load_snapshot(&id).await.unwrap().unwrap();
+    assert_eq!(loaded.version(), Version::new(10).unwrap());
+    assert_eq!(loaded.schema_version(), 2);
+    assert_eq!(loaded.payload(), &[2, 3]);
+}
+
+#[tokio::test]
+async fn delete_then_load_returns_none() {
+    let (store, _dir) = temp_store();
+    let id = tid("agg-1");
+    setup_stream(&store, &id, 3).await;
+
+    let snap = PendingSnapshot::new(Version::new(3).unwrap(), 1, vec![1]);
+    store.save_snapshot(&id, &snap).await.unwrap();
+    store.delete_snapshot(&id).await.unwrap();
+
+    assert!(store.load_snapshot(&id).await.unwrap().is_none());
+}
+
+// ── 2. Lifecycle Tests ─────────────────────────────────────────────
+
+#[tokio::test]
+async fn snapshot_persists_across_reopen() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("db");
+    let id = tid("agg-1");
+
+    // First session: create stream + snapshot
+    {
+        let store = FjallStore::builder(&db_path).open().unwrap();
+        setup_stream(&store, &id, 5).await;
+        let snap = PendingSnapshot::new(Version::new(5).unwrap(), 1, vec![42, 43, 44]);
+        store.save_snapshot(&id, &snap).await.unwrap();
+    }
+
+    // Second session: reopen + verify snapshot
+    {
+        let store = FjallStore::builder(&db_path).open().unwrap();
+        let loaded = store.load_snapshot(&id).await.unwrap().unwrap();
+        assert_eq!(loaded.version(), Version::new(5).unwrap());
+        assert_eq!(loaded.schema_version(), 1);
+        assert_eq!(loaded.payload(), &[42, 43, 44]);
+    }
+}
+
+// ── 3. Defensive Boundary Tests ────────────────────────────────────
+
+#[tokio::test]
+async fn load_nonexistent_stream_returns_none() {
+    let (store, _dir) = temp_store();
+    let result = store.load_snapshot(&tid("nope")).await.unwrap();
+    assert!(result.is_none());
+}
+
+#[tokio::test]
+async fn load_existing_stream_without_snapshot_returns_none() {
+    let (store, _dir) = temp_store();
+    let id = tid("agg-1");
+    setup_stream(&store, &id, 3).await;
+
+    let result = store.load_snapshot(&id).await.unwrap();
+    assert!(result.is_none());
+}
+
+#[tokio::test]
+async fn delete_nonexistent_is_ok() {
+    let (store, _dir) = temp_store();
+    let result = store.delete_snapshot(&tid("nope")).await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn save_to_nonexistent_stream_is_noop() {
+    let (store, _dir) = temp_store();
+    // No stream exists — save should silently succeed (no-op)
+    let snap = PendingSnapshot::new(Version::new(1).unwrap(), 1, vec![1]);
+    let result = store.save_snapshot(&tid("nope"), &snap).await;
+    assert!(result.is_ok());
+
+    // And loading returns None
+    assert!(store.load_snapshot(&tid("nope")).await.unwrap().is_none());
+}
+
+// ── 4. Isolation Tests ─────────────────────────────────────────────
+
+#[tokio::test]
+async fn different_streams_have_separate_snapshots() {
+    let (store, _dir) = temp_store();
+    let id1 = tid("agg-1");
+    let id2 = tid("agg-2");
+    setup_stream(&store, &id1, 5).await;
+    setup_stream(&store, &id2, 10).await;
+
+    let snap1 = PendingSnapshot::new(Version::new(5).unwrap(), 1, vec![1]);
+    store.save_snapshot(&id1, &snap1).await.unwrap();
+
+    let snap2 = PendingSnapshot::new(Version::new(10).unwrap(), 1, vec![2]);
+    store.save_snapshot(&id2, &snap2).await.unwrap();
+
+    let loaded1 = store.load_snapshot(&id1).await.unwrap().unwrap();
+    let loaded2 = store.load_snapshot(&id2).await.unwrap().unwrap();
+
+    assert_eq!(loaded1.version(), Version::new(5).unwrap());
+    assert_eq!(loaded1.payload(), &[1]);
+    assert_eq!(loaded2.version(), Version::new(10).unwrap());
+    assert_eq!(loaded2.payload(), &[2]);
+}

--- a/crates/nexus-fjall/tests/snapshot_tests.rs
+++ b/crates/nexus-fjall/tests/snapshot_tests.rs
@@ -11,10 +11,13 @@
 )]
 
 use std::fmt;
+use std::num::NonZeroU32;
 
 use nexus::{Id, Version};
 use nexus_fjall::FjallStore;
 use nexus_store::snapshot::{PendingSnapshot, SnapshotStore};
+
+const SV1: NonZeroU32 = NonZeroU32::MIN;
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 struct TestId(String);
@@ -62,12 +65,12 @@ async fn save_then_load_roundtrips() {
     let id = tid("agg-1");
     setup_stream(&store, &id, 5).await;
 
-    let snap = PendingSnapshot::new(Version::new(5).unwrap(), 1, vec![1, 2, 3]);
+    let snap = PendingSnapshot::new(Version::new(5).unwrap(), SV1, vec![1, 2, 3]);
     store.save_snapshot(&id, &snap).await.unwrap();
 
     let loaded = store.load_snapshot(&id).await.unwrap().unwrap();
     assert_eq!(loaded.version(), Version::new(5).unwrap());
-    assert_eq!(loaded.schema_version(), 1);
+    assert_eq!(loaded.schema_version(), SV1);
     assert_eq!(loaded.payload(), &[1, 2, 3]);
 }
 
@@ -77,15 +80,19 @@ async fn save_overwrites_previous_snapshot() {
     let id = tid("agg-1");
     setup_stream(&store, &id, 10).await;
 
-    let snap1 = PendingSnapshot::new(Version::new(5).unwrap(), 1, vec![1]);
+    let snap1 = PendingSnapshot::new(Version::new(5).unwrap(), SV1, vec![1]);
     store.save_snapshot(&id, &snap1).await.unwrap();
 
-    let snap2 = PendingSnapshot::new(Version::new(10).unwrap(), 2, vec![2, 3]);
+    let snap2 = PendingSnapshot::new(
+        Version::new(10).unwrap(),
+        NonZeroU32::new(2).unwrap(),
+        vec![2, 3],
+    );
     store.save_snapshot(&id, &snap2).await.unwrap();
 
     let loaded = store.load_snapshot(&id).await.unwrap().unwrap();
     assert_eq!(loaded.version(), Version::new(10).unwrap());
-    assert_eq!(loaded.schema_version(), 2);
+    assert_eq!(loaded.schema_version(), NonZeroU32::new(2).unwrap());
     assert_eq!(loaded.payload(), &[2, 3]);
 }
 
@@ -95,7 +102,7 @@ async fn delete_then_load_returns_none() {
     let id = tid("agg-1");
     setup_stream(&store, &id, 3).await;
 
-    let snap = PendingSnapshot::new(Version::new(3).unwrap(), 1, vec![1]);
+    let snap = PendingSnapshot::new(Version::new(3).unwrap(), SV1, vec![1]);
     store.save_snapshot(&id, &snap).await.unwrap();
     store.delete_snapshot(&id).await.unwrap();
 
@@ -114,7 +121,7 @@ async fn snapshot_persists_across_reopen() {
     {
         let store = FjallStore::builder(&db_path).open().unwrap();
         setup_stream(&store, &id, 5).await;
-        let snap = PendingSnapshot::new(Version::new(5).unwrap(), 1, vec![42, 43, 44]);
+        let snap = PendingSnapshot::new(Version::new(5).unwrap(), SV1, vec![42, 43, 44]);
         store.save_snapshot(&id, &snap).await.unwrap();
     }
 
@@ -123,7 +130,7 @@ async fn snapshot_persists_across_reopen() {
         let store = FjallStore::builder(&db_path).open().unwrap();
         let loaded = store.load_snapshot(&id).await.unwrap().unwrap();
         assert_eq!(loaded.version(), Version::new(5).unwrap());
-        assert_eq!(loaded.schema_version(), 1);
+        assert_eq!(loaded.schema_version(), SV1);
         assert_eq!(loaded.payload(), &[42, 43, 44]);
     }
 }
@@ -158,7 +165,7 @@ async fn delete_nonexistent_is_ok() {
 async fn save_to_nonexistent_stream_is_noop() {
     let (store, _dir) = temp_store();
     // No stream exists — save should silently succeed (no-op)
-    let snap = PendingSnapshot::new(Version::new(1).unwrap(), 1, vec![1]);
+    let snap = PendingSnapshot::new(Version::new(1).unwrap(), SV1, vec![1]);
     let result = store.save_snapshot(&tid("nope"), &snap).await;
     assert!(result.is_ok());
 
@@ -176,10 +183,10 @@ async fn different_streams_have_separate_snapshots() {
     setup_stream(&store, &id1, 5).await;
     setup_stream(&store, &id2, 10).await;
 
-    let snap1 = PendingSnapshot::new(Version::new(5).unwrap(), 1, vec![1]);
+    let snap1 = PendingSnapshot::new(Version::new(5).unwrap(), SV1, vec![1]);
     store.save_snapshot(&id1, &snap1).await.unwrap();
 
-    let snap2 = PendingSnapshot::new(Version::new(10).unwrap(), 1, vec![2]);
+    let snap2 = PendingSnapshot::new(Version::new(10).unwrap(), SV1, vec![2]);
     store.save_snapshot(&id2, &snap2).await.unwrap();
 
     let loaded1 = store.load_snapshot(&id1).await.unwrap().unwrap();

--- a/crates/nexus-store/Cargo.toml
+++ b/crates/nexus-store/Cargo.toml
@@ -15,6 +15,8 @@ testing = ["dep:tokio"]
 bounded-labels = []
 serde = ["dep:serde"]
 json = ["serde", "dep:serde_json"]
+snapshot = []
+snapshot-json = ["snapshot", "json"]
 
 [dependencies]
 nexus = { version = "0.1.0", path = "../nexus" }

--- a/crates/nexus-store/src/lib.rs
+++ b/crates/nexus-store/src/lib.rs
@@ -1,6 +1,8 @@
 pub mod codec;
 pub mod envelope;
 pub mod error;
+#[cfg(feature = "snapshot")]
+pub mod snapshot;
 pub mod store;
 pub mod stream_label;
 #[cfg(feature = "testing")]

--- a/crates/nexus-store/src/lib.rs
+++ b/crates/nexus-store/src/lib.rs
@@ -17,9 +17,18 @@ pub use codec::{BorrowingCodec, Codec};
 pub use envelope::{PendingEnvelope, PersistedEnvelope, pending_envelope};
 pub use error::{AppendError, InvalidSchemaVersion, StoreError, UpcastError};
 pub use nexus::Version;
-pub use store::{
-    EventStore, EventStream, NeedsCodec, RawEventStore, Repository, RepositoryBuilder, Store,
-    ZeroCopyEventStore,
+#[cfg(all(feature = "snapshot", feature = "testing"))]
+pub use snapshot::InMemorySnapshotStore;
+#[cfg(feature = "snapshot")]
+pub use snapshot::{
+    AfterEventTypes, EveryNEvents, PendingSnapshot, PersistedSnapshot, SnapshotStore,
+    SnapshotTrigger,
 };
+pub use store::{
+    EventStore, EventStream, NeedsCodec, NoSnapshot, RawEventStore, Repository, RepositoryBuilder,
+    Store, ZeroCopyEventStore,
+};
+#[cfg(feature = "snapshot")]
+pub use store::{Snapshotting, WithSnapshot};
 pub use stream_label::{StreamLabel, ToStreamLabel};
 pub use upcasting::{EventMorsel, Upcaster};

--- a/crates/nexus-store/src/snapshot/mod.rs
+++ b/crates/nexus-store/src/snapshot/mod.rs
@@ -1,0 +1,5 @@
+mod pending;
+mod persisted;
+
+pub use pending::PendingSnapshot;
+pub use persisted::PersistedSnapshot;

--- a/crates/nexus-store/src/snapshot/mod.rs
+++ b/crates/nexus-store/src/snapshot/mod.rs
@@ -1,5 +1,7 @@
 mod pending;
 mod persisted;
+mod store;
 
 pub use pending::PendingSnapshot;
 pub use persisted::PersistedSnapshot;
+pub use store::SnapshotStore;

--- a/crates/nexus-store/src/snapshot/mod.rs
+++ b/crates/nexus-store/src/snapshot/mod.rs
@@ -1,9 +1,13 @@
 mod pending;
 mod persisted;
 mod store;
+#[cfg(feature = "testing")]
+mod testing;
 mod trigger;
 
 pub use pending::PendingSnapshot;
 pub use persisted::PersistedSnapshot;
 pub use store::SnapshotStore;
+#[cfg(feature = "testing")]
+pub use testing::InMemorySnapshotStore;
 pub use trigger::{AfterEventTypes, EveryNEvents, SnapshotTrigger};

--- a/crates/nexus-store/src/snapshot/mod.rs
+++ b/crates/nexus-store/src/snapshot/mod.rs
@@ -1,7 +1,9 @@
 mod pending;
 mod persisted;
 mod store;
+mod trigger;
 
 pub use pending::PendingSnapshot;
 pub use persisted::PersistedSnapshot;
 pub use store::SnapshotStore;
+pub use trigger::{AfterEventTypes, EveryNEvents, SnapshotTrigger};

--- a/crates/nexus-store/src/snapshot/pending.rs
+++ b/crates/nexus-store/src/snapshot/pending.rs
@@ -1,6 +1,6 @@
-use nexus::Version;
+use std::num::NonZeroU32;
 
-use crate::error::InvalidSchemaVersion;
+use nexus::Version;
 
 /// Snapshot payload ready for persistence (write path).
 ///
@@ -9,47 +9,19 @@ use crate::error::InvalidSchemaVersion;
 #[derive(Debug, Clone)]
 pub struct PendingSnapshot {
     version: Version,
-    schema_version: u32,
+    schema_version: NonZeroU32,
     payload: Vec<u8>,
 }
 
 impl PendingSnapshot {
     /// Create a new pending snapshot.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `schema_version` is 0. Use [`try_new`](Self::try_new)
-    /// for a fallible alternative.
     #[must_use]
-    #[allow(
-        clippy::panic,
-        reason = "convenience constructor with documented panic"
-    )]
-    pub fn new(version: Version, schema_version: u32, payload: Vec<u8>) -> Self {
-        match Self::try_new(version, schema_version, payload) {
-            Ok(snap) => snap,
-            Err(e) => panic!("{e}"),
-        }
-    }
-
-    /// Try to create a new pending snapshot.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`InvalidSchemaVersion`] if `schema_version` is 0.
-    pub fn try_new(
-        version: Version,
-        schema_version: u32,
-        payload: Vec<u8>,
-    ) -> Result<Self, InvalidSchemaVersion> {
-        if schema_version == 0 {
-            return Err(InvalidSchemaVersion);
-        }
-        Ok(Self {
+    pub const fn new(version: Version, schema_version: NonZeroU32, payload: Vec<u8>) -> Self {
+        Self {
             version,
             schema_version,
             payload,
-        })
+        }
     }
 
     /// The aggregate version at the time of the snapshot.
@@ -60,7 +32,7 @@ impl PendingSnapshot {
 
     /// The schema version for invalidation checking.
     #[must_use]
-    pub const fn schema_version(&self) -> u32 {
+    pub const fn schema_version(&self) -> NonZeroU32 {
         self.schema_version
     }
 

--- a/crates/nexus-store/src/snapshot/pending.rs
+++ b/crates/nexus-store/src/snapshot/pending.rs
@@ -1,0 +1,66 @@
+use nexus::Version;
+
+use crate::error::InvalidSchemaVersion;
+
+/// Snapshot payload ready for persistence (write path).
+///
+/// Contains the serialized aggregate state, the aggregate version at
+/// snapshot time, and a schema version for invalidation.
+#[derive(Debug, Clone)]
+pub struct PendingSnapshot {
+    version: Version,
+    schema_version: u32,
+    payload: Vec<u8>,
+}
+
+impl PendingSnapshot {
+    /// Create a new pending snapshot.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `schema_version` is 0. Use [`try_new`](Self::try_new)
+    /// for a fallible alternative.
+    #[must_use]
+    pub fn new(version: Version, schema_version: u32, payload: Vec<u8>) -> Self {
+        match Self::try_new(version, schema_version, payload) {
+            Ok(snap) => snap,
+            Err(e) => panic!("{e}"),
+        }
+    }
+
+    /// Try to create a new pending snapshot.
+    ///
+    /// Returns `Err` if `schema_version` is 0.
+    pub fn try_new(
+        version: Version,
+        schema_version: u32,
+        payload: Vec<u8>,
+    ) -> Result<Self, InvalidSchemaVersion> {
+        if schema_version == 0 {
+            return Err(InvalidSchemaVersion);
+        }
+        Ok(Self {
+            version,
+            schema_version,
+            payload,
+        })
+    }
+
+    /// The aggregate version at the time of the snapshot.
+    #[must_use]
+    pub const fn version(&self) -> Version {
+        self.version
+    }
+
+    /// The schema version for invalidation checking.
+    #[must_use]
+    pub const fn schema_version(&self) -> u32 {
+        self.schema_version
+    }
+
+    /// The serialized state bytes.
+    #[must_use]
+    pub fn payload(&self) -> &[u8] {
+        &self.payload
+    }
+}

--- a/crates/nexus-store/src/snapshot/pending.rs
+++ b/crates/nexus-store/src/snapshot/pending.rs
@@ -21,6 +21,10 @@ impl PendingSnapshot {
     /// Panics if `schema_version` is 0. Use [`try_new`](Self::try_new)
     /// for a fallible alternative.
     #[must_use]
+    #[allow(
+        clippy::panic,
+        reason = "convenience constructor with documented panic"
+    )]
     pub fn new(version: Version, schema_version: u32, payload: Vec<u8>) -> Self {
         match Self::try_new(version, schema_version, payload) {
             Ok(snap) => snap,
@@ -30,7 +34,9 @@ impl PendingSnapshot {
 
     /// Try to create a new pending snapshot.
     ///
-    /// Returns `Err` if `schema_version` is 0.
+    /// # Errors
+    ///
+    /// Returns [`InvalidSchemaVersion`] if `schema_version` is 0.
     pub fn try_new(
         version: Version,
         schema_version: u32,

--- a/crates/nexus-store/src/snapshot/persisted.rs
+++ b/crates/nexus-store/src/snapshot/persisted.rs
@@ -1,0 +1,64 @@
+use nexus::Version;
+
+use crate::error::InvalidSchemaVersion;
+
+/// Persisted snapshot loaded from storage (read path).
+///
+/// Owns the payload bytes. This is the simplified owned variant —
+/// a borrowing variant with GAT lifetimes can be added later if
+/// benchmarks show the extra allocation matters for specific backends.
+#[derive(Debug, Clone)]
+pub struct PersistedSnapshot {
+    version: Version,
+    schema_version: u32,
+    payload: Vec<u8>,
+}
+
+impl PersistedSnapshot {
+    /// Create a new persisted snapshot.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `schema_version` is 0.
+    #[must_use]
+    pub fn new(version: Version, schema_version: u32, payload: Vec<u8>) -> Self {
+        match Self::try_new(version, schema_version, payload) {
+            Ok(snap) => snap,
+            Err(e) => panic!("{e}"),
+        }
+    }
+
+    /// Try to create a new persisted snapshot.
+    pub fn try_new(
+        version: Version,
+        schema_version: u32,
+        payload: Vec<u8>,
+    ) -> Result<Self, InvalidSchemaVersion> {
+        if schema_version == 0 {
+            return Err(InvalidSchemaVersion);
+        }
+        Ok(Self {
+            version,
+            schema_version,
+            payload,
+        })
+    }
+
+    /// The aggregate version at the time of the snapshot.
+    #[must_use]
+    pub const fn version(&self) -> Version {
+        self.version
+    }
+
+    /// The schema version for invalidation checking.
+    #[must_use]
+    pub const fn schema_version(&self) -> u32 {
+        self.schema_version
+    }
+
+    /// The serialized state bytes.
+    #[must_use]
+    pub fn payload(&self) -> &[u8] {
+        &self.payload
+    }
+}

--- a/crates/nexus-store/src/snapshot/persisted.rs
+++ b/crates/nexus-store/src/snapshot/persisted.rs
@@ -1,6 +1,6 @@
-use nexus::Version;
+use std::num::NonZeroU32;
 
-use crate::error::InvalidSchemaVersion;
+use nexus::Version;
 
 /// Persisted snapshot loaded from storage (read path).
 ///
@@ -10,46 +10,19 @@ use crate::error::InvalidSchemaVersion;
 #[derive(Debug, Clone)]
 pub struct PersistedSnapshot {
     version: Version,
-    schema_version: u32,
+    schema_version: NonZeroU32,
     payload: Vec<u8>,
 }
 
 impl PersistedSnapshot {
     /// Create a new persisted snapshot.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `schema_version` is 0.
     #[must_use]
-    #[allow(
-        clippy::panic,
-        reason = "convenience constructor with documented panic"
-    )]
-    pub fn new(version: Version, schema_version: u32, payload: Vec<u8>) -> Self {
-        match Self::try_new(version, schema_version, payload) {
-            Ok(snap) => snap,
-            Err(e) => panic!("{e}"),
-        }
-    }
-
-    /// Try to create a new persisted snapshot.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`InvalidSchemaVersion`] if `schema_version` is 0.
-    pub fn try_new(
-        version: Version,
-        schema_version: u32,
-        payload: Vec<u8>,
-    ) -> Result<Self, InvalidSchemaVersion> {
-        if schema_version == 0 {
-            return Err(InvalidSchemaVersion);
-        }
-        Ok(Self {
+    pub const fn new(version: Version, schema_version: NonZeroU32, payload: Vec<u8>) -> Self {
+        Self {
             version,
             schema_version,
             payload,
-        })
+        }
     }
 
     /// The aggregate version at the time of the snapshot.
@@ -60,7 +33,7 @@ impl PersistedSnapshot {
 
     /// The schema version for invalidation checking.
     #[must_use]
-    pub const fn schema_version(&self) -> u32 {
+    pub const fn schema_version(&self) -> NonZeroU32 {
         self.schema_version
     }
 

--- a/crates/nexus-store/src/snapshot/persisted.rs
+++ b/crates/nexus-store/src/snapshot/persisted.rs
@@ -21,6 +21,10 @@ impl PersistedSnapshot {
     ///
     /// Panics if `schema_version` is 0.
     #[must_use]
+    #[allow(
+        clippy::panic,
+        reason = "convenience constructor with documented panic"
+    )]
     pub fn new(version: Version, schema_version: u32, payload: Vec<u8>) -> Self {
         match Self::try_new(version, schema_version, payload) {
             Ok(snap) => snap,
@@ -29,6 +33,10 @@ impl PersistedSnapshot {
     }
 
     /// Try to create a new persisted snapshot.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`InvalidSchemaVersion`] if `schema_version` is 0.
     pub fn try_new(
         version: Version,
         schema_version: u32,

--- a/crates/nexus-store/src/snapshot/store.rs
+++ b/crates/nexus-store/src/snapshot/store.rs
@@ -1,0 +1,67 @@
+use std::convert::Infallible;
+use std::future::Future;
+
+use nexus::Id;
+
+use super::pending::PendingSnapshot;
+use super::persisted::PersistedSnapshot;
+
+/// Byte-level snapshot storage trait.
+///
+/// Adapters (fjall, postgres, etc.) implement this to persist and
+/// retrieve serialized aggregate state.
+///
+/// `()` is the no-op implementation: `load_snapshot` always returns
+/// `None`, `save_snapshot` and `delete_snapshot` silently discard.
+/// Used when snapshot support is not configured.
+pub trait SnapshotStore: Send + Sync {
+    /// Adapter-specific error type.
+    type Error: std::error::Error + Send + Sync + 'static;
+
+    /// Load the most recent snapshot for the given aggregate.
+    ///
+    /// Returns `None` if no snapshot exists.
+    fn load_snapshot(
+        &self,
+        id: &impl Id,
+    ) -> impl Future<Output = Result<Option<PersistedSnapshot>, Self::Error>> + Send;
+
+    /// Persist a snapshot for the given aggregate.
+    ///
+    /// Overwrites any existing snapshot for this aggregate.
+    fn save_snapshot(
+        &self,
+        id: &impl Id,
+        snapshot: &PendingSnapshot,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+
+    /// Delete the snapshot for the given aggregate.
+    ///
+    /// Returns `Ok(())` if no snapshot exists (idempotent).
+    fn delete_snapshot(&self, id: &impl Id)
+    -> impl Future<Output = Result<(), Self::Error>> + Send;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// No-op implementation — snapshots disabled
+// ═══════════════════════════════════════════════════════════════════════════
+
+impl SnapshotStore for () {
+    type Error = Infallible;
+
+    async fn load_snapshot(&self, _id: &impl Id) -> Result<Option<PersistedSnapshot>, Infallible> {
+        Ok(None)
+    }
+
+    async fn save_snapshot(
+        &self,
+        _id: &impl Id,
+        _snapshot: &PendingSnapshot,
+    ) -> Result<(), Infallible> {
+        Ok(())
+    }
+
+    async fn delete_snapshot(&self, _id: &impl Id) -> Result<(), Infallible> {
+        Ok(())
+    }
+}

--- a/crates/nexus-store/src/snapshot/store.rs
+++ b/crates/nexus-store/src/snapshot/store.rs
@@ -43,6 +43,30 @@ pub trait SnapshotStore: Send + Sync {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
+// Delegation implementation — share via reference
+// ═══════════════════════════════════════════════════════════════════════════
+
+impl<T: SnapshotStore> SnapshotStore for &T {
+    type Error = T::Error;
+
+    async fn load_snapshot(&self, id: &impl Id) -> Result<Option<PersistedSnapshot>, Self::Error> {
+        (**self).load_snapshot(id).await
+    }
+
+    async fn save_snapshot(
+        &self,
+        id: &impl Id,
+        snapshot: &PendingSnapshot,
+    ) -> Result<(), Self::Error> {
+        (**self).save_snapshot(id, snapshot).await
+    }
+
+    async fn delete_snapshot(&self, id: &impl Id) -> Result<(), Self::Error> {
+        (**self).delete_snapshot(id).await
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
 // No-op implementation — snapshots disabled
 // ═══════════════════════════════════════════════════════════════════════════
 

--- a/crates/nexus-store/src/snapshot/testing.rs
+++ b/crates/nexus-store/src/snapshot/testing.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::convert::Infallible;
+use std::num::NonZeroU32;
 
 use nexus::Id;
 use tokio::sync::RwLock;
@@ -19,7 +20,7 @@ pub struct InMemorySnapshotStore {
 #[derive(Debug, Clone)]
 struct StoredSnapshot {
     version: nexus::Version,
-    schema_version: u32,
+    schema_version: NonZeroU32,
     payload: Vec<u8>,
 }
 

--- a/crates/nexus-store/src/snapshot/testing.rs
+++ b/crates/nexus-store/src/snapshot/testing.rs
@@ -1,0 +1,68 @@
+use std::collections::HashMap;
+use std::convert::Infallible;
+
+use nexus::Id;
+use tokio::sync::RwLock;
+
+use super::pending::PendingSnapshot;
+use super::persisted::PersistedSnapshot;
+use super::store::SnapshotStore;
+
+/// In-memory snapshot store for tests.
+///
+/// Stores snapshots in a `HashMap` protected by a `RwLock`.
+#[derive(Debug, Default)]
+pub struct InMemorySnapshotStore {
+    snapshots: RwLock<HashMap<String, StoredSnapshot>>,
+}
+
+#[derive(Debug, Clone)]
+struct StoredSnapshot {
+    version: nexus::Version,
+    schema_version: u32,
+    payload: Vec<u8>,
+}
+
+impl InMemorySnapshotStore {
+    /// Create a new empty in-memory snapshot store.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl SnapshotStore for InMemorySnapshotStore {
+    type Error = Infallible;
+
+    async fn load_snapshot(&self, id: &impl Id) -> Result<Option<PersistedSnapshot>, Infallible> {
+        let snapshots = self.snapshots.read().await;
+        let key = id.to_string();
+        Ok(snapshots
+            .get(&key)
+            .map(|s| PersistedSnapshot::new(s.version, s.schema_version, s.payload.clone())))
+    }
+
+    async fn save_snapshot(
+        &self,
+        id: &impl Id,
+        snapshot: &PendingSnapshot,
+    ) -> Result<(), Infallible> {
+        let mut snapshots = self.snapshots.write().await;
+        let key = id.to_string();
+        snapshots.insert(
+            key,
+            StoredSnapshot {
+                version: snapshot.version(),
+                schema_version: snapshot.schema_version(),
+                payload: snapshot.payload().to_vec(),
+            },
+        );
+        Ok(())
+    }
+
+    async fn delete_snapshot(&self, id: &impl Id) -> Result<(), Infallible> {
+        let mut snapshots = self.snapshots.write().await;
+        snapshots.remove(&id.to_string());
+        Ok(())
+    }
+}

--- a/crates/nexus-store/src/snapshot/trigger.rs
+++ b/crates/nexus-store/src/snapshot/trigger.rs
@@ -1,0 +1,82 @@
+use std::num::NonZeroU64;
+
+use nexus::Version;
+
+/// Strategy for deciding when to take a snapshot.
+///
+/// Checked after each successful `save()`. The trigger receives both the
+/// old and new aggregate version (to detect boundary crossings regardless
+/// of batch size) and the names of events just persisted (for semantic
+/// triggers).
+pub trait SnapshotTrigger: Send + Sync {
+    /// Whether a snapshot should be taken after this save.
+    ///
+    /// - `old_version`: aggregate version before save (`None` for new aggregates)
+    /// - `new_version`: aggregate version after save
+    /// - `event_names`: names of events just persisted (from `DomainEvent::name()`)
+    fn should_snapshot(
+        &self,
+        old_version: Option<Version>,
+        new_version: Version,
+        event_names: &[&str],
+    ) -> bool;
+}
+
+/// Trigger a snapshot every N events.
+///
+/// Detects when a save crosses an N-event boundary, regardless of batch
+/// size. For example, `EveryNEvents(100)` triggers when the aggregate
+/// crosses version 100, 200, 300, etc. — even if the batch was 7 events
+/// jumping from version 96 to 103.
+///
+/// Uses a bucket-crossing algorithm instead of modulo to avoid missing
+/// boundaries when batches skip over exact multiples.
+#[derive(Debug, Clone, Copy)]
+pub struct EveryNEvents(pub NonZeroU64);
+
+impl SnapshotTrigger for EveryNEvents {
+    fn should_snapshot(
+        &self,
+        old_version: Option<Version>,
+        new_version: Version,
+        _event_names: &[&str],
+    ) -> bool {
+        let n = self.0.get();
+        let old_bucket = old_version.map_or(0, |v| v.as_u64() / n);
+        let new_bucket = new_version.as_u64() / n;
+        new_bucket > old_bucket
+    }
+}
+
+/// Trigger a snapshot after specific event types are persisted.
+///
+/// Useful for domain milestones (e.g., `OrderCompleted`, `AccountClosed`)
+/// where the aggregate is unlikely to change further, or where a stable
+/// snapshot point aligns with business semantics.
+#[derive(Debug, Clone)]
+pub struct AfterEventTypes {
+    types: Vec<&'static str>,
+}
+
+impl AfterEventTypes {
+    /// Create a trigger that fires when any of the given event types is persisted.
+    #[must_use]
+    pub fn new(types: &[&'static str]) -> Self {
+        Self {
+            types: types.to_vec(),
+        }
+    }
+}
+
+impl SnapshotTrigger for AfterEventTypes {
+    fn should_snapshot(
+        &self,
+        _old_version: Option<Version>,
+        _new_version: Version,
+        event_names: &[&str],
+    ) -> bool {
+        event_names
+            .iter()
+            .any(|name| self.types.iter().any(|t| t == name))
+    }
+}

--- a/crates/nexus-store/src/store/builder.rs
+++ b/crates/nexus-store/src/store/builder.rs
@@ -40,7 +40,7 @@ pub struct WithSnapshot<SS, SC, T> {
     store: SS,
     codec: SC,
     trigger: T,
-    schema_version: u32,
+    schema_version: std::num::NonZeroU32,
     snapshot_on_read: bool,
 }
 
@@ -151,6 +151,10 @@ use std::num::NonZeroU64;
 #[cfg(feature = "snapshot")]
 const DEFAULT_SNAPSHOT_INTERVAL: u64 = 100;
 
+/// Default snapshot schema version.
+#[cfg(feature = "snapshot")]
+const DEFAULT_SCHEMA_VERSION: std::num::NonZeroU32 = std::num::NonZeroU32::MIN;
+
 #[cfg(all(feature = "snapshot-json", feature = "snapshot"))]
 impl<S, C, U> RepositoryBuilder<S, C, U, NoSnapshot> {
     /// Configure a snapshot store with JSON codec (default).
@@ -182,7 +186,7 @@ impl<S, C, U> RepositoryBuilder<S, C, U, NoSnapshot> {
                     NonZeroU64::new(DEFAULT_SNAPSHOT_INTERVAL)
                         .expect("DEFAULT_SNAPSHOT_INTERVAL is non-zero"),
                 ),
-                schema_version: 1,
+                schema_version: DEFAULT_SCHEMA_VERSION,
                 snapshot_on_read: false,
             },
         }
@@ -221,7 +225,7 @@ impl<S, C, U> RepositoryBuilder<S, C, U, NoSnapshot> {
                     NonZeroU64::new(DEFAULT_SNAPSHOT_INTERVAL)
                         .expect("DEFAULT_SNAPSHOT_INTERVAL is non-zero"),
                 ),
-                schema_version: 1,
+                schema_version: DEFAULT_SCHEMA_VERSION,
                 snapshot_on_read: false,
             },
         }
@@ -272,7 +276,7 @@ impl<S, C, U, SS, SC, T> RepositoryBuilder<S, C, U, WithSnapshot<SS, SC, T>> {
 
     /// Set the schema version for snapshot invalidation.
     #[must_use]
-    pub const fn snapshot_schema_version(mut self, version: u32) -> Self {
+    pub const fn snapshot_schema_version(mut self, version: std::num::NonZeroU32) -> Self {
         self.snapshot.schema_version = version;
         self
     }

--- a/crates/nexus-store/src/store/builder.rs
+++ b/crates/nexus-store/src/store/builder.rs
@@ -28,6 +28,23 @@ impl NeedsCodec {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
+// Snapshot typestate markers
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Marker: no snapshot configured (default).
+pub struct NoSnapshot;
+
+/// Snapshot configuration, created by builder methods.
+#[cfg(feature = "snapshot")]
+pub struct WithSnapshot<SS, SC, T> {
+    store: SS,
+    codec: SC,
+    trigger: T,
+    schema_version: u32,
+    snapshot_on_read: bool,
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
 // RepositoryBuilder
 // ═══════════════════════════════════════════════════════════════════════════
 
@@ -52,23 +69,25 @@ impl NeedsCodec {
 /// // With an upcaster:
 /// let repo = store.repository().upcaster(MyUpcaster).build();
 /// ```
-pub struct RepositoryBuilder<S, C, U> {
+pub struct RepositoryBuilder<S, C, U, Snap = NoSnapshot> {
     store: Store<S>,
     codec: C,
     upcaster: U,
+    snapshot: Snap,
 }
 
-impl<S, C, U> RepositoryBuilder<S, C, U> {
+impl<S, C, U, Snap> RepositoryBuilder<S, C, U, Snap> {
     /// Replace the codec.
     ///
     /// Returns a new builder with the updated codec type, preserving
     /// the store and upcaster.
     #[must_use]
-    pub fn codec<NewC>(self, codec: NewC) -> RepositoryBuilder<S, NewC, U> {
+    pub fn codec<NewC>(self, codec: NewC) -> RepositoryBuilder<S, NewC, U, Snap> {
         RepositoryBuilder {
             store: self.store,
             codec,
             upcaster: self.upcaster,
+            snapshot: self.snapshot,
         }
     }
 
@@ -77,16 +96,21 @@ impl<S, C, U> RepositoryBuilder<S, C, U> {
     /// Returns a new builder with the updated upcaster type, preserving
     /// the store and codec. Pass `()` for no upcasting.
     #[must_use]
-    pub fn upcaster<NewU>(self, upcaster: NewU) -> RepositoryBuilder<S, C, NewU> {
+    pub fn upcaster<NewU>(self, upcaster: NewU) -> RepositoryBuilder<S, C, NewU, Snap> {
         RepositoryBuilder {
             store: self.store,
             codec: self.codec,
             upcaster,
+            snapshot: self.snapshot,
         }
     }
 }
 
-impl<S, C, U> RepositoryBuilder<S, C, U>
+// ═══════════════════════════════════════════════════════════════════════════
+// NoSnapshot — plain EventStore / ZeroCopyEventStore
+// ═══════════════════════════════════════════════════════════════════════════
+
+impl<S, C, U> RepositoryBuilder<S, C, U, NoSnapshot>
 where
     S: RawEventStore,
     C: Send + Sync + 'static,
@@ -109,6 +133,201 @@ where
     #[must_use]
     pub fn build_zero_copy(self) -> ZeroCopyEventStore<S, C, U> {
         ZeroCopyEventStore::new(self.store, self.codec, self.upcaster)
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Snapshot builder methods
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[cfg(feature = "snapshot")]
+use super::snapshotting::Snapshotting;
+#[cfg(feature = "snapshot")]
+use crate::snapshot::{EveryNEvents, SnapshotStore, SnapshotTrigger};
+#[cfg(feature = "snapshot")]
+use std::num::NonZeroU64;
+
+/// Default snapshot interval.
+#[cfg(feature = "snapshot")]
+const DEFAULT_SNAPSHOT_INTERVAL: u64 = 100;
+
+#[cfg(all(feature = "snapshot-json", feature = "snapshot"))]
+impl<S, C, U> RepositoryBuilder<S, C, U, NoSnapshot> {
+    /// Configure a snapshot store with JSON codec (default).
+    ///
+    /// Pre-fills:
+    /// - Snapshot codec: [`JsonCodec`](crate::JsonCodec)
+    /// - Trigger: [`EveryNEvents(100)`](EveryNEvents)
+    /// - Schema version: 1
+    /// - Snapshot on read: false
+    ///
+    /// Override any default with `.snapshot_codec()`, `.snapshot_trigger()`, etc.
+    #[must_use]
+    #[allow(
+        clippy::expect_used,
+        reason = "DEFAULT_SNAPSHOT_INTERVAL is non-zero by inspection"
+    )]
+    pub fn snapshot_store<SS: SnapshotStore>(
+        self,
+        snapshot_store: SS,
+    ) -> RepositoryBuilder<S, C, U, WithSnapshot<SS, crate::JsonCodec, EveryNEvents>> {
+        RepositoryBuilder {
+            store: self.store,
+            codec: self.codec,
+            upcaster: self.upcaster,
+            snapshot: WithSnapshot {
+                store: snapshot_store,
+                codec: crate::JsonCodec::default(),
+                trigger: EveryNEvents(
+                    NonZeroU64::new(DEFAULT_SNAPSHOT_INTERVAL)
+                        .expect("DEFAULT_SNAPSHOT_INTERVAL is non-zero"),
+                ),
+                schema_version: 1,
+                snapshot_on_read: false,
+            },
+        }
+    }
+}
+
+#[cfg(all(feature = "snapshot", not(feature = "snapshot-json")))]
+impl<S, C, U> RepositoryBuilder<S, C, U, NoSnapshot> {
+    /// Configure a snapshot store with an explicit codec.
+    ///
+    /// Pre-fills:
+    /// - Trigger: [`EveryNEvents(100)`](EveryNEvents)
+    /// - Schema version: 1
+    /// - Snapshot on read: false
+    ///
+    /// Override any default with `.snapshot_trigger()`, etc.
+    #[must_use]
+    #[allow(
+        clippy::expect_used,
+        reason = "DEFAULT_SNAPSHOT_INTERVAL is non-zero by inspection"
+    )]
+    pub fn snapshot_store<SS: SnapshotStore, SC>(
+        self,
+        snapshot_store: SS,
+        snapshot_codec: SC,
+    ) -> RepositoryBuilder<S, C, U, WithSnapshot<SS, SC, EveryNEvents>> {
+        RepositoryBuilder {
+            store: self.store,
+            codec: self.codec,
+            upcaster: self.upcaster,
+            snapshot: WithSnapshot {
+                store: snapshot_store,
+                codec: snapshot_codec,
+                trigger: EveryNEvents(
+                    NonZeroU64::new(DEFAULT_SNAPSHOT_INTERVAL)
+                        .expect("DEFAULT_SNAPSHOT_INTERVAL is non-zero"),
+                ),
+                schema_version: 1,
+                snapshot_on_read: false,
+            },
+        }
+    }
+}
+
+#[cfg(feature = "snapshot")]
+impl<S, C, U, SS, SC, T> RepositoryBuilder<S, C, U, WithSnapshot<SS, SC, T>> {
+    /// Replace the snapshot codec.
+    #[must_use]
+    pub fn snapshot_codec<NewSC>(
+        self,
+        codec: NewSC,
+    ) -> RepositoryBuilder<S, C, U, WithSnapshot<SS, NewSC, T>> {
+        RepositoryBuilder {
+            store: self.store,
+            codec: self.codec,
+            upcaster: self.upcaster,
+            snapshot: WithSnapshot {
+                store: self.snapshot.store,
+                codec,
+                trigger: self.snapshot.trigger,
+                schema_version: self.snapshot.schema_version,
+                snapshot_on_read: self.snapshot.snapshot_on_read,
+            },
+        }
+    }
+
+    /// Replace the snapshot trigger.
+    #[must_use]
+    pub fn snapshot_trigger<NewT: SnapshotTrigger>(
+        self,
+        trigger: NewT,
+    ) -> RepositoryBuilder<S, C, U, WithSnapshot<SS, SC, NewT>> {
+        RepositoryBuilder {
+            store: self.store,
+            codec: self.codec,
+            upcaster: self.upcaster,
+            snapshot: WithSnapshot {
+                store: self.snapshot.store,
+                codec: self.snapshot.codec,
+                trigger,
+                schema_version: self.snapshot.schema_version,
+                snapshot_on_read: self.snapshot.snapshot_on_read,
+            },
+        }
+    }
+
+    /// Set the schema version for snapshot invalidation.
+    #[must_use]
+    pub const fn snapshot_schema_version(
+        mut self,
+        version: u32,
+    ) -> RepositoryBuilder<S, C, U, WithSnapshot<SS, SC, T>> {
+        self.snapshot.schema_version = version;
+        self
+    }
+
+    /// Enable lazy snapshot creation on read (after full replay).
+    #[must_use]
+    pub const fn snapshot_on_read(
+        mut self,
+        enabled: bool,
+    ) -> RepositoryBuilder<S, C, U, WithSnapshot<SS, SC, T>> {
+        self.snapshot.snapshot_on_read = enabled;
+        self
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// WithSnapshot — Snapshotting<EventStore / ZeroCopyEventStore>
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[cfg(feature = "snapshot")]
+impl<S, C, U, SS, SC, T> RepositoryBuilder<S, C, U, WithSnapshot<SS, SC, T>>
+where
+    S: RawEventStore,
+    C: Send + Sync + 'static,
+{
+    /// Build a snapshot-aware [`EventStore`] using an owning [`Codec`](crate::Codec).
+    #[must_use]
+    pub fn build(self) -> Snapshotting<EventStore<S, C, U>, SS, SC, T> {
+        let inner = EventStore::new(self.store, self.codec, self.upcaster);
+        let snap = self.snapshot;
+        Snapshotting::new(
+            inner,
+            snap.store,
+            snap.codec,
+            snap.trigger,
+            snap.schema_version,
+            snap.snapshot_on_read,
+        )
+    }
+
+    /// Build a snapshot-aware [`ZeroCopyEventStore`] using a [`BorrowingCodec`](crate::BorrowingCodec).
+    #[must_use]
+    pub fn build_zero_copy(self) -> Snapshotting<ZeroCopyEventStore<S, C, U>, SS, SC, T> {
+        let inner = ZeroCopyEventStore::new(self.store, self.codec, self.upcaster);
+        let snap = self.snapshot;
+        Snapshotting::new(
+            inner,
+            snap.store,
+            snap.codec,
+            snap.trigger,
+            snap.schema_version,
+            snap.snapshot_on_read,
+        )
     }
 }
 
@@ -141,6 +360,7 @@ impl<S: RawEventStore> Store<S> {
             store: self.clone(),
             codec: crate::JsonCodec::default(),
             upcaster: (),
+            snapshot: NoSnapshot,
         }
     }
 }
@@ -164,6 +384,7 @@ impl<S: RawEventStore> Store<S> {
             store: self.clone(),
             codec: NeedsCodec::new(),
             upcaster: (),
+            snapshot: NoSnapshot,
         }
     }
 }

--- a/crates/nexus-store/src/store/builder.rs
+++ b/crates/nexus-store/src/store/builder.rs
@@ -202,7 +202,8 @@ impl<S, C, U> RepositoryBuilder<S, C, U, NoSnapshot> {
     #[must_use]
     #[allow(
         clippy::expect_used,
-        reason = "DEFAULT_SNAPSHOT_INTERVAL is non-zero by inspection"
+        clippy::missing_panics_doc,
+        reason = "DEFAULT_SNAPSHOT_INTERVAL is non-zero by inspection — cannot panic"
     )]
     pub fn snapshot_store<SS: SnapshotStore, SC>(
         self,
@@ -271,20 +272,14 @@ impl<S, C, U, SS, SC, T> RepositoryBuilder<S, C, U, WithSnapshot<SS, SC, T>> {
 
     /// Set the schema version for snapshot invalidation.
     #[must_use]
-    pub const fn snapshot_schema_version(
-        mut self,
-        version: u32,
-    ) -> RepositoryBuilder<S, C, U, WithSnapshot<SS, SC, T>> {
+    pub const fn snapshot_schema_version(mut self, version: u32) -> Self {
         self.snapshot.schema_version = version;
         self
     }
 
     /// Enable lazy snapshot creation on read (after full replay).
     #[must_use]
-    pub const fn snapshot_on_read(
-        mut self,
-        enabled: bool,
-    ) -> RepositoryBuilder<S, C, U, WithSnapshot<SS, SC, T>> {
+    pub const fn snapshot_on_read(mut self, enabled: bool) -> Self {
         self.snapshot.snapshot_on_read = enabled;
         self
     }

--- a/crates/nexus-store/src/store/event_store.rs
+++ b/crates/nexus-store/src/store/event_store.rs
@@ -1,6 +1,7 @@
 use std::num::NonZeroU32;
 
 use super::raw::RawEventStore;
+use super::replay::ReplayFrom;
 use super::repository::Repository;
 use super::store::Store;
 use super::stream::EventStream;
@@ -64,7 +65,7 @@ impl<S, C, U> EventStore<S, C, U> {
     }
 }
 
-impl<A, S, C, U> Repository<A> for EventStore<S, C, U>
+impl<A, S, C, U> ReplayFrom<A> for EventStore<S, C, U>
 where
     A: Aggregate,
     S: RawEventStore,
@@ -73,17 +74,17 @@ where
     EventOf<A>: DomainEvent,
     for<'a> S::Stream<'a>: Send,
 {
-    type Error = StoreError;
-
-    async fn load(&self, id: A::Id) -> Result<AggregateRoot<A>, StoreError> {
+    async fn replay_from(
+        &self,
+        mut root: AggregateRoot<A>,
+        from: Version,
+    ) -> Result<AggregateRoot<A>, StoreError> {
         let mut stream = self
             .store
             .raw()
-            .read_stream(&id, Version::INITIAL)
+            .read_stream(root.id(), from)
             .await
             .map_err(|e| StoreError::Adapter(Box::new(e)))?;
-
-        let mut root = AggregateRoot::<A>::new(id);
 
         while let Some(result) = stream.next().await {
             let env = result.map_err(|e| StoreError::Adapter(Box::new(e)))?;
@@ -111,6 +112,23 @@ where
         }
 
         Ok(root)
+    }
+}
+
+impl<A, S, C, U> Repository<A> for EventStore<S, C, U>
+where
+    A: Aggregate,
+    S: RawEventStore,
+    C: Codec<EventOf<A>>,
+    U: Upcaster,
+    EventOf<A>: DomainEvent,
+    for<'a> S::Stream<'a>: Send,
+{
+    type Error = StoreError;
+
+    async fn load(&self, id: A::Id) -> Result<AggregateRoot<A>, StoreError> {
+        let root = AggregateRoot::<A>::new(id);
+        self.replay_from(root, Version::INITIAL).await
     }
 
     async fn save(

--- a/crates/nexus-store/src/store/mod.rs
+++ b/crates/nexus-store/src/store/mod.rs
@@ -1,6 +1,7 @@
 mod builder;
 mod event_store;
 mod raw;
+pub(crate) mod replay;
 mod repository;
 #[allow(
     clippy::module_inception,

--- a/crates/nexus-store/src/store/mod.rs
+++ b/crates/nexus-store/src/store/mod.rs
@@ -3,6 +3,8 @@ mod event_store;
 mod raw;
 pub(crate) mod replay;
 mod repository;
+#[cfg(feature = "snapshot")]
+mod snapshotting;
 #[allow(
     clippy::module_inception,
     reason = "Store<S> is the primary public type of the store module"
@@ -15,6 +17,8 @@ pub use builder::{NeedsCodec, RepositoryBuilder};
 pub use event_store::EventStore;
 pub use raw::RawEventStore;
 pub use repository::Repository;
+#[cfg(feature = "snapshot")]
+pub use snapshotting::Snapshotting;
 pub use store::Store;
 pub use stream::EventStream;
 pub use zero_copy_event_store::ZeroCopyEventStore;

--- a/crates/nexus-store/src/store/mod.rs
+++ b/crates/nexus-store/src/store/mod.rs
@@ -13,7 +13,9 @@ mod store;
 mod stream;
 mod zero_copy_event_store;
 
-pub use builder::{NeedsCodec, RepositoryBuilder};
+#[cfg(feature = "snapshot")]
+pub use builder::WithSnapshot;
+pub use builder::{NeedsCodec, NoSnapshot, RepositoryBuilder};
 pub use event_store::EventStore;
 pub use raw::RawEventStore;
 pub use repository::Repository;

--- a/crates/nexus-store/src/store/replay.rs
+++ b/crates/nexus-store/src/store/replay.rs
@@ -8,7 +8,7 @@ use crate::error::StoreError;
 ///
 /// Both `EventStore` and `ZeroCopyEventStore` implement this to share
 /// replay logic with `Snapshotting`. Not public API.
-pub(crate) trait ReplayFrom<A: Aggregate>: Send + Sync {
+pub trait ReplayFrom<A: Aggregate>: Send + Sync {
     /// Replay events starting from `from` version (inclusive) into `root`.
     ///
     /// Returns the updated aggregate with all events applied.

--- a/crates/nexus-store/src/store/replay.rs
+++ b/crates/nexus-store/src/store/replay.rs
@@ -1,0 +1,20 @@
+use std::future::Future;
+
+use nexus::{Aggregate, AggregateRoot, Version};
+
+use crate::error::StoreError;
+
+/// Internal trait for replaying events from a given starting point.
+///
+/// Both `EventStore` and `ZeroCopyEventStore` implement this to share
+/// replay logic with `Snapshotting`. Not public API.
+pub(crate) trait ReplayFrom<A: Aggregate>: Send + Sync {
+    /// Replay events starting from `from` version (inclusive) into `root`.
+    ///
+    /// Returns the updated aggregate with all events applied.
+    fn replay_from(
+        &self,
+        root: AggregateRoot<A>,
+        from: Version,
+    ) -> impl Future<Output = Result<AggregateRoot<A>, StoreError>> + Send;
+}

--- a/crates/nexus-store/src/store/snapshotting.rs
+++ b/crates/nexus-store/src/store/snapshotting.rs
@@ -36,6 +36,10 @@ pub struct Snapshotting<R, SS, SC, T> {
 
 impl<R, SS, SC, T> Snapshotting<R, SS, SC, T> {
     /// Create a new snapshot-aware repository.
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "snapshot config is flat — all fields are semantically distinct"
+    )]
     pub const fn new(
         inner: R,
         snapshot_store: SS,
@@ -68,7 +72,7 @@ where
 
     async fn load(&self, id: A::Id) -> Result<AggregateRoot<A>, StoreError> {
         // Try snapshot first.
-        let snapshot_hit = self.try_load_from_snapshot(&id).await;
+        let snapshot_hit = self.try_load_from_snapshot::<A>(&id).await;
 
         if let Some((root, from)) = snapshot_hit {
             // Snapshot hit — partial replay from snapshot version.
@@ -79,10 +83,10 @@ where
         let root = self.inner.load(id).await?;
 
         // Lazy snapshot: if enabled and aggregate has events, snapshot now.
-        if self.snapshot_on_read {
-            if let Some(version) = root.version() {
-                self.try_save_snapshot(&root, version).await;
-            }
+        if self.snapshot_on_read
+            && let Some(version) = root.version()
+        {
+            self.try_save_snapshot::<A>(&root, version).await;
         }
 
         Ok(root)
@@ -99,15 +103,15 @@ where
         self.inner.save(aggregate, events).await?;
 
         // Check trigger — maybe snapshot.
-        if !events.is_empty() {
-            if let Some(new_version) = aggregate.version() {
-                let event_names: Vec<&str> = events.iter().map(|e| e.name()).collect();
-                if self
-                    .trigger
-                    .should_snapshot(old_version, new_version, &event_names)
-                {
-                    self.try_save_snapshot(aggregate, new_version).await;
-                }
+        if !events.is_empty()
+            && let Some(new_version) = aggregate.version()
+        {
+            let event_names: Vec<&str> = events.iter().map(DomainEvent::name).collect();
+            if self
+                .trigger
+                .should_snapshot(old_version, new_version, &event_names)
+            {
+                self.try_save_snapshot::<A>(aggregate, new_version).await;
             }
         }
 
@@ -117,10 +121,13 @@ where
 
 impl<R, SS, SC, T> Snapshotting<R, SS, SC, T>
 where
+    R: Send + Sync,
     SS: SnapshotStore,
+    SC: Send + Sync,
+    T: Send + Sync,
 {
-    /// Try to load a snapshot. Returns (root, next_version_to_replay) on hit.
-    /// Returns None on miss, schema mismatch, or any error (best-effort).
+    /// Try to load a snapshot. Returns `(root, next_version)` on hit.
+    /// Returns `None` on miss, schema mismatch, or any error (best-effort).
     async fn try_load_from_snapshot<A>(&self, id: &A::Id) -> Option<(AggregateRoot<A>, Version)>
     where
         A: Aggregate,
@@ -146,13 +153,13 @@ where
         A: Aggregate,
         SC: Codec<A::State>,
     {
-        if let Ok(payload) = self.snapshot_codec.encode(aggregate.state()) {
-            if let Ok(snap) = PendingSnapshot::try_new(version, self.schema_version, payload) {
-                let _ = self
-                    .snapshot_store
-                    .save_snapshot(aggregate.id(), &snap)
-                    .await;
-            }
+        if let Ok(payload) = self.snapshot_codec.encode(aggregate.state())
+            && let Ok(snap) = PendingSnapshot::try_new(version, self.schema_version, payload)
+        {
+            let _ = self
+                .snapshot_store
+                .save_snapshot(aggregate.id(), &snap)
+                .await;
         }
     }
 }

--- a/crates/nexus-store/src/store/snapshotting.rs
+++ b/crates/nexus-store/src/store/snapshotting.rs
@@ -1,3 +1,5 @@
+use std::num::NonZeroU32;
+
 use crate::codec::Codec;
 use crate::error::StoreError;
 use crate::snapshot::{PendingSnapshot, SnapshotStore, SnapshotTrigger};
@@ -30,7 +32,7 @@ pub struct Snapshotting<R, SS, SC, T> {
     snapshot_store: SS,
     snapshot_codec: SC,
     trigger: T,
-    schema_version: u32,
+    schema_version: NonZeroU32,
     snapshot_on_read: bool,
 }
 
@@ -45,7 +47,7 @@ impl<R, SS, SC, T> Snapshotting<R, SS, SC, T> {
         snapshot_store: SS,
         snapshot_codec: SC,
         trigger: T,
-        schema_version: u32,
+        schema_version: NonZeroU32,
         snapshot_on_read: bool,
     ) -> Self {
         Self {
@@ -153,9 +155,8 @@ where
         A: Aggregate,
         SC: Codec<A::State>,
     {
-        if let Ok(payload) = self.snapshot_codec.encode(aggregate.state())
-            && let Ok(snap) = PendingSnapshot::try_new(version, self.schema_version, payload)
-        {
+        if let Ok(payload) = self.snapshot_codec.encode(aggregate.state()) {
+            let snap = PendingSnapshot::new(version, self.schema_version, payload);
             let _ = self
                 .snapshot_store
                 .save_snapshot(aggregate.id(), &snap)

--- a/crates/nexus-store/src/store/snapshotting.rs
+++ b/crates/nexus-store/src/store/snapshotting.rs
@@ -1,0 +1,158 @@
+use crate::codec::Codec;
+use crate::error::StoreError;
+use crate::snapshot::{PendingSnapshot, SnapshotStore, SnapshotTrigger};
+use nexus::{Aggregate, AggregateRoot, DomainEvent, EventOf, Version};
+
+use super::replay::ReplayFrom;
+use super::repository::Repository;
+
+/// Snapshot-aware repository decorator.
+///
+/// Wraps an inner repository (e.g., `EventStore` or `ZeroCopyEventStore`)
+/// and adds transparent snapshot support:
+///
+/// - **Load:** tries the snapshot store first; on hit with matching schema
+///   version, restores state from snapshot and replays only subsequent events.
+///   On miss or schema mismatch, falls back to full event replay via the
+///   inner repository. Optionally creates a snapshot after a full replay
+///   (lazy/on-read snapshotting) if `snapshot_on_read` is enabled.
+///
+/// - **Save:** delegates event persistence to the inner repository, then
+///   checks the trigger to optionally persist a snapshot of the current state.
+///   Snapshot save is best-effort — failures are silently ignored so they
+///   never block event persistence.
+///
+/// The trigger type `T` is a generic parameter (not `Box<dyn>`) for
+/// zero-cost monomorphization — the compiler inlines `should_snapshot()`
+/// calls entirely.
+pub struct Snapshotting<R, SS, SC, T> {
+    inner: R,
+    snapshot_store: SS,
+    snapshot_codec: SC,
+    trigger: T,
+    schema_version: u32,
+    snapshot_on_read: bool,
+}
+
+impl<R, SS, SC, T> Snapshotting<R, SS, SC, T> {
+    /// Create a new snapshot-aware repository.
+    pub const fn new(
+        inner: R,
+        snapshot_store: SS,
+        snapshot_codec: SC,
+        trigger: T,
+        schema_version: u32,
+        snapshot_on_read: bool,
+    ) -> Self {
+        Self {
+            inner,
+            snapshot_store,
+            snapshot_codec,
+            trigger,
+            schema_version,
+            snapshot_on_read,
+        }
+    }
+}
+
+impl<A, R, SS, SC, T> Repository<A> for Snapshotting<R, SS, SC, T>
+where
+    A: Aggregate,
+    R: Repository<A, Error = StoreError> + ReplayFrom<A>,
+    SS: SnapshotStore,
+    SC: Codec<A::State>,
+    T: SnapshotTrigger,
+    EventOf<A>: DomainEvent,
+{
+    type Error = StoreError;
+
+    async fn load(&self, id: A::Id) -> Result<AggregateRoot<A>, StoreError> {
+        // Try snapshot first.
+        let snapshot_hit = self.try_load_from_snapshot(&id).await;
+
+        if let Some((root, from)) = snapshot_hit {
+            // Snapshot hit — partial replay from snapshot version.
+            return self.inner.replay_from(root, from).await;
+        }
+
+        // Fallback: full replay.
+        let root = self.inner.load(id).await?;
+
+        // Lazy snapshot: if enabled and aggregate has events, snapshot now.
+        if self.snapshot_on_read {
+            if let Some(version) = root.version() {
+                self.try_save_snapshot(&root, version).await;
+            }
+        }
+
+        Ok(root)
+    }
+
+    async fn save(
+        &self,
+        aggregate: &mut AggregateRoot<A>,
+        events: &[EventOf<A>],
+    ) -> Result<(), StoreError> {
+        let old_version = aggregate.version();
+
+        // Delegate event persistence to inner.
+        self.inner.save(aggregate, events).await?;
+
+        // Check trigger — maybe snapshot.
+        if !events.is_empty() {
+            if let Some(new_version) = aggregate.version() {
+                let event_names: Vec<&str> = events.iter().map(|e| e.name()).collect();
+                if self
+                    .trigger
+                    .should_snapshot(old_version, new_version, &event_names)
+                {
+                    self.try_save_snapshot(aggregate, new_version).await;
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl<R, SS, SC, T> Snapshotting<R, SS, SC, T>
+where
+    SS: SnapshotStore,
+{
+    /// Try to load a snapshot. Returns (root, next_version_to_replay) on hit.
+    /// Returns None on miss, schema mismatch, or any error (best-effort).
+    async fn try_load_from_snapshot<A>(&self, id: &A::Id) -> Option<(AggregateRoot<A>, Version)>
+    where
+        A: Aggregate,
+        SC: Codec<A::State>,
+    {
+        let holder = self.snapshot_store.load_snapshot(id).await.ok()??;
+
+        if holder.schema_version() != self.schema_version {
+            return None;
+        }
+
+        let state = self.snapshot_codec.decode("", holder.payload()).ok()?;
+
+        let version = holder.version();
+        let root = AggregateRoot::<A>::restore(id.clone(), state, version);
+        let next = version.next()?;
+        Some((root, next))
+    }
+
+    /// Best-effort snapshot save. Errors are silently ignored.
+    async fn try_save_snapshot<A>(&self, aggregate: &AggregateRoot<A>, version: Version)
+    where
+        A: Aggregate,
+        SC: Codec<A::State>,
+    {
+        if let Ok(payload) = self.snapshot_codec.encode(aggregate.state()) {
+            if let Ok(snap) = PendingSnapshot::try_new(version, self.schema_version, payload) {
+                let _ = self
+                    .snapshot_store
+                    .save_snapshot(aggregate.id(), &snap)
+                    .await;
+            }
+        }
+    }
+}

--- a/crates/nexus-store/src/store/zero_copy_event_store.rs
+++ b/crates/nexus-store/src/store/zero_copy_event_store.rs
@@ -1,5 +1,6 @@
 use super::event_store::version_to_nz32;
 use super::raw::RawEventStore;
+use super::replay::ReplayFrom;
 use super::repository::Repository;
 use super::store::Store;
 use super::stream::EventStream;
@@ -48,7 +49,7 @@ impl<S, C, U> ZeroCopyEventStore<S, C, U> {
     }
 }
 
-impl<A, S, C, U> Repository<A> for ZeroCopyEventStore<S, C, U>
+impl<A, S, C, U> ReplayFrom<A> for ZeroCopyEventStore<S, C, U>
 where
     A: Aggregate,
     S: RawEventStore,
@@ -57,17 +58,17 @@ where
     EventOf<A>: DomainEvent,
     for<'a> S::Stream<'a>: Send,
 {
-    type Error = StoreError;
-
-    async fn load(&self, id: A::Id) -> Result<AggregateRoot<A>, StoreError> {
+    async fn replay_from(
+        &self,
+        mut root: AggregateRoot<A>,
+        from: Version,
+    ) -> Result<AggregateRoot<A>, StoreError> {
         let mut stream = self
             .store
             .raw()
-            .read_stream(&id, Version::INITIAL)
+            .read_stream(root.id(), from)
             .await
             .map_err(|e| StoreError::Adapter(Box::new(e)))?;
-
-        let mut root = AggregateRoot::<A>::new(id);
 
         while let Some(result) = stream.next().await {
             let env = result.map_err(|e| StoreError::Adapter(Box::new(e)))?;
@@ -95,6 +96,23 @@ where
         }
 
         Ok(root)
+    }
+}
+
+impl<A, S, C, U> Repository<A> for ZeroCopyEventStore<S, C, U>
+where
+    A: Aggregate,
+    S: RawEventStore,
+    C: BorrowingCodec<EventOf<A>>,
+    U: Upcaster,
+    EventOf<A>: DomainEvent,
+    for<'a> S::Stream<'a>: Send,
+{
+    type Error = StoreError;
+
+    async fn load(&self, id: A::Id) -> Result<AggregateRoot<A>, StoreError> {
+        let root = AggregateRoot::<A>::new(id);
+        self.replay_from(root, Version::INITIAL).await
     }
 
     async fn save(

--- a/crates/nexus-store/tests/snapshot_integration_tests.rs
+++ b/crates/nexus-store/tests/snapshot_integration_tests.rs
@@ -11,7 +11,14 @@
 )]
 
 use std::fmt;
-use std::num::NonZeroU64;
+use std::num::{NonZeroU32, NonZeroU64};
+
+const SV1: NonZeroU32 = NonZeroU32::MIN;
+
+#[allow(clippy::unwrap_used, reason = "test constant")]
+fn sv2() -> NonZeroU32 {
+    NonZeroU32::new(2).unwrap()
+}
 
 use nexus::*;
 use nexus_store::Store;
@@ -94,7 +101,7 @@ fn repo(
         InMemorySnapshotStore::new(),
         nexus_store::JsonCodec::default(),
         trigger,
-        1,
+        SV1,
         snapshot_on_read,
     )
 }
@@ -193,7 +200,7 @@ async fn schema_version_mismatch_falls_back_to_full_replay() {
         &snap_store,
         nexus_store::JsonCodec::default(),
         EveryNEvents(NonZeroU64::new(1).unwrap()),
-        1, // schema v1
+        SV1, // schema v1
         false,
     );
 
@@ -211,7 +218,7 @@ async fn schema_version_mismatch_falls_back_to_full_replay() {
         &snap_store,
         nexus_store::JsonCodec::default(),
         EveryNEvents(NonZeroU64::new(1).unwrap()),
-        2, // schema v2 — mismatch!
+        sv2(), // schema v2 — mismatch!
         false,
     );
 
@@ -260,7 +267,7 @@ async fn lazy_snapshot_on_read_after_full_replay() {
         &snap_store,
         nexus_store::JsonCodec::default(),
         EveryNEvents(NonZeroU64::new(1000).unwrap()), // very high threshold
-        1,
+        SV1,
         false, // no on-read yet
     );
 
@@ -286,7 +293,7 @@ async fn lazy_snapshot_on_read_after_full_replay() {
         &snap_store,
         nexus_store::JsonCodec::default(),
         EveryNEvents(NonZeroU64::new(1000).unwrap()),
-        1,
+        SV1,
         true, // on-read enabled!
     );
 
@@ -446,7 +453,7 @@ async fn sequence_snapshot_invalidation_then_new_snapshot() {
         &snap_store,
         nexus_store::JsonCodec::default(),
         EveryNEvents(NonZeroU64::new(1).unwrap()),
-        1,
+        SV1,
         false,
     );
     let id = CounterId(1);
@@ -463,7 +470,7 @@ async fn sequence_snapshot_invalidation_then_new_snapshot() {
         &snap_store,
         nexus_store::JsonCodec::default(),
         EveryNEvents(NonZeroU64::new(1).unwrap()),
-        2,
+        sv2(),
         false,
     );
     let mut agg: AggregateRoot<CounterAggregate> = repo_v2.load(id.clone()).await.unwrap();
@@ -482,7 +489,7 @@ async fn sequence_snapshot_invalidation_then_new_snapshot() {
 
     // Verify the snapshot has schema v2
     let snap = snap_store.load_snapshot(&id).await.unwrap().unwrap();
-    assert_eq!(snap.schema_version(), 2);
+    assert_eq!(snap.schema_version(), sv2());
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -526,7 +533,7 @@ async fn lifecycle_lazy_snapshot_then_subsequent_load_uses_it() {
         &snap_store,
         nexus_store::JsonCodec::default(),
         EveryNEvents(NonZeroU64::new(10000).unwrap()),
-        1,
+        SV1,
         false,
     );
     let id = CounterId(1);
@@ -555,7 +562,7 @@ async fn lifecycle_lazy_snapshot_then_subsequent_load_uses_it() {
         &snap_store,
         nexus_store::JsonCodec::default(),
         EveryNEvents(NonZeroU64::new(10000).unwrap()),
-        1,
+        SV1,
         true,
     );
     let _loaded: AggregateRoot<CounterAggregate> = repo_on_read.load(id.clone()).await.unwrap();
@@ -603,7 +610,7 @@ async fn defensive_snapshot_codec_error_falls_back_to_full_replay() {
         &snap_store,
         nexus_store::JsonCodec::default(),
         EveryNEvents(NonZeroU64::new(1).unwrap()),
-        1,
+        SV1,
         false,
     );
     let id = CounterId(1);
@@ -620,7 +627,7 @@ async fn defensive_snapshot_codec_error_falls_back_to_full_replay() {
         &snap_store,
         FailCodec,
         EveryNEvents(NonZeroU64::new(1).unwrap()),
-        1,
+        SV1,
         false,
     );
     let loaded: AggregateRoot<CounterAggregate> = repo_bad.load(id).await.unwrap();
@@ -665,7 +672,7 @@ async fn defensive_snapshot_store_load_error_falls_back_to_full_replay() {
         InMemorySnapshotStore::new(),
         nexus_store::JsonCodec::default(),
         EveryNEvents(NonZeroU64::new(1).unwrap()),
-        1,
+        SV1,
         false,
     );
     let id = CounterId(1);
@@ -685,7 +692,7 @@ async fn defensive_snapshot_store_load_error_falls_back_to_full_replay() {
         ErrorStore,
         nexus_store::JsonCodec::default(),
         EveryNEvents(NonZeroU64::new(1).unwrap()),
-        1,
+        SV1,
         false,
     );
     let loaded: AggregateRoot<CounterAggregate> = bad_repo.load(id).await.unwrap();
@@ -727,7 +734,7 @@ async fn defensive_snapshot_save_failure_does_not_fail_event_save() {
         SaveErrorStore,
         nexus_store::JsonCodec::default(),
         EveryNEvents(NonZeroU64::new(1).unwrap()),
-        1,
+        SV1,
         false,
     );
 
@@ -774,7 +781,7 @@ async fn isolation_concurrent_loads_from_same_snapshot_get_independent_copies() 
         &snap_store,
         nexus_store::JsonCodec::default(),
         EveryNEvents(NonZeroU64::new(1).unwrap()),
-        1,
+        SV1,
         false,
     );
     let id = CounterId(1);
@@ -797,7 +804,7 @@ async fn isolation_concurrent_loads_from_same_snapshot_get_independent_copies() 
         &snap_store,
         nexus_store::JsonCodec::default(),
         EveryNEvents(NonZeroU64::new(1).unwrap()),
-        1,
+        SV1,
         false,
     );
 

--- a/crates/nexus-store/tests/snapshot_integration_tests.rs
+++ b/crates/nexus-store/tests/snapshot_integration_tests.rs
@@ -349,3 +349,472 @@ async fn multiple_save_load_cycles() {
     assert_eq!(agg.state().value, 6);
     assert_eq!(agg.version(), Some(Version::new(6).unwrap()));
 }
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 1. Sequence/Protocol Tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn sequence_save_snapshot_save_more_snapshot_again() {
+    let repo = repo(EveryNEvents(NonZeroU64::new(3).unwrap()), false);
+    let id = CounterId(42);
+
+    // Save 3 → snapshot at v3
+    let mut agg = repo.load(id.clone()).await.unwrap();
+    repo.save(
+        &mut agg,
+        &[
+            CounterEvent::Incremented,
+            CounterEvent::Incremented,
+            CounterEvent::Incremented,
+        ],
+    )
+    .await
+    .unwrap();
+    assert_eq!(agg.version(), Some(Version::new(3).unwrap()));
+
+    // Reload from snapshot → save 3 more → snapshot at v6
+    let mut agg = repo.load(id.clone()).await.unwrap();
+    assert_eq!(agg.state().value, 3);
+    repo.save(
+        &mut agg,
+        &[
+            CounterEvent::Decremented,
+            CounterEvent::Decremented,
+            CounterEvent::Incremented,
+        ],
+    )
+    .await
+    .unwrap();
+
+    // Final reload — should use v6 snapshot
+    let agg = repo.load(id).await.unwrap();
+    assert_eq!(agg.state().value, 2); // 3 - 1 - 1 + 1
+    assert_eq!(agg.version(), Some(Version::new(6).unwrap()));
+}
+
+#[tokio::test]
+async fn sequence_batch_crossing_non_multiple_boundary() {
+    // EveryNEvents(5): batch 96→103 crosses 100-boundary
+    // We simulate with small numbers: EveryNEvents(5), batch 3→8 crosses 5
+    let repo = repo(EveryNEvents(NonZeroU64::new(5).unwrap()), false);
+    let id = CounterId(1);
+
+    // Save 3 events (v1-v3)
+    let mut agg = repo.load(id.clone()).await.unwrap();
+    repo.save(
+        &mut agg,
+        &[
+            CounterEvent::Incremented,
+            CounterEvent::Incremented,
+            CounterEvent::Incremented,
+        ],
+    )
+    .await
+    .unwrap();
+
+    // Save 5 events in batch (v4-v8) — crosses the 5 boundary
+    repo.save(
+        &mut agg,
+        &[
+            CounterEvent::Incremented,
+            CounterEvent::Incremented,
+            CounterEvent::Incremented,
+            CounterEvent::Incremented,
+            CounterEvent::Incremented,
+        ],
+    )
+    .await
+    .unwrap();
+
+    // Snapshot should exist at v8. Reload and verify.
+    let loaded = repo.load(id).await.unwrap();
+    assert_eq!(loaded.state().value, 8);
+    assert_eq!(loaded.version(), Some(Version::new(8).unwrap()));
+}
+
+#[tokio::test]
+async fn sequence_snapshot_invalidation_then_new_snapshot() {
+    let raw = InMemoryStore::new();
+    let store = Store::new(raw);
+    let snap_store = InMemorySnapshotStore::new();
+
+    // Save with schema v1, triggers snapshot
+    let inner = store.repository().build();
+    let repo_v1 = Snapshotting::new(
+        inner,
+        &snap_store,
+        nexus_store::JsonCodec::default(),
+        EveryNEvents(NonZeroU64::new(1).unwrap()),
+        1,
+        false,
+    );
+    let id = CounterId(1);
+    let mut agg: AggregateRoot<CounterAggregate> = repo_v1.load(id.clone()).await.unwrap();
+    repo_v1
+        .save(&mut agg, &[CounterEvent::Incremented])
+        .await
+        .unwrap();
+
+    // Switch to schema v2 — old snapshot ignored, full replay, new snapshot created
+    let inner2 = store.repository().build();
+    let repo_v2 = Snapshotting::new(
+        inner2,
+        &snap_store,
+        nexus_store::JsonCodec::default(),
+        EveryNEvents(NonZeroU64::new(1).unwrap()),
+        2,
+        false,
+    );
+    let mut agg: AggregateRoot<CounterAggregate> = repo_v2.load(id.clone()).await.unwrap();
+    assert_eq!(agg.state().value, 1);
+
+    // Save another event → new snapshot with schema v2
+    repo_v2
+        .save(&mut agg, &[CounterEvent::Incremented])
+        .await
+        .unwrap();
+
+    // Reload should hit v2 snapshot
+    let loaded: AggregateRoot<CounterAggregate> = repo_v2.load(id.clone()).await.unwrap();
+    assert_eq!(loaded.state().value, 2);
+    assert_eq!(loaded.version(), Some(Version::new(2).unwrap()));
+
+    // Verify the snapshot has schema v2
+    let snap = snap_store.load_snapshot(&id).await.unwrap().unwrap();
+    assert_eq!(snap.schema_version(), 2);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 2. Lifecycle Tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn lifecycle_create_save_snapshot_reload_verify() {
+    let repo = repo(EveryNEvents(NonZeroU64::new(2).unwrap()), false);
+    let id = CounterId(99);
+
+    // Create new aggregate
+    let mut agg = repo.load(id.clone()).await.unwrap();
+    assert_eq!(agg.version(), None);
+    assert_eq!(agg.state().value, 0);
+
+    // Save 2 events → snapshot
+    repo.save(
+        &mut agg,
+        &[CounterEvent::Incremented, CounterEvent::Decremented],
+    )
+    .await
+    .unwrap();
+
+    // Reload → from snapshot, state should match
+    let loaded = repo.load(id).await.unwrap();
+    assert_eq!(loaded.state().value, 0); // +1 -1
+    assert_eq!(loaded.version(), Some(Version::new(2).unwrap()));
+}
+
+#[tokio::test]
+async fn lifecycle_lazy_snapshot_then_subsequent_load_uses_it() {
+    let raw = InMemoryStore::new();
+    let store = Store::new(raw);
+    let snap_store = InMemorySnapshotStore::new();
+
+    // Save events without snapshot
+    let inner = store.repository().build();
+    let repo_no_snap = Snapshotting::new(
+        inner,
+        &snap_store,
+        nexus_store::JsonCodec::default(),
+        EveryNEvents(NonZeroU64::new(10000).unwrap()),
+        1,
+        false,
+    );
+    let id = CounterId(1);
+    let mut agg: AggregateRoot<CounterAggregate> = repo_no_snap.load(id.clone()).await.unwrap();
+    repo_no_snap
+        .save(
+            &mut agg,
+            &[
+                CounterEvent::Incremented,
+                CounterEvent::Incremented,
+                CounterEvent::Incremented,
+                CounterEvent::Incremented,
+                CounterEvent::Incremented,
+            ],
+        )
+        .await
+        .unwrap();
+
+    // No snapshot yet
+    assert!(snap_store.load_snapshot(&id).await.unwrap().is_none());
+
+    // Load with on-read → creates lazy snapshot
+    let inner2 = store.repository().build();
+    let repo_on_read = Snapshotting::new(
+        inner2,
+        &snap_store,
+        nexus_store::JsonCodec::default(),
+        EveryNEvents(NonZeroU64::new(10000).unwrap()),
+        1,
+        true,
+    );
+    let _loaded: AggregateRoot<CounterAggregate> = repo_on_read.load(id.clone()).await.unwrap();
+
+    // Snapshot now exists
+    let snap = snap_store.load_snapshot(&id).await.unwrap().unwrap();
+    assert_eq!(snap.version(), Version::new(5).unwrap());
+
+    // Second load uses snapshot (we can't directly prove partial replay,
+    // but state correctness confirms the snapshot path works)
+    let loaded2: AggregateRoot<CounterAggregate> = repo_on_read.load(id).await.unwrap();
+    assert_eq!(loaded2.state().value, 5);
+    assert_eq!(loaded2.version(), Some(Version::new(5).unwrap()));
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 3. Defensive Boundary Tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn defensive_snapshot_codec_error_falls_back_to_full_replay() {
+    // Use a codec that always fails decode
+    struct FailCodec;
+    impl nexus_store::Codec<CounterState> for FailCodec {
+        type Error = std::io::Error;
+        fn encode(&self, _state: &CounterState) -> Result<Vec<u8>, Self::Error> {
+            Ok(vec![1, 2, 3])
+        }
+        fn decode(&self, _event_type: &str, _payload: &[u8]) -> Result<CounterState, Self::Error> {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "always fails",
+            ))
+        }
+    }
+
+    let raw = InMemoryStore::new();
+    let store = Store::new(raw);
+    let snap_store = InMemorySnapshotStore::new();
+
+    // Save events and manually insert a snapshot
+    let inner = store.repository().build();
+    let repo_good = Snapshotting::new(
+        inner,
+        &snap_store,
+        nexus_store::JsonCodec::default(),
+        EveryNEvents(NonZeroU64::new(1).unwrap()),
+        1,
+        false,
+    );
+    let id = CounterId(1);
+    let mut agg: AggregateRoot<CounterAggregate> = repo_good.load(id.clone()).await.unwrap();
+    repo_good
+        .save(&mut agg, &[CounterEvent::Incremented])
+        .await
+        .unwrap();
+
+    // Now load with the failing codec — should fall back to full replay
+    let inner2 = store.repository().build();
+    let repo_bad = Snapshotting::new(
+        inner2,
+        &snap_store,
+        FailCodec,
+        EveryNEvents(NonZeroU64::new(1).unwrap()),
+        1,
+        false,
+    );
+    let loaded: AggregateRoot<CounterAggregate> = repo_bad.load(id).await.unwrap();
+    assert_eq!(loaded.state().value, 1);
+    assert_eq!(loaded.version(), Some(Version::new(1).unwrap()));
+}
+
+#[tokio::test]
+async fn defensive_snapshot_store_load_error_falls_back_to_full_replay() {
+    // A snapshot store that always errors on load
+    struct ErrorStore;
+    impl SnapshotStore for ErrorStore {
+        type Error = std::io::Error;
+        async fn load_snapshot(
+            &self,
+            _id: &impl nexus::Id,
+        ) -> Result<Option<nexus_store::snapshot::PersistedSnapshot>, Self::Error> {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "disk on fire",
+            ))
+        }
+        async fn save_snapshot(
+            &self,
+            _id: &impl nexus::Id,
+            _snapshot: &nexus_store::snapshot::PendingSnapshot,
+        ) -> Result<(), Self::Error> {
+            Ok(())
+        }
+        async fn delete_snapshot(&self, _id: &impl nexus::Id) -> Result<(), Self::Error> {
+            Ok(())
+        }
+    }
+
+    let raw = InMemoryStore::new();
+    let store = Store::new(raw);
+
+    // Save some events first
+    let inner = store.repository().build();
+    let good_repo = Snapshotting::new(
+        inner,
+        InMemorySnapshotStore::new(),
+        nexus_store::JsonCodec::default(),
+        EveryNEvents(NonZeroU64::new(1).unwrap()),
+        1,
+        false,
+    );
+    let id = CounterId(1);
+    let mut agg: AggregateRoot<CounterAggregate> = good_repo.load(id.clone()).await.unwrap();
+    good_repo
+        .save(
+            &mut agg,
+            &[CounterEvent::Incremented, CounterEvent::Incremented],
+        )
+        .await
+        .unwrap();
+
+    // Now load with error store — should fall back to full replay
+    let inner2 = store.repository().build();
+    let bad_repo = Snapshotting::new(
+        inner2,
+        ErrorStore,
+        nexus_store::JsonCodec::default(),
+        EveryNEvents(NonZeroU64::new(1).unwrap()),
+        1,
+        false,
+    );
+    let loaded: AggregateRoot<CounterAggregate> = bad_repo.load(id).await.unwrap();
+    assert_eq!(loaded.state().value, 2);
+}
+
+#[tokio::test]
+async fn defensive_snapshot_save_failure_does_not_fail_event_save() {
+    // A snapshot store that always errors on save
+    struct SaveErrorStore;
+    impl SnapshotStore for SaveErrorStore {
+        type Error = std::io::Error;
+        async fn load_snapshot(
+            &self,
+            _id: &impl nexus::Id,
+        ) -> Result<Option<nexus_store::snapshot::PersistedSnapshot>, Self::Error> {
+            Ok(None)
+        }
+        async fn save_snapshot(
+            &self,
+            _id: &impl nexus::Id,
+            _snapshot: &nexus_store::snapshot::PendingSnapshot,
+        ) -> Result<(), Self::Error> {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "snapshot write failed",
+            ))
+        }
+        async fn delete_snapshot(&self, _id: &impl nexus::Id) -> Result<(), Self::Error> {
+            Ok(())
+        }
+    }
+
+    let raw = InMemoryStore::new();
+    let store = Store::new(raw);
+    let inner = store.repository().build();
+    let repo = Snapshotting::new(
+        inner,
+        SaveErrorStore,
+        nexus_store::JsonCodec::default(),
+        EveryNEvents(NonZeroU64::new(1).unwrap()),
+        1,
+        false,
+    );
+
+    let id = CounterId(1);
+    let mut agg: AggregateRoot<CounterAggregate> = repo.load(id.clone()).await.unwrap();
+
+    // Save should succeed despite snapshot save failure
+    let result = repo.save(&mut agg, &[CounterEvent::Incremented]).await;
+    assert!(result.is_ok());
+    assert_eq!(agg.state().value, 1);
+
+    // Events persist correctly — reload works via full replay
+    let loaded: AggregateRoot<CounterAggregate> = repo.load(id).await.unwrap();
+    assert_eq!(loaded.state().value, 1);
+}
+
+#[tokio::test]
+async fn defensive_after_event_types_empty_names_no_trigger() {
+    let trigger = AfterEventTypes::new(&["OrderCompleted"]);
+    // Empty event names should not trigger
+    assert!(!trigger.should_snapshot(None, Version::new(5).unwrap(), &[]));
+    // Non-matching should not trigger
+    assert!(!trigger.should_snapshot(
+        Some(Version::new(1).unwrap()),
+        Version::new(2).unwrap(),
+        &["ItemAdded"]
+    ));
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 4. Linearizability/Isolation Tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn isolation_concurrent_loads_from_same_snapshot_get_independent_copies() {
+    let raw = InMemoryStore::new();
+    let store = Store::new(raw);
+    let snap_store = InMemorySnapshotStore::new();
+
+    // Save 3 events, snapshot at v3
+    let inner = store.repository().build();
+    let repo = Snapshotting::new(
+        inner,
+        &snap_store,
+        nexus_store::JsonCodec::default(),
+        EveryNEvents(NonZeroU64::new(1).unwrap()),
+        1,
+        false,
+    );
+    let id = CounterId(1);
+    let mut agg: AggregateRoot<CounterAggregate> = repo.load(id.clone()).await.unwrap();
+    repo.save(
+        &mut agg,
+        &[
+            CounterEvent::Incremented,
+            CounterEvent::Incremented,
+            CounterEvent::Incremented,
+        ],
+    )
+    .await
+    .unwrap();
+
+    // Load two copies concurrently
+    let inner2 = store.repository().build();
+    let repo2 = Snapshotting::new(
+        inner2,
+        &snap_store,
+        nexus_store::JsonCodec::default(),
+        EveryNEvents(NonZeroU64::new(1).unwrap()),
+        1,
+        false,
+    );
+
+    let (load_a, load_b) = tokio::join!(
+        async {
+            let agg: AggregateRoot<CounterAggregate> = repo2.load(id.clone()).await.unwrap();
+            agg
+        },
+        async {
+            let agg: AggregateRoot<CounterAggregate> = repo.load(id.clone()).await.unwrap();
+            agg
+        },
+    );
+
+    // Both should have identical state but be independent instances
+    assert_eq!(load_a.state().value, 3);
+    assert_eq!(load_b.state().value, 3);
+    assert_eq!(load_a.version(), Some(Version::new(3).unwrap()));
+    assert_eq!(load_b.version(), Some(Version::new(3).unwrap()));
+}

--- a/crates/nexus-store/tests/snapshot_integration_tests.rs
+++ b/crates/nexus-store/tests/snapshot_integration_tests.rs
@@ -1,0 +1,351 @@
+#![cfg(all(feature = "snapshot", feature = "json", feature = "testing"))]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::shadow_reuse,
+    clippy::shadow_same,
+    clippy::shadow_unrelated,
+    clippy::as_conversions,
+    reason = "test harness — relaxed lints for test code"
+)]
+
+use std::fmt;
+use std::num::NonZeroU64;
+
+use nexus::*;
+use nexus_store::Store;
+use nexus_store::snapshot::{
+    AfterEventTypes, EveryNEvents, InMemorySnapshotStore, SnapshotStore, SnapshotTrigger,
+};
+use nexus_store::store::{Repository, Snapshotting};
+use nexus_store::testing::InMemoryStore;
+
+// ── Test domain ────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+enum CounterEvent {
+    Incremented,
+    Decremented,
+}
+
+impl Message for CounterEvent {}
+impl DomainEvent for CounterEvent {
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Incremented => "Incremented",
+            Self::Decremented => "Decremented",
+        }
+    }
+}
+
+#[derive(Default, Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+struct CounterState {
+    value: i64,
+}
+
+impl AggregateState for CounterState {
+    type Event = CounterEvent;
+    fn initial() -> Self {
+        Self::default()
+    }
+    fn apply(mut self, event: &CounterEvent) -> Self {
+        match event {
+            CounterEvent::Incremented => self.value += 1,
+            CounterEvent::Decremented => self.value -= 1,
+        }
+        self
+    }
+}
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+struct CounterId(u64);
+
+impl fmt::Display for CounterId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "counter-{}", self.0)
+    }
+}
+impl Id for CounterId {}
+
+#[derive(Debug, thiserror::Error)]
+#[error("counter error")]
+struct CounterError;
+
+struct CounterAggregate;
+impl Aggregate for CounterAggregate {
+    type State = CounterState;
+    type Error = CounterError;
+    type Id = CounterId;
+}
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+fn repo(
+    trigger: impl SnapshotTrigger,
+    snapshot_on_read: bool,
+) -> impl Repository<CounterAggregate, Error = nexus_store::StoreError> {
+    let raw = InMemoryStore::new();
+    let store = Store::new(raw);
+    let inner = store.repository().build();
+
+    Snapshotting::new(
+        inner,
+        InMemorySnapshotStore::new(),
+        nexus_store::JsonCodec::default(),
+        trigger,
+        1,
+        snapshot_on_read,
+    )
+}
+
+// ── Tests ──────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn load_without_snapshot_does_full_replay() {
+    let repo = repo(EveryNEvents(NonZeroU64::new(100).unwrap()), false);
+    let id = CounterId(1);
+
+    // Save 5 events
+    let mut agg = repo.load(id.clone()).await.unwrap();
+    let events = vec![
+        CounterEvent::Incremented,
+        CounterEvent::Incremented,
+        CounterEvent::Incremented,
+        CounterEvent::Decremented,
+        CounterEvent::Incremented,
+    ];
+    repo.save(&mut agg, &events).await.unwrap();
+
+    // Reload — should replay all 5 events
+    let loaded = repo.load(id).await.unwrap();
+    assert_eq!(loaded.state().value, 3); // +1 +1 +1 -1 +1 = 3
+    assert_eq!(loaded.version(), Some(Version::new(5).unwrap()));
+}
+
+#[tokio::test]
+async fn save_triggers_snapshot_and_load_uses_it() {
+    // EveryNEvents(3) — snapshot after 3 events
+    let repo = repo(EveryNEvents(NonZeroU64::new(3).unwrap()), false);
+    let id = CounterId(1);
+
+    let mut agg = repo.load(id.clone()).await.unwrap();
+    let events = vec![
+        CounterEvent::Incremented,
+        CounterEvent::Incremented,
+        CounterEvent::Incremented,
+    ];
+    repo.save(&mut agg, &events).await.unwrap();
+
+    // At this point, trigger should have fired (crossed 3-boundary).
+    // Reload — should hit snapshot + partial replay (0 additional events).
+    let loaded = repo.load(id).await.unwrap();
+    assert_eq!(loaded.state().value, 3);
+    assert_eq!(loaded.version(), Some(Version::new(3).unwrap()));
+}
+
+#[tokio::test]
+async fn save_below_threshold_no_snapshot_then_crosses() {
+    let repo = repo(EveryNEvents(NonZeroU64::new(5).unwrap()), false);
+    let id = CounterId(1);
+
+    // Save 3 events — below threshold
+    let mut agg = repo.load(id.clone()).await.unwrap();
+    repo.save(
+        &mut agg,
+        &[
+            CounterEvent::Incremented,
+            CounterEvent::Incremented,
+            CounterEvent::Incremented,
+        ],
+    )
+    .await
+    .unwrap();
+
+    // Save 3 more — crosses 5-boundary (v3→v6)
+    repo.save(
+        &mut agg,
+        &[
+            CounterEvent::Incremented,
+            CounterEvent::Incremented,
+            CounterEvent::Incremented,
+        ],
+    )
+    .await
+    .unwrap();
+
+    // Reload — should use snapshot at v6
+    let loaded = repo.load(id).await.unwrap();
+    assert_eq!(loaded.state().value, 6);
+    assert_eq!(loaded.version(), Some(Version::new(6).unwrap()));
+}
+
+#[tokio::test]
+async fn schema_version_mismatch_falls_back_to_full_replay() {
+    // Create a repo with schema_version=1, save events+snapshot
+    let raw = InMemoryStore::new();
+    let store = Store::new(raw);
+    let inner = store.repository().build();
+    let snap_store = InMemorySnapshotStore::new();
+
+    let repo_v1 = Snapshotting::new(
+        inner,
+        &snap_store,
+        nexus_store::JsonCodec::default(),
+        EveryNEvents(NonZeroU64::new(1).unwrap()),
+        1, // schema v1
+        false,
+    );
+
+    let id = CounterId(1);
+    let mut agg: AggregateRoot<CounterAggregate> = repo_v1.load(id.clone()).await.unwrap();
+    repo_v1
+        .save(&mut agg, &[CounterEvent::Incremented])
+        .await
+        .unwrap();
+
+    // Now create a new repo with schema_version=2 pointing to same stores
+    let inner2 = store.repository().build();
+    let repo_v2 = Snapshotting::new(
+        inner2,
+        &snap_store,
+        nexus_store::JsonCodec::default(),
+        EveryNEvents(NonZeroU64::new(1).unwrap()),
+        2, // schema v2 — mismatch!
+        false,
+    );
+
+    // Load should ignore the v1 snapshot and do full replay
+    let loaded: AggregateRoot<CounterAggregate> = repo_v2.load(id).await.unwrap();
+    assert_eq!(loaded.state().value, 1);
+    assert_eq!(loaded.version(), Some(Version::new(1).unwrap()));
+}
+
+#[tokio::test]
+async fn after_event_types_trigger_snapshots_on_domain_milestone() {
+    let repo = repo(AfterEventTypes::new(&["Decremented"]), false);
+    let id = CounterId(1);
+
+    let mut agg = repo.load(id.clone()).await.unwrap();
+
+    // Save Incremented — no snapshot
+    repo.save(&mut agg, &[CounterEvent::Incremented])
+        .await
+        .unwrap();
+    repo.save(&mut agg, &[CounterEvent::Incremented])
+        .await
+        .unwrap();
+
+    // Save Decremented — triggers snapshot
+    repo.save(&mut agg, &[CounterEvent::Decremented])
+        .await
+        .unwrap();
+
+    // Reload — snapshot at v3, state=1
+    let loaded = repo.load(id).await.unwrap();
+    assert_eq!(loaded.state().value, 1);
+    assert_eq!(loaded.version(), Some(Version::new(3).unwrap()));
+}
+
+#[tokio::test]
+async fn lazy_snapshot_on_read_after_full_replay() {
+    let raw = InMemoryStore::new();
+    let store = Store::new(raw);
+    let snap_store = InMemorySnapshotStore::new();
+
+    // First, save events without snapshots (no trigger, just on-read)
+    let inner = store.repository().build();
+    let repo_write = Snapshotting::new(
+        inner,
+        &snap_store,
+        nexus_store::JsonCodec::default(),
+        EveryNEvents(NonZeroU64::new(1000).unwrap()), // very high threshold
+        1,
+        false, // no on-read yet
+    );
+
+    let id = CounterId(1);
+    let mut agg: AggregateRoot<CounterAggregate> = repo_write.load(id.clone()).await.unwrap();
+    repo_write
+        .save(
+            &mut agg,
+            &[
+                CounterEvent::Incremented,
+                CounterEvent::Incremented,
+                CounterEvent::Incremented,
+            ],
+        )
+        .await
+        .unwrap();
+
+    // No snapshot yet (threshold too high).
+    // Now create a repo with on-read enabled
+    let inner2 = store.repository().build();
+    let repo_read = Snapshotting::new(
+        inner2,
+        &snap_store,
+        nexus_store::JsonCodec::default(),
+        EveryNEvents(NonZeroU64::new(1000).unwrap()),
+        1,
+        true, // on-read enabled!
+    );
+
+    // First load → full replay → lazy snapshot created
+    let loaded: AggregateRoot<CounterAggregate> = repo_read.load(id.clone()).await.unwrap();
+    assert_eq!(loaded.state().value, 3);
+
+    // Verify snapshot was created by checking load_snapshot directly
+    let snap = snap_store.load_snapshot(&id).await.unwrap();
+    assert!(snap.is_some());
+    assert_eq!(snap.unwrap().version(), Version::new(3).unwrap());
+}
+
+#[tokio::test]
+async fn empty_events_save_is_noop() {
+    let repo = repo(EveryNEvents(NonZeroU64::new(1).unwrap()), false);
+    let id = CounterId(1);
+
+    let mut agg = repo.load(id.clone()).await.unwrap();
+    // Save empty slice — should not trigger snapshot
+    repo.save(&mut agg, &[]).await.unwrap();
+
+    assert_eq!(agg.version(), None);
+}
+
+#[tokio::test]
+async fn multiple_save_load_cycles() {
+    let repo = repo(EveryNEvents(NonZeroU64::new(3).unwrap()), false);
+    let id = CounterId(1);
+
+    // Cycle 1: save 3 → snapshot at v3
+    let mut agg = repo.load(id.clone()).await.unwrap();
+    repo.save(
+        &mut agg,
+        &[
+            CounterEvent::Incremented,
+            CounterEvent::Incremented,
+            CounterEvent::Incremented,
+        ],
+    )
+    .await
+    .unwrap();
+
+    // Cycle 2: reload, save 3 more → snapshot at v6
+    let mut agg = repo.load(id.clone()).await.unwrap();
+    assert_eq!(agg.state().value, 3);
+    repo.save(
+        &mut agg,
+        &[
+            CounterEvent::Incremented,
+            CounterEvent::Incremented,
+            CounterEvent::Incremented,
+        ],
+    )
+    .await
+    .unwrap();
+
+    // Cycle 3: reload, verify state
+    let agg = repo.load(id).await.unwrap();
+    assert_eq!(agg.state().value, 6);
+    assert_eq!(agg.version(), Some(Version::new(6).unwrap()));
+}

--- a/crates/nexus-store/tests/snapshot_tests.rs
+++ b/crates/nexus-store/tests/snapshot_tests.rs
@@ -1,0 +1,42 @@
+#![cfg(feature = "snapshot")]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::shadow_reuse,
+    clippy::shadow_same,
+    clippy::shadow_unrelated,
+    clippy::as_conversions,
+    reason = "test harness — relaxed lints for test code"
+)]
+
+use nexus::Version;
+use nexus_store::snapshot::{PendingSnapshot, PersistedSnapshot};
+
+#[test]
+fn pending_snapshot_stores_version_and_payload() {
+    let version = Version::new(42).unwrap();
+    let payload = vec![1, 2, 3];
+    let snap = PendingSnapshot::new(version, 1, payload.clone());
+
+    assert_eq!(snap.version(), version);
+    assert_eq!(snap.schema_version(), 1);
+    assert_eq!(snap.payload(), &payload);
+}
+
+#[test]
+fn pending_snapshot_schema_version_must_be_nonzero() {
+    let version = Version::new(1).unwrap();
+    let result = PendingSnapshot::try_new(version, 0, vec![]);
+    assert!(result.is_err());
+}
+
+#[test]
+fn persisted_snapshot_stores_version_and_payload() {
+    let version = Version::new(10).unwrap();
+    let snap = PersistedSnapshot::new(version, 2, vec![4, 5, 6]);
+
+    assert_eq!(snap.version(), version);
+    assert_eq!(snap.schema_version(), 2);
+    assert_eq!(snap.payload(), &[4, 5, 6]);
+}

--- a/crates/nexus-store/tests/snapshot_tests.rs
+++ b/crates/nexus-store/tests/snapshot_tests.rs
@@ -10,8 +10,21 @@
     reason = "test harness — relaxed lints for test code"
 )]
 
-use nexus::Version;
-use nexus_store::snapshot::{PendingSnapshot, PersistedSnapshot};
+use std::fmt;
+
+use nexus::{Id, Version};
+use nexus_store::snapshot::{PendingSnapshot, PersistedSnapshot, SnapshotStore};
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+struct TestId(String);
+
+impl fmt::Display for TestId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl Id for TestId {}
 
 #[test]
 fn pending_snapshot_stores_version_and_payload() {
@@ -39,4 +52,31 @@ fn persisted_snapshot_stores_version_and_payload() {
     assert_eq!(snap.version(), version);
     assert_eq!(snap.schema_version(), 2);
     assert_eq!(snap.payload(), &[4, 5, 6]);
+}
+
+// ── () no-op SnapshotStore ─────────────────────────────────────────
+
+#[tokio::test]
+async fn unit_snapshot_store_returns_none() {
+    let store = ();
+    let id = TestId("agg-1".into());
+    let result = store.load_snapshot(&id).await;
+    assert!(result.unwrap().is_none());
+}
+
+#[tokio::test]
+async fn unit_snapshot_store_save_succeeds() {
+    let store = ();
+    let id = TestId("agg-1".into());
+    let snap = PendingSnapshot::new(Version::new(1).unwrap(), 1, vec![1, 2, 3]);
+    let result = store.save_snapshot(&id, &snap).await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn unit_snapshot_store_delete_succeeds() {
+    let store = ();
+    let id = TestId("agg-1".into());
+    let result = store.delete_snapshot(&id).await;
+    assert!(result.is_ok());
 }

--- a/crates/nexus-store/tests/snapshot_tests.rs
+++ b/crates/nexus-store/tests/snapshot_tests.rs
@@ -12,7 +12,7 @@
 
 use std::fmt;
 
-use std::num::NonZeroU64;
+use std::num::{NonZeroU32, NonZeroU64};
 
 use nexus::{Id, Version};
 use nexus_store::snapshot::{
@@ -35,27 +35,22 @@ impl Id for TestId {}
 fn pending_snapshot_stores_version_and_payload() {
     let version = Version::new(42).unwrap();
     let payload = vec![1, 2, 3];
-    let snap = PendingSnapshot::new(version, 1, payload.clone());
+    let sv = NonZeroU32::new(1).unwrap();
+    let snap = PendingSnapshot::new(version, sv, payload.clone());
 
     assert_eq!(snap.version(), version);
-    assert_eq!(snap.schema_version(), 1);
+    assert_eq!(snap.schema_version(), sv);
     assert_eq!(snap.payload(), &payload);
-}
-
-#[test]
-fn pending_snapshot_schema_version_must_be_nonzero() {
-    let version = Version::new(1).unwrap();
-    let result = PendingSnapshot::try_new(version, 0, vec![]);
-    assert!(result.is_err());
 }
 
 #[test]
 fn persisted_snapshot_stores_version_and_payload() {
     let version = Version::new(10).unwrap();
-    let snap = PersistedSnapshot::new(version, 2, vec![4, 5, 6]);
+    let sv = NonZeroU32::new(2).unwrap();
+    let snap = PersistedSnapshot::new(version, sv, vec![4, 5, 6]);
 
     assert_eq!(snap.version(), version);
-    assert_eq!(snap.schema_version(), 2);
+    assert_eq!(snap.schema_version(), sv);
     assert_eq!(snap.payload(), &[4, 5, 6]);
 }
 
@@ -73,7 +68,11 @@ async fn unit_snapshot_store_returns_none() {
 async fn unit_snapshot_store_save_succeeds() {
     let store = ();
     let id = TestId("agg-1".into());
-    let snap = PendingSnapshot::new(Version::new(1).unwrap(), 1, vec![1, 2, 3]);
+    let snap = PendingSnapshot::new(
+        Version::new(1).unwrap(),
+        NonZeroU32::new(1).unwrap(),
+        vec![1, 2, 3],
+    );
     let result = store.save_snapshot(&id, &snap).await;
     assert!(result.is_ok());
 }
@@ -184,13 +183,13 @@ mod in_memory_tests {
         let store = InMemorySnapshotStore::new();
         let id = TestId("agg-1".into());
         let version = Version::new(10).unwrap();
-        let snap = PendingSnapshot::new(version, 1, vec![1, 2, 3]);
+        let snap = PendingSnapshot::new(version, NonZeroU32::new(1).unwrap(), vec![1, 2, 3]);
 
         store.save_snapshot(&id, &snap).await.unwrap();
         let loaded = store.load_snapshot(&id).await.unwrap().unwrap();
 
         assert_eq!(loaded.version(), version);
-        assert_eq!(loaded.schema_version(), 1);
+        assert_eq!(loaded.schema_version(), NonZeroU32::new(1).unwrap());
         assert_eq!(loaded.payload(), &[1, 2, 3]);
     }
 
@@ -199,10 +198,18 @@ mod in_memory_tests {
         let store = InMemorySnapshotStore::new();
         let id = TestId("agg-1".into());
 
-        let snap1 = PendingSnapshot::new(Version::new(10).unwrap(), 1, vec![1]);
+        let snap1 = PendingSnapshot::new(
+            Version::new(10).unwrap(),
+            NonZeroU32::new(1).unwrap(),
+            vec![1],
+        );
         store.save_snapshot(&id, &snap1).await.unwrap();
 
-        let snap2 = PendingSnapshot::new(Version::new(20).unwrap(), 1, vec![2]);
+        let snap2 = PendingSnapshot::new(
+            Version::new(20).unwrap(),
+            NonZeroU32::new(1).unwrap(),
+            vec![2],
+        );
         store.save_snapshot(&id, &snap2).await.unwrap();
 
         let loaded = store.load_snapshot(&id).await.unwrap().unwrap();
@@ -214,13 +221,21 @@ mod in_memory_tests {
     async fn different_aggregates_have_separate_snapshots() {
         let store = InMemorySnapshotStore::new();
 
-        let snap1 = PendingSnapshot::new(Version::new(5).unwrap(), 1, vec![1]);
+        let snap1 = PendingSnapshot::new(
+            Version::new(5).unwrap(),
+            NonZeroU32::new(1).unwrap(),
+            vec![1],
+        );
         store
             .save_snapshot(&TestId("agg-1".into()), &snap1)
             .await
             .unwrap();
 
-        let snap2 = PendingSnapshot::new(Version::new(10).unwrap(), 1, vec![2]);
+        let snap2 = PendingSnapshot::new(
+            Version::new(10).unwrap(),
+            NonZeroU32::new(1).unwrap(),
+            vec![2],
+        );
         store
             .save_snapshot(&TestId("agg-2".into()), &snap2)
             .await
@@ -245,7 +260,11 @@ mod in_memory_tests {
         let store = InMemorySnapshotStore::new();
         let id = TestId("agg-1".into());
 
-        let snap = PendingSnapshot::new(Version::new(10).unwrap(), 1, vec![1]);
+        let snap = PendingSnapshot::new(
+            Version::new(10).unwrap(),
+            NonZeroU32::new(1).unwrap(),
+            vec![1],
+        );
         store.save_snapshot(&id, &snap).await.unwrap();
 
         store.delete_snapshot(&id).await.unwrap();
@@ -297,7 +316,7 @@ mod builder_tests {
             .repository()
             .snapshot_store(snap)
             .snapshot_trigger(AfterEventTypes::new(&["Done"]))
-            .snapshot_schema_version(2)
+            .snapshot_schema_version(NonZeroU32::new(2).unwrap())
             .snapshot_on_read(true)
             .build();
     }

--- a/crates/nexus-store/tests/snapshot_tests.rs
+++ b/crates/nexus-store/tests/snapshot_tests.rs
@@ -12,8 +12,13 @@
 
 use std::fmt;
 
+use std::num::NonZeroU64;
+
 use nexus::{Id, Version};
-use nexus_store::snapshot::{PendingSnapshot, PersistedSnapshot, SnapshotStore};
+use nexus_store::snapshot::{
+    AfterEventTypes, EveryNEvents, PendingSnapshot, PersistedSnapshot, SnapshotStore,
+    SnapshotTrigger,
+};
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 struct TestId(String);
@@ -79,4 +84,83 @@ async fn unit_snapshot_store_delete_succeeds() {
     let id = TestId("agg-1".into());
     let result = store.delete_snapshot(&id).await;
     assert!(result.is_ok());
+}
+
+// ── EveryNEvents ────────────────────────────────────────────────────
+
+#[test]
+fn every_n_events_triggers_on_boundary_crossing() {
+    let trigger = EveryNEvents(NonZeroU64::new(100).unwrap());
+
+    // Single-event saves crossing the boundary
+    let v99 = Some(Version::new(99).unwrap());
+    let v100 = Version::new(100).unwrap();
+    assert!(trigger.should_snapshot(v99, v100, &[]));
+
+    // Not yet at boundary
+    let v98 = Some(Version::new(98).unwrap());
+    let v99_ver = Version::new(99).unwrap();
+    assert!(!trigger.should_snapshot(v98, v99_ver, &[]));
+}
+
+#[test]
+fn every_n_events_triggers_on_batch_crossing_boundary() {
+    let trigger = EveryNEvents(NonZeroU64::new(100).unwrap());
+
+    // Batch of 7 events crossing the 100 boundary: 96 → 103
+    let old = Some(Version::new(96).unwrap());
+    let new = Version::new(103).unwrap();
+    assert!(trigger.should_snapshot(old, new, &[]));
+}
+
+#[test]
+fn every_n_events_first_save_triggers_at_boundary() {
+    let trigger = EveryNEvents(NonZeroU64::new(100).unwrap());
+
+    // Fresh aggregate, first save crosses boundary
+    let new = Version::new(100).unwrap();
+    assert!(trigger.should_snapshot(None, new, &[]));
+
+    // Fresh aggregate, first save below boundary
+    let new_50 = Version::new(50).unwrap();
+    assert!(!trigger.should_snapshot(None, new_50, &[]));
+}
+
+#[test]
+fn every_1_event_always_triggers() {
+    let trigger = EveryNEvents(NonZeroU64::new(1).unwrap());
+    assert!(trigger.should_snapshot(None, Version::new(1).unwrap(), &[]));
+    assert!(trigger.should_snapshot(
+        Some(Version::new(1).unwrap()),
+        Version::new(2).unwrap(),
+        &[],
+    ));
+}
+
+// ── AfterEventTypes ─────────────────────────────────────────────────
+
+#[test]
+fn after_event_types_triggers_on_matching_event() {
+    let trigger = AfterEventTypes::new(&["OrderCompleted", "OrderCancelled"]);
+
+    assert!(trigger.should_snapshot(None, Version::new(5).unwrap(), &["OrderCompleted"]));
+    assert!(trigger.should_snapshot(None, Version::new(5).unwrap(), &["OrderCancelled"]));
+    assert!(!trigger.should_snapshot(None, Version::new(5).unwrap(), &["ItemAdded"]));
+}
+
+#[test]
+fn after_event_types_triggers_if_any_event_in_batch_matches() {
+    let trigger = AfterEventTypes::new(&["OrderCompleted"]);
+
+    assert!(trigger.should_snapshot(
+        None,
+        Version::new(5).unwrap(),
+        &["ItemAdded", "OrderCompleted"],
+    ));
+}
+
+#[test]
+fn after_event_types_does_not_trigger_on_empty_events() {
+    let trigger = AfterEventTypes::new(&["OrderCompleted"]);
+    assert!(!trigger.should_snapshot(None, Version::new(5).unwrap(), &[]));
 }

--- a/crates/nexus-store/tests/snapshot_tests.rs
+++ b/crates/nexus-store/tests/snapshot_tests.rs
@@ -260,3 +260,45 @@ mod in_memory_tests {
         assert!(result.is_ok());
     }
 }
+
+// ── Builder integration ─────────────────────────────────────────────
+
+#[cfg(all(feature = "testing", feature = "snapshot-json"))]
+mod builder_tests {
+    use super::*;
+    use nexus_store::Store;
+    use nexus_store::snapshot::InMemorySnapshotStore;
+    use nexus_store::testing::InMemoryStore;
+
+    /// Verify the builder API compiles: no snapshot → EventStore
+    #[test]
+    fn builder_without_snapshot_compiles() {
+        let raw = InMemoryStore::new();
+        let store = Store::new(raw);
+        let _repo = store.repository().build();
+    }
+
+    /// Verify the builder API compiles: with snapshot → Snapshotting<EventStore>
+    #[test]
+    fn builder_with_snapshot_compiles() {
+        let raw = InMemoryStore::new();
+        let store = Store::new(raw);
+        let snap = InMemorySnapshotStore::new();
+        let _repo = store.repository().snapshot_store(snap).build();
+    }
+
+    /// Verify the builder API compiles: with custom trigger
+    #[test]
+    fn builder_with_custom_trigger_compiles() {
+        let raw = InMemoryStore::new();
+        let store = Store::new(raw);
+        let snap = InMemorySnapshotStore::new();
+        let _repo = store
+            .repository()
+            .snapshot_store(snap)
+            .snapshot_trigger(AfterEventTypes::new(&["Done"]))
+            .snapshot_schema_version(2)
+            .snapshot_on_read(true)
+            .build();
+    }
+}

--- a/crates/nexus-store/tests/snapshot_tests.rs
+++ b/crates/nexus-store/tests/snapshot_tests.rs
@@ -164,3 +164,99 @@ fn after_event_types_does_not_trigger_on_empty_events() {
     let trigger = AfterEventTypes::new(&["OrderCompleted"]);
     assert!(!trigger.should_snapshot(None, Version::new(5).unwrap(), &[]));
 }
+
+// ── InMemorySnapshotStore ───────────────────────────────────────────
+
+#[cfg(feature = "testing")]
+mod in_memory_tests {
+    use super::*;
+    use nexus_store::snapshot::InMemorySnapshotStore;
+
+    #[tokio::test]
+    async fn load_returns_none_when_empty() {
+        let store = InMemorySnapshotStore::new();
+        let result = store.load_snapshot(&TestId("agg-1".into())).await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn save_then_load_roundtrips() {
+        let store = InMemorySnapshotStore::new();
+        let id = TestId("agg-1".into());
+        let version = Version::new(10).unwrap();
+        let snap = PendingSnapshot::new(version, 1, vec![1, 2, 3]);
+
+        store.save_snapshot(&id, &snap).await.unwrap();
+        let loaded = store.load_snapshot(&id).await.unwrap().unwrap();
+
+        assert_eq!(loaded.version(), version);
+        assert_eq!(loaded.schema_version(), 1);
+        assert_eq!(loaded.payload(), &[1, 2, 3]);
+    }
+
+    #[tokio::test]
+    async fn save_overwrites_previous_snapshot() {
+        let store = InMemorySnapshotStore::new();
+        let id = TestId("agg-1".into());
+
+        let snap1 = PendingSnapshot::new(Version::new(10).unwrap(), 1, vec![1]);
+        store.save_snapshot(&id, &snap1).await.unwrap();
+
+        let snap2 = PendingSnapshot::new(Version::new(20).unwrap(), 1, vec![2]);
+        store.save_snapshot(&id, &snap2).await.unwrap();
+
+        let loaded = store.load_snapshot(&id).await.unwrap().unwrap();
+        assert_eq!(loaded.version(), Version::new(20).unwrap());
+        assert_eq!(loaded.payload(), &[2]);
+    }
+
+    #[tokio::test]
+    async fn different_aggregates_have_separate_snapshots() {
+        let store = InMemorySnapshotStore::new();
+
+        let snap1 = PendingSnapshot::new(Version::new(5).unwrap(), 1, vec![1]);
+        store
+            .save_snapshot(&TestId("agg-1".into()), &snap1)
+            .await
+            .unwrap();
+
+        let snap2 = PendingSnapshot::new(Version::new(10).unwrap(), 1, vec![2]);
+        store
+            .save_snapshot(&TestId("agg-2".into()), &snap2)
+            .await
+            .unwrap();
+
+        let loaded1 = store
+            .load_snapshot(&TestId("agg-1".into()))
+            .await
+            .unwrap()
+            .unwrap();
+        let loaded2 = store
+            .load_snapshot(&TestId("agg-2".into()))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(loaded1.version(), Version::new(5).unwrap());
+        assert_eq!(loaded2.version(), Version::new(10).unwrap());
+    }
+
+    #[tokio::test]
+    async fn delete_removes_snapshot() {
+        let store = InMemorySnapshotStore::new();
+        let id = TestId("agg-1".into());
+
+        let snap = PendingSnapshot::new(Version::new(10).unwrap(), 1, vec![1]);
+        store.save_snapshot(&id, &snap).await.unwrap();
+
+        store.delete_snapshot(&id).await.unwrap();
+        let loaded = store.load_snapshot(&id).await.unwrap();
+        assert!(loaded.is_none());
+    }
+
+    #[tokio::test]
+    async fn delete_nonexistent_is_ok() {
+        let store = InMemorySnapshotStore::new();
+        let result = store.delete_snapshot(&TestId("nope".into())).await;
+        assert!(result.is_ok());
+    }
+}

--- a/crates/nexus/src/aggregate.rs
+++ b/crates/nexus/src/aggregate.rs
@@ -287,6 +287,23 @@ impl<A: Aggregate> AggregateRoot<A> {
         }
     }
 
+    /// Create an aggregate root restored from a snapshot.
+    ///
+    /// The root is initialized with the given state and version,
+    /// as if those events had already been replayed. Subsequent
+    /// calls to [`replay`](Self::replay) will expect versions
+    /// starting at `version + 1`.
+    ///
+    /// Used by snapshot-aware repositories to skip full event replay.
+    #[must_use]
+    pub const fn restore(id: A::Id, state: A::State, version: Version) -> Self {
+        Self {
+            id,
+            state,
+            version: Some(version),
+        }
+    }
+
     /// The aggregate's identity.
     #[must_use]
     pub const fn id(&self) -> &A::Id {

--- a/crates/nexus/tests/kernel_tests/aggregate_root_tests.rs
+++ b/crates/nexus/tests/kernel_tests/aggregate_root_tests.rs
@@ -538,3 +538,48 @@ fn version_new_accepts_nonzero() {
 fn version_initial_is_one() {
     assert_eq!(Version::INITIAL.as_u64(), 1);
 }
+
+// ---------------------------------------------------------------------------
+// Tests: restore from snapshot
+// ---------------------------------------------------------------------------
+
+#[test]
+fn restore_creates_root_at_given_state_and_version() {
+    let id = TestId("1".into());
+    let state = CounterState { value: 42 };
+    let version = Version::new(10).unwrap();
+
+    let root = AggregateRoot::<CounterAggregate>::restore(id.clone(), state, version);
+
+    assert_eq!(root.id(), &id);
+    assert_eq!(root.state().value, 42);
+    assert_eq!(root.version(), Some(version));
+}
+
+#[test]
+fn restore_then_replay_continues_from_snapshot_version() {
+    let id = TestId("1".into());
+    let state = CounterState { value: 42 };
+    let version = Version::new(10).unwrap();
+
+    let mut root = AggregateRoot::<CounterAggregate>::restore(id, state, version);
+
+    // Next replay must be version 11
+    let result = root.replay(Version::new(11).unwrap(), &CounterEvent::Incremented);
+    assert!(result.is_ok());
+    assert_eq!(root.state().value, 43);
+    assert_eq!(root.version(), Some(Version::new(11).unwrap()));
+}
+
+#[test]
+fn restore_then_replay_rejects_wrong_version() {
+    let id = TestId("1".into());
+    let state = CounterState { value: 42 };
+    let version = Version::new(10).unwrap();
+
+    let mut root = AggregateRoot::<CounterAggregate>::restore(id, state, version);
+
+    // Replaying version 10 (not 11) must fail
+    let result = root.replay(Version::new(10).unwrap(), &CounterEvent::Incremented);
+    assert!(result.is_err());
+}

--- a/docs/plans/2026-04-10-snapshot-design.md
+++ b/docs/plans/2026-04-10-snapshot-design.md
@@ -281,6 +281,22 @@ Implements `SnapshotStore` behind `nexus-fjall/snapshot` feature.
 
 - `AggregateRoot::restore(id, state, version)` — new constructor for creating an aggregate from snapshot state. Minimal change: no new traits, no new bounds.
 
+## Performance Considerations
+
+**Snapshot overhead:** Each snapshot adds one read (load) and one write (save) per aggregate lifecycle. On the read path, a snapshot miss falls back to full replay with zero additional cost beyond the failed point-read. On the write path, snapshot saves are best-effort — failures never block event persistence.
+
+**When snapshots hurt:**
+- **Small aggregates (< 50 events):** The snapshot read + deserialization cost exceeds replaying 50 events. The crossover point depends on event size and `apply()` complexity.
+- **Write-heavy workloads:** Use `snapshot_on_read(true)` (lazy snapshotting) to move snapshot creation to the read path, avoiding write amplification.
+- **Rapidly-evolving state schemas:** Each schema version change invalidates all existing snapshots, forcing full replay until new snapshots are built. Frequent schema changes negate snapshot benefits.
+
+**When snapshots help:**
+- **10,000+ events per aggregate:** Essential. Even with efficient `apply()` and fast storage, deserializing 10K events measurably impacts latency.
+- **Expensive deserialization:** Aggregates with large event payloads or complex `apply()` logic benefit from snapshots at lower event counts.
+- **Latency-sensitive reads:** IoT/mobile scenarios where reload latency must be bounded regardless of aggregate history length.
+
+**Alternative: "Closing the Books" (#139):** Design aggregates with natural lifecycle boundaries (e.g., `CashierShift` per shift vs. `CashRegister` forever). When an aggregate completes its lifecycle, archive its stream and start a new one. This eliminates the need for snapshots entirely and is the preferred approach when domain semantics allow it.
+
 ## Related Issues
 
 - #139 — Document "Closing the Books" pattern as preferred alternative

--- a/docs/plans/2026-04-10-snapshot-design.md
+++ b/docs/plans/2026-04-10-snapshot-design.md
@@ -4,6 +4,20 @@
 
 Aggregates with thousands of events reload slowly because every event must be replayed from the beginning. Snapshots periodically persist aggregate state so rehydration only replays events *after* the snapshot.
 
+## When to Use Snapshots
+
+**Measure first.** Snapshots add complexity — only enable them when replay cost is measurable.
+
+| Event Count | Snapshot Value |
+|-------------|---------------|
+| < 50 | Always hurts — overhead exceeds benefit |
+| 50–200 | Rarely helps unless deserialization is expensive |
+| 200–500 | Measure. Depends on event size and apply complexity |
+| 500+ | Likely helps |
+| 10,000+ | Essential — but also consider "Closing the Books" pattern (#139) |
+
+**Preferred alternative:** Short-lived streams with natural lifecycle boundaries (e.g., `CashierShift` instead of `CashRegister`) eliminate the need for snapshots entirely. See #139.
+
 ## Design Decisions
 
 | Decision | Choice | Rationale |
@@ -13,9 +27,27 @@ Aggregates with thousands of events reload slowly because every event must be re
 | Trigger ownership | Repository-owned, transparent to caller | Snapshots are an infrastructure optimization, not business logic |
 | Trait surface | Same `Repository<A>`, smarter implementation | Callers don't know or care about snapshots |
 | Schema evolution | Versioned snapshots with explicit invalidation | Explicit version mismatch over silent deserialization failure |
-| Read path | Borrowed via GAT holder (zero-copy capable) | Mirrors `PersistedEnvelope<'a>` / `EventStream` pattern |
+| Read path | Owned `PersistedSnapshot` | Simpler than GAT holder; borrowing variant can be added later when benchmarks justify it |
 | No-op | `()` implements `SnapshotStore` | Same pattern as `()` upcaster; compiler eliminates dead code |
 | Feature gating | `snapshot`, `snapshot-json` features | Independent from event serialization features |
+| Trigger type | Generic parameter `T` (not `Box<dyn>`) | Zero-cost monomorphization — compiler inlines `should_snapshot()` |
+| Trigger signature | Receives old + new version + event names | Fixes batch-crossing bug; enables semantic triggers |
+| Lazy snapshotting | Configurable snapshot-on-read | For write-heavy / IoT workloads where write-path overhead matters |
+| Retention | `delete_snapshot` on `SnapshotStore` | Prevents unbounded growth on disk-constrained embedded targets |
+
+## Audit Changes (2026-04-10)
+
+Based on competitive analysis of Axon 5, Pekko, Marten, Equinox, eventsourced-rs, cqrs-es, and disintegrate:
+
+| Issue | Resolution |
+|-------|------------|
+| **Critical: modulo trigger bug** | `SnapshotTrigger::should_snapshot` now receives `old_version` + `new_version` + `event_names`; `EveryNEvents` uses boundary-crossing check instead of modulo |
+| **High: GAT Holder complexity** | Simplified to owned `PersistedSnapshot` struct; borrowing variant deferred |
+| **High: `Box<dyn SnapshotTrigger>`** | Trigger is now a type parameter `T` on `Snapshotting` — monomorphized, zero-cost |
+| **Medium: event-type triggers** | `AfterEventTypes` trigger added; trigger signature includes `event_names: &[&str]` |
+| **Medium: lazy snapshotting** | Snapshotting facade supports snapshot-on-read after full replay |
+| **Low: snapshot retention** | `delete_snapshot` added to `SnapshotStore` trait |
+| **Informational** | GitHub issues created: #139 (Closing the Books), #140 (projection convergence), #141 (DurableState mode) |
 
 ## New Types and Traits
 
@@ -24,28 +56,32 @@ Aggregates with thousands of events reload slowly because every event must be re
 ```rust
 pub trait SnapshotStore: Send + Sync {
     type Error: std::error::Error + Send + Sync + 'static;
-    type Holder<'a>: SnapshotRead + 'a where Self: 'a;
 
     fn load_snapshot(
         &self,
         id: &impl Id,
-    ) -> impl Future<Output = Result<Option<Self::Holder<'_>>, Self::Error>> + Send;
+    ) -> impl Future<Output = Result<Option<PersistedSnapshot>, Self::Error>> + Send;
 
     fn save_snapshot(
         &self,
         id: &impl Id,
         snapshot: &PendingSnapshot,
     ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+
+    fn delete_snapshot(
+        &self,
+        id: &impl Id,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
 }
 ```
 
-### SnapshotRead (borrowed read-path accessor)
+### PersistedSnapshot (owned read-path container)
 
 ```rust
-pub trait SnapshotRead {
-    fn version(&self) -> Version;
-    fn schema_version(&self) -> u32;
-    fn payload(&self) -> &[u8];
+pub struct PersistedSnapshot {
+    version: Version,
+    schema_version: u32,
+    payload: Vec<u8>,
 }
 ```
 
@@ -64,13 +100,16 @@ pub struct PendingSnapshot {
 ```rust
 impl SnapshotStore for () {
     type Error = Infallible;
-    type Holder<'a> = /* never-constructed type */;
 
-    async fn load_snapshot(&self, _id: &impl Id) -> Result<Option<Self::Holder<'_>>, Infallible> {
+    async fn load_snapshot(&self, _id: &impl Id) -> Result<Option<PersistedSnapshot>, Infallible> {
         Ok(None)
     }
 
     async fn save_snapshot(&self, _id: &impl Id, _snapshot: &PendingSnapshot) -> Result<(), Infallible> {
+        Ok(())
+    }
+
+    async fn delete_snapshot(&self, _id: &impl Id) -> Result<(), Infallible> {
         Ok(())
     }
 }
@@ -80,14 +119,32 @@ impl SnapshotStore for () {
 
 ```rust
 pub trait SnapshotTrigger: Send + Sync {
-    fn should_snapshot(&self, events_since_snapshot: u64) -> bool;
+    /// Receives old/new version + event names to handle both boundary
+    /// crossing and semantic triggers correctly.
+    fn should_snapshot(
+        &self,
+        old_version: Option<Version>,
+        new_version: Version,
+        event_names: &[&str],
+    ) -> bool;
 }
 
 pub struct EveryNEvents(pub NonZeroU64);
 
 impl SnapshotTrigger for EveryNEvents {
-    fn should_snapshot(&self, events_since_snapshot: u64) -> bool {
-        events_since_snapshot >= self.0.get()
+    fn should_snapshot(&self, old_version: Option<Version>, new_version: Version, _: &[&str]) -> bool {
+        let n = self.0.get();
+        let old_bucket = old_version.map_or(0, |v| v.as_u64() / n);
+        let new_bucket = new_version.as_u64() / n;
+        new_bucket > old_bucket
+    }
+}
+
+pub struct AfterEventTypes { types: Vec<&'static str> }
+
+impl SnapshotTrigger for AfterEventTypes {
+    fn should_snapshot(&self, _: Option<Version>, _: Version, event_names: &[&str]) -> bool {
+        event_names.iter().any(|name| self.types.iter().any(|t| t == name))
     }
 }
 ```
@@ -102,7 +159,7 @@ No new codec traits. Snapshots reuse `Codec<A::State>` and `BorrowingCodec<A::St
 # nexus-store/Cargo.toml
 [features]
 snapshot = []
-snapshot-json = ["snapshot", "dep:serde", "dep:serde_json"]
+snapshot-json = ["snapshot", "json"]
 
 # nexus-fjall/Cargo.toml
 [features]
@@ -112,6 +169,20 @@ snapshot = ["nexus-store/snapshot"]
 - `snapshot` — enables traits, types, builder methods, load/save logic
 - `snapshot-json` — adds `JsonCodec` as default snapshot codec (independent from event `json` feature)
 - Without `snapshot`, `EventStore` stays `EventStore<S, C, U>` — zero overhead
+
+## Snapshotting Decorator
+
+```rust
+/// Trigger is a type param T — monomorphized, zero-cost.
+pub struct Snapshotting<R, SS, SC, T> {
+    inner: R,             // EventStore or ZeroCopyEventStore
+    snapshot_store: SS,
+    snapshot_codec: SC,
+    trigger: T,
+    schema_version: u32,
+    snapshot_on_read: bool,
+}
+```
 
 ## Builder Integration
 
@@ -126,11 +197,12 @@ let repo = store.repository()
     .snapshot_schema_version(1)
     .build();
 
-// Custom snapshot codec (e.g., rkyv for snapshots, JSON for events)
+// Custom snapshot codec + semantic trigger + lazy on-read
 let repo = store.repository()
     .snapshot_store(fjall_snapshots)
     .snapshot_codec(RkyvCodec)
-    .snapshot_trigger(EveryNEvents(NonZeroU64::new(100).unwrap()))
+    .snapshot_trigger(AfterEventTypes::new(&["OrderCompleted"]))
+    .snapshot_on_read(true)
     .build();
 ```
 
@@ -138,81 +210,53 @@ Builder enforces via typestate:
 - `snapshot_store` set without codec → blocked unless a default feature (`snapshot-json`) provides one
 - `snapshot_trigger` defaults to `EveryNEvents(100)` if not specified
 - `snapshot_schema_version` defaults to 1 if not specified
-
-### EventStore with snapshot support
-
-```rust
-#[cfg(feature = "snapshot")]
-pub struct EventStore<S, C, U = (), SS = (), SC = ()> {
-    store: Store<S>,
-    codec: C,
-    upcaster: U,
-    snapshot_store: SS,
-    snapshot_codec: SC,
-    snapshot_trigger: Box<dyn SnapshotTrigger>,
-    snapshot_schema_version: u32,
-}
-
-#[cfg(not(feature = "snapshot"))]
-pub struct EventStore<S, C, U = ()> {
-    store: Store<S>,
-    codec: C,
-    upcaster: U,
-}
-```
-
-Same pattern applies to `ZeroCopyEventStore`.
+- `snapshot_on_read` defaults to false
 
 ## Load Path
 
 ```
 load(id)
   │
-  ├─ snapshot store != () ?
-  │   ├─ yes → load_snapshot(id)
-  │   │         ├─ Some(holder) AND holder.schema_version() == current →
-  │   │         │    decode state from holder.payload() via snapshot codec
-  │   │         │    create AggregateRoot with state + holder.version()
-  │   │         │    read_stream(id, from: holder.version().next())
-  │   │         │    replay remaining events only
-  │   │         │
-  │   │         └─ None OR schema mismatch →
-  │   │              full replay from Version::INITIAL (same as today)
+  ├─ try load_snapshot(id)
+  │   ├─ Ok(Some(snap)) AND snap.schema_version() == current →
+  │   │    decode state from snap.payload() via snapshot codec
+  │   │    create AggregateRoot::restore(id, state, snap.version())
+  │   │    replay_from(root, snap.version().next())
+  │   │    return root
   │   │
-  │   └─ no → full replay from Version::INITIAL (same as today)
+  │   └─ None OR schema mismatch OR error →
+  │        full replay from Version::INITIAL via inner.load(id)
+  │        if snapshot_on_read → try_save_snapshot (best-effort)
+  │        return root
   │
   └─ return AggregateRoot<A>
 ```
 
-Snapshot load failure (IO/decode) = cache miss, fall back to full replay. Log warning.
+Snapshot load failure (IO/decode) = cache miss, fall back to full replay.
 
 ## Save Path
 
 ```
 save(aggregate, events)
   │
-  ├─ encode + append events (same as today)
+  ├─ old_version = aggregate.version()
+  ├─ inner.save(aggregate, events) — encode + append + advance
   │
-  ├─ snapshot store != () ?
-  │   ├─ yes → compute events_since_snapshot =
-  │   │         current_version - snapshot_version (or current_version if no snapshot)
-  │   │         trigger.should_snapshot(events_since_snapshot)?
-  │   │           ├─ yes → encode state via snapshot codec
-  │   │           │         save_snapshot(id, PendingSnapshot { version, schema_version, payload })
-  │   │           └─ no  → skip
-  │   └─ no → skip
-  │
-  ├─ advance_version + apply_events (same as today)
+  ├─ trigger.should_snapshot(old_version, new_version, event_names)?
+  │   ├─ yes → encode state via snapshot codec
+  │   │         save_snapshot(id, PendingSnapshot { version, schema_version, payload })
+  │   │         (best-effort — errors silently ignored)
+  │   └─ no  → skip
   │
   └─ return Ok(())
 ```
 
-Snapshot save is best-effort — happens after successful event append. Failure is logged, not propagated. Events are the source of truth.
+Snapshot save is best-effort — happens after successful event append. Events are the source of truth.
 
 ## Error Handling
 
-- **Snapshot load failure:** cache miss, full replay. Log warning.
-- **Snapshot save failure:** log warning, don't propagate.
+- **Snapshot load failure:** cache miss, full replay. Errors silently discarded.
+- **Snapshot save failure:** silently discarded. Events already persisted.
 - **Schema version mismatch:** expected after state changes. Silent fallback to full replay.
 - No new variants on `StoreError` — snapshots are transparent and best-effort.
 
@@ -228,7 +272,17 @@ Implements `SnapshotStore` behind `nexus-fjall/snapshot` feature.
 ## What Doesn't Change
 
 - `Repository<A>` trait signature
-- `Aggregate`, `AggregateState`, `AggregateRoot` (kernel crate)
+- `AggregateState` trait (kernel crate)
 - `RawEventStore` trait
 - Event codecs, upcasters
 - Callers of `repository.load()` / `repository.save()`
+
+## Kernel Addition
+
+- `AggregateRoot::restore(id, state, version)` — new constructor for creating an aggregate from snapshot state. Minimal change: no new traits, no new bounds.
+
+## Related Issues
+
+- #139 — Document "Closing the Books" pattern as preferred alternative
+- #140 — Design snapshot traits for future projection convergence
+- #141 — Consider DurableState mode (snapshot-only persistence, Tier 3)

--- a/docs/plans/2026-04-10-snapshot-design.md
+++ b/docs/plans/2026-04-10-snapshot-design.md
@@ -1,0 +1,234 @@
+# Aggregate Snapshot Design
+
+## Problem
+
+Aggregates with thousands of events reload slowly because every event must be replayed from the beginning. Snapshots periodically persist aggregate state so rehydration only replays events *after* the snapshot.
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Snapshot serialization | External codec — reuses `Codec<S>` / `BorrowingCodec<S>` | Aggregates stay serialization-free, same pattern as events |
+| Crate location | `nexus-store` | Same persistence layer as `RawEventStore` |
+| Trigger ownership | Repository-owned, transparent to caller | Snapshots are an infrastructure optimization, not business logic |
+| Trait surface | Same `Repository<A>`, smarter implementation | Callers don't know or care about snapshots |
+| Schema evolution | Versioned snapshots with explicit invalidation | Explicit version mismatch over silent deserialization failure |
+| Read path | Borrowed via GAT holder (zero-copy capable) | Mirrors `PersistedEnvelope<'a>` / `EventStream` pattern |
+| No-op | `()` implements `SnapshotStore` | Same pattern as `()` upcaster; compiler eliminates dead code |
+| Feature gating | `snapshot`, `snapshot-json` features | Independent from event serialization features |
+
+## New Types and Traits
+
+### SnapshotStore (byte-level, adapters implement)
+
+```rust
+pub trait SnapshotStore: Send + Sync {
+    type Error: std::error::Error + Send + Sync + 'static;
+    type Holder<'a>: SnapshotRead + 'a where Self: 'a;
+
+    fn load_snapshot(
+        &self,
+        id: &impl Id,
+    ) -> impl Future<Output = Result<Option<Self::Holder<'_>>, Self::Error>> + Send;
+
+    fn save_snapshot(
+        &self,
+        id: &impl Id,
+        snapshot: &PendingSnapshot,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+}
+```
+
+### SnapshotRead (borrowed read-path accessor)
+
+```rust
+pub trait SnapshotRead {
+    fn version(&self) -> Version;
+    fn schema_version(&self) -> u32;
+    fn payload(&self) -> &[u8];
+}
+```
+
+### PendingSnapshot (owned write-path container)
+
+```rust
+pub struct PendingSnapshot {
+    version: Version,
+    schema_version: u32,
+    payload: Vec<u8>,
+}
+```
+
+### No-op implementation
+
+```rust
+impl SnapshotStore for () {
+    type Error = Infallible;
+    type Holder<'a> = /* never-constructed type */;
+
+    async fn load_snapshot(&self, _id: &impl Id) -> Result<Option<Self::Holder<'_>>, Infallible> {
+        Ok(None)
+    }
+
+    async fn save_snapshot(&self, _id: &impl Id, _snapshot: &PendingSnapshot) -> Result<(), Infallible> {
+        Ok(())
+    }
+}
+```
+
+### SnapshotTrigger (pluggable strategy)
+
+```rust
+pub trait SnapshotTrigger: Send + Sync {
+    fn should_snapshot(&self, events_since_snapshot: u64) -> bool;
+}
+
+pub struct EveryNEvents(pub NonZeroU64);
+
+impl SnapshotTrigger for EveryNEvents {
+    fn should_snapshot(&self, events_since_snapshot: u64) -> bool {
+        events_since_snapshot >= self.0.get()
+    }
+}
+```
+
+### Snapshot codec — reuses existing traits
+
+No new codec traits. Snapshots reuse `Codec<A::State>` and `BorrowingCodec<A::State>` directly.
+
+## Feature Gates
+
+```toml
+# nexus-store/Cargo.toml
+[features]
+snapshot = []
+snapshot-json = ["snapshot", "dep:serde", "dep:serde_json"]
+
+# nexus-fjall/Cargo.toml
+[features]
+snapshot = ["nexus-store/snapshot"]
+```
+
+- `snapshot` — enables traits, types, builder methods, load/save logic
+- `snapshot-json` — adds `JsonCodec` as default snapshot codec (independent from event `json` feature)
+- Without `snapshot`, `EventStore` stays `EventStore<S, C, U>` — zero overhead
+
+## Builder Integration
+
+```rust
+// Without snapshot feature — unchanged
+let repo = store.repository().build();
+
+// With snapshot-json — auto-wired default codec
+let repo = store.repository()
+    .snapshot_store(fjall_snapshots)
+    .snapshot_trigger(EveryNEvents(NonZeroU64::new(100).unwrap()))
+    .snapshot_schema_version(1)
+    .build();
+
+// Custom snapshot codec (e.g., rkyv for snapshots, JSON for events)
+let repo = store.repository()
+    .snapshot_store(fjall_snapshots)
+    .snapshot_codec(RkyvCodec)
+    .snapshot_trigger(EveryNEvents(NonZeroU64::new(100).unwrap()))
+    .build();
+```
+
+Builder enforces via typestate:
+- `snapshot_store` set without codec → blocked unless a default feature (`snapshot-json`) provides one
+- `snapshot_trigger` defaults to `EveryNEvents(100)` if not specified
+- `snapshot_schema_version` defaults to 1 if not specified
+
+### EventStore with snapshot support
+
+```rust
+#[cfg(feature = "snapshot")]
+pub struct EventStore<S, C, U = (), SS = (), SC = ()> {
+    store: Store<S>,
+    codec: C,
+    upcaster: U,
+    snapshot_store: SS,
+    snapshot_codec: SC,
+    snapshot_trigger: Box<dyn SnapshotTrigger>,
+    snapshot_schema_version: u32,
+}
+
+#[cfg(not(feature = "snapshot"))]
+pub struct EventStore<S, C, U = ()> {
+    store: Store<S>,
+    codec: C,
+    upcaster: U,
+}
+```
+
+Same pattern applies to `ZeroCopyEventStore`.
+
+## Load Path
+
+```
+load(id)
+  │
+  ├─ snapshot store != () ?
+  │   ├─ yes → load_snapshot(id)
+  │   │         ├─ Some(holder) AND holder.schema_version() == current →
+  │   │         │    decode state from holder.payload() via snapshot codec
+  │   │         │    create AggregateRoot with state + holder.version()
+  │   │         │    read_stream(id, from: holder.version().next())
+  │   │         │    replay remaining events only
+  │   │         │
+  │   │         └─ None OR schema mismatch →
+  │   │              full replay from Version::INITIAL (same as today)
+  │   │
+  │   └─ no → full replay from Version::INITIAL (same as today)
+  │
+  └─ return AggregateRoot<A>
+```
+
+Snapshot load failure (IO/decode) = cache miss, fall back to full replay. Log warning.
+
+## Save Path
+
+```
+save(aggregate, events)
+  │
+  ├─ encode + append events (same as today)
+  │
+  ├─ snapshot store != () ?
+  │   ├─ yes → compute events_since_snapshot =
+  │   │         current_version - snapshot_version (or current_version if no snapshot)
+  │   │         trigger.should_snapshot(events_since_snapshot)?
+  │   │           ├─ yes → encode state via snapshot codec
+  │   │           │         save_snapshot(id, PendingSnapshot { version, schema_version, payload })
+  │   │           └─ no  → skip
+  │   └─ no → skip
+  │
+  ├─ advance_version + apply_events (same as today)
+  │
+  └─ return Ok(())
+```
+
+Snapshot save is best-effort — happens after successful event append. Failure is logged, not propagated. Events are the source of truth.
+
+## Error Handling
+
+- **Snapshot load failure:** cache miss, full replay. Log warning.
+- **Snapshot save failure:** log warning, don't propagate.
+- **Schema version mismatch:** expected after state changes. Silent fallback to full replay.
+- No new variants on `StoreError` — snapshots are transparent and best-effort.
+
+## Fjall Adapter
+
+Third partition in `FjallStore`, point-read optimized (not scan-optimized like events).
+
+Key: aggregate stream ID (numeric u64).
+Value: `[u32 LE schema_version][u64 BE version][payload]`.
+
+Implements `SnapshotStore` behind `nexus-fjall/snapshot` feature.
+
+## What Doesn't Change
+
+- `Repository<A>` trait signature
+- `Aggregate`, `AggregateState`, `AggregateRoot` (kernel crate)
+- `RawEventStore` trait
+- Event codecs, upcasters
+- Callers of `repository.load()` / `repository.save()`

--- a/docs/plans/2026-04-10-snapshot-implementation.md
+++ b/docs/plans/2026-04-10-snapshot-implementation.md
@@ -1,0 +1,1537 @@
+# Aggregate Snapshot Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add feature-gated aggregate snapshot support to nexus-store so rehydration skips replaying the full event stream.
+
+**Architecture:** `Snapshotting<R, SS, SC>` decorator wraps `EventStore`/`ZeroCopyEventStore`, intercepts `load()`/`save()` to check/write snapshots. Extract shared replay logic into a `pub(crate)` trait `ReplayFrom<A>` to avoid duplicating the stream replay loop. All snapshot types live behind `#[cfg(feature = "snapshot")]`. `()` serves as no-op `SnapshotStore`. Builder typestate gains a `Snap` param (`NoSnapshot` or `WithSnapshot<SS, SC>`) to produce either plain `EventStore` or `Snapshotting<EventStore, SS, SC>`.
+
+**Tech Stack:** Rust, nexus kernel (`AggregateRoot`), nexus-store traits, fjall LSM storage.
+
+---
+
+### Task 1: Add feature flags to nexus-store
+
+**Files:**
+- Modify: `crates/nexus-store/Cargo.toml`
+
+**Step 1: Add snapshot features**
+
+Add to the `[features]` section:
+
+```toml
+[features]
+testing = ["dep:tokio"]
+bounded-labels = []
+serde = ["dep:serde"]
+json = ["serde", "dep:serde_json"]
+snapshot = []
+snapshot-json = ["snapshot", "json"]
+```
+
+**Step 2: Verify it compiles**
+
+Run: `cargo build -p nexus-store` and `cargo build -p nexus-store --features snapshot`
+Expected: both succeed (features exist but nothing uses them yet)
+
+**Step 3: Commit**
+
+```
+feat(store): add snapshot and snapshot-json feature flags
+```
+
+---
+
+### Task 2: Create PendingSnapshot struct
+
+**Files:**
+- Create: `crates/nexus-store/src/snapshot/pending.rs`
+- Create: `crates/nexus-store/src/snapshot/mod.rs`
+- Modify: `crates/nexus-store/src/lib.rs`
+- Test: `crates/nexus-store/tests/snapshot_tests.rs`
+
+**Step 1: Write the failing test**
+
+Create `crates/nexus-store/tests/snapshot_tests.rs`:
+
+```rust
+#![cfg(feature = "snapshot")]
+
+use nexus_store::snapshot::{PendingSnapshot};
+use nexus::Version;
+
+#[test]
+fn pending_snapshot_stores_version_and_payload() {
+    let version = Version::new(42).unwrap();
+    let payload = vec![1, 2, 3];
+    let snap = PendingSnapshot::new(version, 1, payload.clone());
+
+    assert_eq!(snap.version(), version);
+    assert_eq!(snap.schema_version(), 1);
+    assert_eq!(snap.payload(), &payload);
+}
+
+#[test]
+fn pending_snapshot_schema_version_must_be_nonzero() {
+    let version = Version::new(1).unwrap();
+    let result = PendingSnapshot::try_new(version, 0, vec![]);
+    assert!(result.is_err());
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p nexus-store --features snapshot -- snapshot_tests`
+Expected: FAIL — module `snapshot` doesn't exist
+
+**Step 3: Create the snapshot module**
+
+Create `crates/nexus-store/src/snapshot/mod.rs`:
+
+```rust
+mod pending;
+
+pub use pending::PendingSnapshot;
+```
+
+Create `crates/nexus-store/src/snapshot/pending.rs`:
+
+```rust
+use nexus::Version;
+
+use crate::error::InvalidSchemaVersion;
+
+/// Snapshot payload ready for persistence (write path).
+///
+/// Contains the serialized aggregate state, the aggregate version at
+/// snapshot time, and a schema version for invalidation.
+#[derive(Debug, Clone)]
+pub struct PendingSnapshot {
+    version: Version,
+    schema_version: u32,
+    payload: Vec<u8>,
+}
+
+impl PendingSnapshot {
+    /// Create a new pending snapshot.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `schema_version` is 0. Use [`try_new`](Self::try_new)
+    /// for a fallible alternative.
+    #[must_use]
+    pub fn new(version: Version, schema_version: u32, payload: Vec<u8>) -> Self {
+        match Self::try_new(version, schema_version, payload) {
+            Ok(snap) => snap,
+            Err(e) => panic!("{e}"),
+        }
+    }
+
+    /// Try to create a new pending snapshot.
+    ///
+    /// Returns `Err` if `schema_version` is 0.
+    pub fn try_new(
+        version: Version,
+        schema_version: u32,
+        payload: Vec<u8>,
+    ) -> Result<Self, InvalidSchemaVersion> {
+        if schema_version == 0 {
+            return Err(InvalidSchemaVersion);
+        }
+        Ok(Self {
+            version,
+            schema_version,
+            payload,
+        })
+    }
+
+    /// The aggregate version at the time of the snapshot.
+    #[must_use]
+    pub const fn version(&self) -> Version {
+        self.version
+    }
+
+    /// The schema version for invalidation checking.
+    #[must_use]
+    pub const fn schema_version(&self) -> u32 {
+        self.schema_version
+    }
+
+    /// The serialized state bytes.
+    #[must_use]
+    pub fn payload(&self) -> &[u8] {
+        &self.payload
+    }
+}
+```
+
+Add to `crates/nexus-store/src/lib.rs`:
+
+```rust
+#[cfg(feature = "snapshot")]
+pub mod snapshot;
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p nexus-store --features snapshot -- snapshot_tests`
+Expected: PASS
+
+**Step 5: Commit**
+
+```
+feat(store): add PendingSnapshot type for snapshot write path
+```
+
+---
+
+### Task 3: Create SnapshotRead trait
+
+**Files:**
+- Create: `crates/nexus-store/src/snapshot/read.rs`
+- Modify: `crates/nexus-store/src/snapshot/mod.rs`
+- Test: `crates/nexus-store/tests/snapshot_tests.rs`
+
+**Step 1: Write the failing test**
+
+Add to `snapshot_tests.rs`:
+
+```rust
+use nexus_store::snapshot::SnapshotRead;
+
+struct TestHolder {
+    version: Version,
+    schema_version: u32,
+    data: Vec<u8>,
+}
+
+impl SnapshotRead for TestHolder {
+    fn version(&self) -> Version { self.version }
+    fn schema_version(&self) -> u32 { self.schema_version }
+    fn payload(&self) -> &[u8] { &self.data }
+}
+
+#[test]
+fn snapshot_read_impl_provides_borrowed_access() {
+    let holder = TestHolder {
+        version: Version::new(10).unwrap(),
+        schema_version: 2,
+        data: vec![4, 5, 6],
+    };
+    assert_eq!(holder.version(), Version::new(10).unwrap());
+    assert_eq!(holder.schema_version(), 2);
+    assert_eq!(holder.payload(), &[4, 5, 6]);
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p nexus-store --features snapshot -- snapshot_read`
+Expected: FAIL — `SnapshotRead` doesn't exist
+
+**Step 3: Create SnapshotRead trait**
+
+Create `crates/nexus-store/src/snapshot/read.rs`:
+
+```rust
+use nexus::Version;
+
+/// Borrowed access to a persisted snapshot (read path).
+///
+/// Implemented by adapter-specific holder types. The holder owns
+/// the raw bytes read from storage; `payload()` borrows from it,
+/// enabling zero-copy decode via [`BorrowingCodec`](crate::BorrowingCodec).
+pub trait SnapshotRead {
+    /// The aggregate version at the time of the snapshot.
+    fn version(&self) -> Version;
+
+    /// The schema version for invalidation checking.
+    fn schema_version(&self) -> u32;
+
+    /// The serialized state bytes, borrowed from the holder.
+    fn payload(&self) -> &[u8];
+}
+```
+
+Update `snapshot/mod.rs`:
+
+```rust
+mod pending;
+mod read;
+
+pub use pending::PendingSnapshot;
+pub use read::SnapshotRead;
+```
+
+**Step 4: Run test**
+
+Run: `cargo test -p nexus-store --features snapshot -- snapshot_read`
+Expected: PASS
+
+**Step 5: Commit**
+
+```
+feat(store): add SnapshotRead trait for borrowed snapshot access
+```
+
+---
+
+### Task 4: Create SnapshotStore trait + () no-op
+
+**Files:**
+- Create: `crates/nexus-store/src/snapshot/store.rs`
+- Modify: `crates/nexus-store/src/snapshot/mod.rs`
+- Test: `crates/nexus-store/tests/snapshot_tests.rs`
+
+**Step 1: Write the failing test**
+
+Add to `snapshot_tests.rs`:
+
+```rust
+use nexus_store::snapshot::SnapshotStore;
+
+#[tokio::test]
+async fn unit_snapshot_store_returns_none() {
+    let store = ();
+    let id = String::from("agg-1");
+    let result = store.load_snapshot(&id).await;
+    assert!(result.unwrap().is_none());
+}
+
+#[tokio::test]
+async fn unit_snapshot_store_save_succeeds() {
+    let store = ();
+    let id = String::from("agg-1");
+    let snap = PendingSnapshot::new(Version::new(1).unwrap(), 1, vec![1, 2, 3]);
+    let result = store.save_snapshot(&id, &snap).await;
+    assert!(result.is_ok());
+}
+```
+
+**Step 2: Run test — expected FAIL**
+
+**Step 3: Create SnapshotStore trait**
+
+Create `crates/nexus-store/src/snapshot/store.rs`:
+
+```rust
+use std::convert::Infallible;
+use std::future::Future;
+
+use nexus::Id;
+
+use super::pending::PendingSnapshot;
+use super::read::SnapshotRead;
+
+/// Byte-level snapshot storage trait.
+///
+/// Adapters (fjall, postgres, etc.) implement this to persist and
+/// retrieve serialized aggregate state. The GAT `Holder<'a>` enables
+/// zero-copy reads — the holder owns the raw bytes and
+/// [`SnapshotRead::payload()`] borrows from it.
+///
+/// `()` is the no-op implementation: `load_snapshot` always returns
+/// `None`, `save_snapshot` silently discards. Used when snapshot
+/// support is not configured.
+pub trait SnapshotStore: Send + Sync {
+    /// Adapter-specific error type.
+    type Error: std::error::Error + Send + Sync + 'static;
+
+    /// Type that owns snapshot bytes on the read path.
+    type Holder<'a>: SnapshotRead + 'a
+    where
+        Self: 'a;
+
+    /// Load the most recent snapshot for the given aggregate.
+    ///
+    /// Returns `None` if no snapshot exists.
+    fn load_snapshot(
+        &self,
+        id: &impl Id,
+    ) -> impl Future<Output = Result<Option<Self::Holder<'_>>, Self::Error>> + Send;
+
+    /// Persist a snapshot for the given aggregate.
+    ///
+    /// Overwrites any existing snapshot for this aggregate.
+    fn save_snapshot(
+        &self,
+        id: &impl Id,
+        snapshot: &PendingSnapshot,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// No-op implementation — snapshots disabled
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Uninhabited holder for the `()` no-op snapshot store.
+///
+/// This type can never be constructed, matching the fact that
+/// the no-op store always returns `None` from `load_snapshot`.
+pub enum NeverSnapshot {}
+
+impl SnapshotRead for NeverSnapshot {
+    fn version(&self) -> nexus::Version {
+        match *self {}
+    }
+    fn schema_version(&self) -> u32 {
+        match *self {}
+    }
+    fn payload(&self) -> &[u8] {
+        match *self {}
+    }
+}
+
+impl SnapshotStore for () {
+    type Error = Infallible;
+    type Holder<'a> = NeverSnapshot;
+
+    async fn load_snapshot(
+        &self,
+        _id: &impl Id,
+    ) -> Result<Option<NeverSnapshot>, Infallible> {
+        Ok(None)
+    }
+
+    async fn save_snapshot(
+        &self,
+        _id: &impl Id,
+        _snapshot: &PendingSnapshot,
+    ) -> Result<(), Infallible> {
+        Ok(())
+    }
+}
+```
+
+Update `snapshot/mod.rs`:
+
+```rust
+mod pending;
+mod read;
+mod store;
+
+pub use pending::PendingSnapshot;
+pub use read::SnapshotRead;
+pub use store::{NeverSnapshot, SnapshotStore};
+```
+
+**Step 4: Run tests — expected PASS**
+
+**Step 5: Commit**
+
+```
+feat(store): add SnapshotStore trait with () no-op implementation
+```
+
+---
+
+### Task 5: Create SnapshotTrigger trait + EveryNEvents
+
+**Files:**
+- Create: `crates/nexus-store/src/snapshot/trigger.rs`
+- Modify: `crates/nexus-store/src/snapshot/mod.rs`
+- Test: `crates/nexus-store/tests/snapshot_tests.rs`
+
+**Step 1: Write the failing test**
+
+Add to `snapshot_tests.rs`:
+
+```rust
+use std::num::NonZeroU64;
+use nexus_store::snapshot::{SnapshotTrigger, EveryNEvents};
+
+#[test]
+fn every_n_events_triggers_at_multiples() {
+    let trigger = EveryNEvents(NonZeroU64::new(100).unwrap());
+    assert!(!trigger.should_snapshot(Version::new(1).unwrap()));
+    assert!(!trigger.should_snapshot(Version::new(99).unwrap()));
+    assert!(trigger.should_snapshot(Version::new(100).unwrap()));
+    assert!(!trigger.should_snapshot(Version::new(101).unwrap()));
+    assert!(trigger.should_snapshot(Version::new(200).unwrap()));
+}
+
+#[test]
+fn every_1_event_always_triggers() {
+    let trigger = EveryNEvents(NonZeroU64::new(1).unwrap());
+    assert!(trigger.should_snapshot(Version::new(1).unwrap()));
+    assert!(trigger.should_snapshot(Version::new(2).unwrap()));
+    assert!(trigger.should_snapshot(Version::new(999).unwrap()));
+}
+```
+
+**Step 2: Run test — expected FAIL**
+
+**Step 3: Create trigger module**
+
+Create `crates/nexus-store/src/snapshot/trigger.rs`:
+
+```rust
+use std::num::NonZeroU64;
+
+use nexus::Version;
+
+/// Strategy for deciding when to take a snapshot.
+///
+/// Checked after each successful `save()`. The trigger receives the
+/// aggregate's new version and returns whether a snapshot should be taken.
+pub trait SnapshotTrigger: Send + Sync {
+    /// Whether a snapshot should be taken at this version.
+    fn should_snapshot(&self, new_version: Version) -> bool;
+}
+
+/// Trigger a snapshot every N events (at version multiples of N).
+///
+/// For example, `EveryNEvents(100)` triggers at versions 100, 200, 300, etc.
+#[derive(Debug, Clone, Copy)]
+pub struct EveryNEvents(pub NonZeroU64);
+
+impl SnapshotTrigger for EveryNEvents {
+    fn should_snapshot(&self, new_version: Version) -> bool {
+        new_version.as_u64() % self.0.get() == 0
+    }
+}
+```
+
+Update `snapshot/mod.rs` to export `SnapshotTrigger` and `EveryNEvents`.
+
+**Step 4: Run tests — expected PASS**
+
+**Step 5: Commit**
+
+```
+feat(store): add SnapshotTrigger trait and EveryNEvents strategy
+```
+
+---
+
+### Task 6: Add AggregateRoot::restore to kernel
+
+**Files:**
+- Modify: `crates/nexus/src/aggregate.rs`
+- Test: `crates/nexus/tests/` (new or existing aggregate test file)
+
+This is a **kernel change** — minimal, just a new constructor. No trait changes, no new bounds. Needed so the store can construct an `AggregateRoot` from a deserialized snapshot state.
+
+**Step 1: Write the failing test**
+
+Find the existing aggregate tests and add:
+
+```rust
+#[test]
+fn restore_creates_root_at_given_state_and_version() {
+    let id = TestId(1);
+    let state = CounterState { value: 42 };
+    let version = Version::new(10).unwrap();
+
+    let root = AggregateRoot::<TestAggregate>::restore(id.clone(), state, version);
+
+    assert_eq!(root.id(), &id);
+    assert_eq!(root.state().value, 42);
+    assert_eq!(root.version(), Some(version));
+}
+
+#[test]
+fn restore_then_replay_continues_from_snapshot_version() {
+    let id = TestId(1);
+    let state = CounterState { value: 42 };
+    let version = Version::new(10).unwrap();
+
+    let mut root = AggregateRoot::<TestAggregate>::restore(id, state, version);
+
+    // Next replay must be version 11
+    let result = root.replay(Version::new(11).unwrap(), &CounterEvent::Incremented);
+    assert!(result.is_ok());
+    assert_eq!(root.state().value, 43);
+    assert_eq!(root.version(), Some(Version::new(11).unwrap()));
+}
+
+#[test]
+fn restore_then_replay_rejects_wrong_version() {
+    let id = TestId(1);
+    let state = CounterState { value: 42 };
+    let version = Version::new(10).unwrap();
+
+    let mut root = AggregateRoot::<TestAggregate>::restore(id, state, version);
+
+    // Replaying version 10 (not 11) must fail
+    let result = root.replay(Version::new(10).unwrap(), &CounterEvent::Incremented);
+    assert!(result.is_err());
+}
+```
+
+Use whichever test aggregate types already exist in the kernel test files. Adapt names as needed.
+
+**Step 2: Run test — expected FAIL**
+
+Run: `cargo test -p nexus -- restore`
+Expected: FAIL — no method `restore` on `AggregateRoot`
+
+**Step 3: Add the restore constructor**
+
+In `crates/nexus/src/aggregate.rs`, add to `impl<A: Aggregate> AggregateRoot<A>` (after `new`):
+
+```rust
+    /// Create an aggregate root restored from a snapshot.
+    ///
+    /// The root is initialized with the given state and version,
+    /// as if those events had already been replayed. Subsequent
+    /// calls to [`replay`](Self::replay) will expect versions
+    /// starting at `version + 1`.
+    ///
+    /// Used by snapshot-aware repositories to skip full event replay.
+    #[must_use]
+    pub fn restore(id: A::Id, state: A::State, version: Version) -> Self {
+        Self {
+            id,
+            state,
+            version: Some(version),
+        }
+    }
+```
+
+**Step 4: Run tests — expected PASS**
+
+Run: `cargo test -p nexus -- restore`
+Expected: PASS
+
+Also run full kernel tests: `cargo test -p nexus`
+Expected: PASS (no regressions)
+
+**Step 5: Commit**
+
+```
+feat(kernel): add AggregateRoot::restore for snapshot rehydration
+```
+
+---
+
+### Task 7: Extract ReplayFrom trait from EventStore/ZeroCopyEventStore
+
+**Files:**
+- Create: `crates/nexus-store/src/store/replay.rs`
+- Modify: `crates/nexus-store/src/store/event_store.rs`
+- Modify: `crates/nexus-store/src/store/zero_copy_event_store.rs`
+- Modify: `crates/nexus-store/src/store/mod.rs`
+
+This is a **refactor** — no behavior change. Extract the replay loop from both `load()` implementations into a shared `pub(crate)` trait so `Snapshotting` can call partial replay without duplicating code.
+
+**Step 1: Run existing tests to establish baseline**
+
+Run: `cargo test -p nexus-store --features json`
+Expected: all PASS
+
+**Step 2: Create the ReplayFrom trait**
+
+Create `crates/nexus-store/src/store/replay.rs`:
+
+```rust
+use crate::error::StoreError;
+use nexus::{Aggregate, AggregateRoot, Version};
+
+/// Internal trait for replaying events from a given starting point.
+///
+/// Both `EventStore` and `ZeroCopyEventStore` implement this to share
+/// replay logic with `Snapshotting`. Not public API.
+pub(crate) trait ReplayFrom<A: Aggregate>: Send + Sync {
+    /// Replay events from `from` version into `root`, returning
+    /// the updated aggregate.
+    fn replay_from(
+        &self,
+        root: AggregateRoot<A>,
+        from: Version,
+    ) -> impl std::future::Future<Output = Result<AggregateRoot<A>, StoreError>> + Send;
+}
+```
+
+**Step 3: Implement for EventStore**
+
+In `event_store.rs`, add:
+
+```rust
+use super::replay::ReplayFrom;
+```
+
+Then add the impl block:
+
+```rust
+impl<A, S, C, U> ReplayFrom<A> for EventStore<S, C, U>
+where
+    A: Aggregate,
+    S: RawEventStore,
+    C: Codec<EventOf<A>>,
+    U: Upcaster,
+    EventOf<A>: DomainEvent,
+    for<'a> S::Stream<'a>: Send,
+{
+    async fn replay_from(
+        &self,
+        mut root: AggregateRoot<A>,
+        from: Version,
+    ) -> Result<AggregateRoot<A>, StoreError> {
+        let mut stream = self
+            .store
+            .raw()
+            .read_stream(root.id(), from)
+            .await
+            .map_err(|e| StoreError::Adapter(Box::new(e)))?;
+
+        while let Some(result) = stream.next().await {
+            let env = result.map_err(|e| StoreError::Adapter(Box::new(e)))?;
+            let morsel = EventMorsel::borrowed(
+                env.event_type(),
+                env.schema_version_as_version(),
+                env.payload(),
+            );
+            let transformed = self
+                .upcaster
+                .apply(morsel)
+                .map_err(|e| StoreError::Codec(Box::new(e)))?;
+            let event = self
+                .codec
+                .decode(transformed.event_type(), transformed.payload())
+                .map_err(|e| StoreError::Codec(Box::new(e)))?;
+            root.replay(env.version(), &event)?;
+        }
+
+        Ok(root)
+    }
+}
+```
+
+Then refactor `Repository::load` to delegate:
+
+```rust
+async fn load(&self, id: A::Id) -> Result<AggregateRoot<A>, StoreError> {
+    let root = AggregateRoot::<A>::new(id);
+    self.replay_from(root, Version::INITIAL).await
+}
+```
+
+**Step 4: Implement for ZeroCopyEventStore**
+
+Same pattern but using `BorrowingCodec`:
+
+```rust
+impl<A, S, C, U> ReplayFrom<A> for ZeroCopyEventStore<S, C, U>
+where
+    A: Aggregate,
+    S: RawEventStore,
+    C: BorrowingCodec<EventOf<A>>,
+    U: Upcaster,
+    EventOf<A>: DomainEvent,
+    for<'a> S::Stream<'a>: Send,
+{
+    async fn replay_from(
+        &self,
+        mut root: AggregateRoot<A>,
+        from: Version,
+    ) -> Result<AggregateRoot<A>, StoreError> {
+        let mut stream = self
+            .store
+            .raw()
+            .read_stream(root.id(), from)
+            .await
+            .map_err(|e| StoreError::Adapter(Box::new(e)))?;
+
+        while let Some(result) = stream.next().await {
+            let env = result.map_err(|e| StoreError::Adapter(Box::new(e)))?;
+            let morsel = EventMorsel::borrowed(
+                env.event_type(),
+                env.schema_version_as_version(),
+                env.payload(),
+            );
+            let transformed = self
+                .upcaster
+                .apply(morsel)
+                .map_err(|e| StoreError::Codec(Box::new(e)))?;
+            let event: &EventOf<A> = self
+                .codec
+                .decode(transformed.event_type(), transformed.payload())
+                .map_err(|e| StoreError::Codec(Box::new(e)))?;
+            root.replay(env.version(), event)?;
+        }
+
+        Ok(root)
+    }
+}
+```
+
+Refactor `ZeroCopyEventStore::load` to delegate similarly.
+
+**Step 5: Update store/mod.rs**
+
+Add:
+
+```rust
+mod replay;
+```
+
+No public re-export — `replay` is `pub(crate)`.
+
+**Step 6: Run all existing tests — expected PASS (no behavior change)**
+
+Run: `cargo test -p nexus-store --features json`
+
+**Step 7: Commit**
+
+```
+refactor(store): extract ReplayFrom trait for shared replay logic
+```
+
+---
+
+### Task 8: Create InMemorySnapshotStore for testing
+
+**Files:**
+- Create: `crates/nexus-store/src/snapshot/testing.rs`
+- Modify: `crates/nexus-store/src/snapshot/mod.rs`
+- Test: `crates/nexus-store/tests/snapshot_tests.rs`
+
+**Step 1: Write the failing test**
+
+Add to `snapshot_tests.rs`:
+
+```rust
+#[cfg(feature = "testing")]
+mod in_memory_tests {
+    use super::*;
+    use nexus_store::snapshot::InMemorySnapshotStore;
+
+    #[tokio::test]
+    async fn load_returns_none_when_empty() {
+        let store = InMemorySnapshotStore::new();
+        let result = store.load_snapshot(&String::from("agg-1")).await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn save_then_load_roundtrips() {
+        let store = InMemorySnapshotStore::new();
+        let id = String::from("agg-1");
+        let version = Version::new(10).unwrap();
+        let snap = PendingSnapshot::new(version, 1, vec![1, 2, 3]);
+
+        store.save_snapshot(&id, &snap).await.unwrap();
+        let loaded = store.load_snapshot(&id).await.unwrap().unwrap();
+
+        assert_eq!(loaded.version(), version);
+        assert_eq!(loaded.schema_version(), 1);
+        assert_eq!(loaded.payload(), &[1, 2, 3]);
+    }
+
+    #[tokio::test]
+    async fn save_overwrites_previous_snapshot() {
+        let store = InMemorySnapshotStore::new();
+        let id = String::from("agg-1");
+
+        let snap1 = PendingSnapshot::new(Version::new(10).unwrap(), 1, vec![1]);
+        store.save_snapshot(&id, &snap1).await.unwrap();
+
+        let snap2 = PendingSnapshot::new(Version::new(20).unwrap(), 1, vec![2]);
+        store.save_snapshot(&id, &snap2).await.unwrap();
+
+        let loaded = store.load_snapshot(&id).await.unwrap().unwrap();
+        assert_eq!(loaded.version(), Version::new(20).unwrap());
+        assert_eq!(loaded.payload(), &[2]);
+    }
+
+    #[tokio::test]
+    async fn different_aggregates_have_separate_snapshots() {
+        let store = InMemorySnapshotStore::new();
+
+        let snap1 = PendingSnapshot::new(Version::new(5).unwrap(), 1, vec![1]);
+        store.save_snapshot(&String::from("agg-1"), &snap1).await.unwrap();
+
+        let snap2 = PendingSnapshot::new(Version::new(10).unwrap(), 1, vec![2]);
+        store.save_snapshot(&String::from("agg-2"), &snap2).await.unwrap();
+
+        let loaded1 = store.load_snapshot(&String::from("agg-1")).await.unwrap().unwrap();
+        let loaded2 = store.load_snapshot(&String::from("agg-2")).await.unwrap().unwrap();
+        assert_eq!(loaded1.version(), Version::new(5).unwrap());
+        assert_eq!(loaded2.version(), Version::new(10).unwrap());
+    }
+}
+```
+
+**Step 2: Run test — expected FAIL**
+
+**Step 3: Implement InMemorySnapshotStore**
+
+Create `crates/nexus-store/src/snapshot/testing.rs`:
+
+```rust
+use std::collections::HashMap;
+use std::convert::Infallible;
+
+use nexus::{Id, Version};
+use tokio::sync::RwLock;
+
+use super::pending::PendingSnapshot;
+use super::read::SnapshotRead;
+use super::store::SnapshotStore;
+
+/// In-memory snapshot store for tests.
+///
+/// Stores snapshots in a `HashMap` protected by a `RwLock`.
+#[derive(Debug, Default)]
+pub struct InMemorySnapshotStore {
+    snapshots: RwLock<HashMap<String, StoredSnapshot>>,
+}
+
+#[derive(Debug, Clone)]
+struct StoredSnapshot {
+    version: Version,
+    schema_version: u32,
+    payload: Vec<u8>,
+}
+
+/// Holder type for borrowed snapshot access.
+#[derive(Debug)]
+pub struct InMemorySnapshotHolder {
+    version: Version,
+    schema_version: u32,
+    payload: Vec<u8>,
+}
+
+impl SnapshotRead for InMemorySnapshotHolder {
+    fn version(&self) -> Version {
+        self.version
+    }
+    fn schema_version(&self) -> u32 {
+        self.schema_version
+    }
+    fn payload(&self) -> &[u8] {
+        &self.payload
+    }
+}
+
+impl InMemorySnapshotStore {
+    /// Create a new empty in-memory snapshot store.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl SnapshotStore for InMemorySnapshotStore {
+    type Error = Infallible;
+    type Holder<'a> = InMemorySnapshotHolder;
+
+    async fn load_snapshot(
+        &self,
+        id: &impl Id,
+    ) -> Result<Option<InMemorySnapshotHolder>, Infallible> {
+        let snapshots = self.snapshots.read().await;
+        let key = id.to_string();
+        Ok(snapshots.get(&key).map(|s| InMemorySnapshotHolder {
+            version: s.version,
+            schema_version: s.schema_version,
+            payload: s.payload.clone(),
+        }))
+    }
+
+    async fn save_snapshot(
+        &self,
+        id: &impl Id,
+        snapshot: &PendingSnapshot,
+    ) -> Result<(), Infallible> {
+        let mut snapshots = self.snapshots.write().await;
+        let key = id.to_string();
+        snapshots.insert(
+            key,
+            StoredSnapshot {
+                version: snapshot.version(),
+                schema_version: snapshot.schema_version(),
+                payload: snapshot.payload().to_vec(),
+            },
+        );
+        Ok(())
+    }
+}
+```
+
+Feature-gate in `snapshot/mod.rs`:
+
+```rust
+#[cfg(feature = "testing")]
+mod testing;
+#[cfg(feature = "testing")]
+pub use testing::{InMemorySnapshotStore, InMemorySnapshotHolder};
+```
+
+**Step 4: Run tests — expected PASS**
+
+Run: `cargo test -p nexus-store --features "snapshot,testing" -- snapshot_tests`
+
+**Step 5: Commit**
+
+```
+feat(store): add InMemorySnapshotStore for snapshot testing
+```
+
+---
+
+### Task 9: Create Snapshotting facade
+
+**Files:**
+- Create: `crates/nexus-store/src/store/snapshotting.rs`
+- Modify: `crates/nexus-store/src/store/mod.rs`
+- Test: `crates/nexus-store/tests/snapshot_integration_tests.rs`
+
+This is the core task — the `Snapshotting` decorator that wraps a `Repository` and adds snapshot load/save logic.
+
+**Step 1: Write integration tests**
+
+Create `crates/nexus-store/tests/snapshot_integration_tests.rs`. These tests need a full test aggregate. Reference existing test aggregates from `event_store_tests.rs` or define test helpers.
+
+Key test cases:
+
+```rust
+#![cfg(feature = "snapshot")]
+
+// (Use existing test aggregate types or define minimal ones)
+
+#[tokio::test]
+async fn load_without_snapshot_does_full_replay() {
+    // Setup: EventStore with InMemoryStore, save 5 events
+    // Add Snapshotting with InMemorySnapshotStore (empty)
+    // Load: should replay all 5 events, aggregate at version 5
+}
+
+#[tokio::test]
+async fn save_triggers_snapshot_at_threshold() {
+    // Setup: Snapshotting with EveryNEvents(3)
+    // Save 3 events → snapshot should be stored
+    // Verify snapshot exists in InMemorySnapshotStore
+}
+
+#[tokio::test]
+async fn load_from_snapshot_skips_replayed_events() {
+    // Setup: Save 10 events, snapshot at version 5
+    // Load: should restore from snapshot + replay events 6-10
+    // Verify aggregate state matches full replay
+}
+
+#[tokio::test]
+async fn schema_version_mismatch_falls_back_to_full_replay() {
+    // Setup: Save events, create snapshot with schema_version=1
+    // Create Snapshotting with schema_version=2
+    // Load: should ignore snapshot, do full replay
+}
+
+#[tokio::test]
+async fn snapshot_load_failure_falls_back_to_full_replay() {
+    // Setup: Use a SnapshotStore that returns Err on load
+    // Load: should fall back to full event replay, not propagate error
+}
+
+#[tokio::test]
+async fn snapshot_save_failure_does_not_fail_event_save() {
+    // Setup: Use a SnapshotStore that returns Err on save
+    // Save: should succeed (events persisted), snapshot failure ignored
+}
+```
+
+**Step 2: Run tests — expected FAIL**
+
+**Step 3: Implement Snapshotting**
+
+Create `crates/nexus-store/src/store/snapshotting.rs`:
+
+```rust
+use crate::codec::Codec;
+use crate::error::StoreError;
+use crate::snapshot::{PendingSnapshot, SnapshotStore, SnapshotTrigger};
+use nexus::{Aggregate, AggregateRoot, EventOf, Version};
+
+use super::replay::ReplayFrom;
+use super::repository::Repository;
+
+/// Snapshot-aware repository decorator.
+///
+/// Wraps an inner repository (e.g., `EventStore` or `ZeroCopyEventStore`)
+/// and adds transparent snapshot support:
+///
+/// - **Load:** tries the snapshot store first; on hit with matching schema
+///   version, restores state from snapshot and replays only subsequent events.
+///   On miss or schema mismatch, falls back to full event replay via the
+///   inner repository.
+///
+/// - **Save:** delegates event persistence to the inner repository, then
+///   checks the trigger to optionally persist a snapshot of the current state.
+///   Snapshot save is best-effort — failures are silently ignored.
+pub struct Snapshotting<R, SS, SC> {
+    inner: R,
+    snapshot_store: SS,
+    snapshot_codec: SC,
+    trigger: Box<dyn SnapshotTrigger>,
+    schema_version: u32,
+}
+
+impl<R, SS, SC> Snapshotting<R, SS, SC> {
+    /// Create a new snapshot-aware repository.
+    pub(crate) fn new(
+        inner: R,
+        snapshot_store: SS,
+        snapshot_codec: SC,
+        trigger: Box<dyn SnapshotTrigger>,
+        schema_version: u32,
+    ) -> Self {
+        Self {
+            inner,
+            snapshot_store,
+            snapshot_codec,
+            trigger,
+            schema_version,
+        }
+    }
+}
+
+impl<A, R, SS, SC> Repository<A> for Snapshotting<R, SS, SC>
+where
+    A: Aggregate,
+    R: Repository<A, Error = StoreError> + ReplayFrom<A>,
+    SS: SnapshotStore,
+    SC: Codec<A::State>,
+    EventOf<A>: nexus::DomainEvent,
+{
+    type Error = StoreError;
+
+    async fn load(&self, id: A::Id) -> Result<AggregateRoot<A>, StoreError> {
+        // Try snapshot first.
+        if let Ok(Some(holder)) = self
+            .snapshot_store
+            .load_snapshot(&id)
+            .await
+            .map_err(|_| ()) // discard error — snapshot is best-effort
+        {
+            if holder.schema_version() == self.schema_version {
+                // Schema matches — decode state.
+                if let Ok(state) = self
+                    .snapshot_codec
+                    .decode("", holder.payload())
+                    .map_err(|_| ()) // discard decode error
+                {
+                    let root = AggregateRoot::<A>::restore(id, state, holder.version());
+                    // Replay events after snapshot version.
+                    if let Some(next) = holder.version().next() {
+                        return self.inner.replay_from(root, next).await;
+                    }
+                    // Snapshot is at u64::MAX — no more events possible.
+                    return Ok(root);
+                }
+            }
+        }
+
+        // Fallback: full replay.
+        self.inner.load(id).await
+    }
+
+    async fn save(
+        &self,
+        aggregate: &mut AggregateRoot<A>,
+        events: &[EventOf<A>],
+    ) -> Result<(), StoreError> {
+        // Delegate event persistence to inner.
+        self.inner.save(aggregate, events).await?;
+
+        // Check trigger — maybe snapshot.
+        if let Some(version) = aggregate.version() {
+            if self.trigger.should_snapshot(version) {
+                // Best-effort: encode state and save snapshot.
+                if let Ok(payload) = self.snapshot_codec.encode(aggregate.state()) {
+                    let snap = PendingSnapshot::new(version, self.schema_version, payload);
+                    // Ignore save errors — snapshot is an optimization.
+                    let _ = self.snapshot_store.save_snapshot(aggregate.id(), &snap).await;
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+```
+
+Update `store/mod.rs`:
+
+```rust
+#[cfg(feature = "snapshot")]
+mod snapshotting;
+
+// existing exports...
+
+#[cfg(feature = "snapshot")]
+pub use snapshotting::Snapshotting;
+```
+
+Update `lib.rs` to re-export:
+
+```rust
+#[cfg(feature = "snapshot")]
+pub use store::Snapshotting;
+```
+
+**Step 4: Run tests**
+
+Run: `cargo test -p nexus-store --features "snapshot,json,testing" -- snapshot_integration`
+Expected: PASS
+
+**Step 5: Commit**
+
+```
+feat(store): add Snapshotting repository decorator
+```
+
+---
+
+### Task 10: Builder integration
+
+**Files:**
+- Modify: `crates/nexus-store/src/store/builder.rs`
+- Modify: `crates/nexus-store/src/store/mod.rs`
+- Modify: `crates/nexus-store/src/lib.rs`
+- Test: `crates/nexus-store/tests/snapshot_tests.rs` (add builder tests)
+
+**Step 1: Write builder tests**
+
+Add to `snapshot_tests.rs`:
+
+```rust
+#[cfg(all(feature = "snapshot", feature = "testing", feature = "json"))]
+mod builder_tests {
+    use std::num::NonZeroU64;
+    use nexus_store::{Store, Repository};
+    use nexus_store::snapshot::{EveryNEvents, InMemorySnapshotStore};
+    use nexus_store::testing::InMemoryStore;
+
+    #[tokio::test]
+    async fn builder_produces_snapshotting_repository() {
+        let raw = InMemoryStore::default();
+        let store = Store::new(raw);
+        let snap_store = InMemorySnapshotStore::new();
+
+        let repo = store
+            .repository()
+            .snapshot_store(snap_store)
+            .snapshot_trigger(EveryNEvents(NonZeroU64::new(100).unwrap()))
+            .snapshot_schema_version(1)
+            .build();
+
+        // Verify it compiles and implements Repository — load an empty aggregate
+        // (use existing test aggregate type)
+    }
+
+    #[tokio::test]
+    async fn builder_without_snapshot_produces_plain_event_store() {
+        let raw = InMemoryStore::default();
+        let store = Store::new(raw);
+
+        let repo = store.repository().build();
+        // This should still work exactly as before
+    }
+}
+```
+
+**Step 2: Implement builder changes**
+
+Add typestate marker and snapshot config to `builder.rs`:
+
+```rust
+#[cfg(feature = "snapshot")]
+use crate::snapshot::{SnapshotStore, SnapshotTrigger, EveryNEvents};
+#[cfg(feature = "snapshot")]
+use super::snapshotting::Snapshotting;
+
+/// Marker: no snapshot configured (default).
+pub struct NoSnapshot;
+
+/// Snapshot configuration.
+#[cfg(feature = "snapshot")]
+pub struct WithSnapshot<SS, SC> {
+    store: SS,
+    codec: SC,
+    trigger: Box<dyn SnapshotTrigger>,
+    schema_version: u32,
+}
+```
+
+Extend `RepositoryBuilder` with a `Snap` type param defaulting to `NoSnapshot`:
+
+```rust
+pub struct RepositoryBuilder<S, C, U, Snap = NoSnapshot> {
+    store: Store<S>,
+    codec: C,
+    upcaster: U,
+    snapshot: Snap,
+}
+```
+
+Add snapshot builder methods (feature-gated):
+
+```rust
+#[cfg(feature = "snapshot")]
+impl<S, C, U> RepositoryBuilder<S, C, U, NoSnapshot> {
+    /// Configure a snapshot store, transitioning the builder to snapshot mode.
+    ///
+    /// After calling this, `.build()` will produce a `Snapshotting` repository
+    /// instead of a plain `EventStore`.
+    #[must_use]
+    pub fn snapshot_store<SS: SnapshotStore>(
+        self,
+        snapshot_store: SS,
+    ) -> RepositoryBuilder<S, C, U, WithSnapshot<SS, NeedsSnapshotCodec>> {
+        // NeedsSnapshotCodec is !Send, like NeedsCodec
+        // ... (or default to JsonCodec with snapshot-json feature)
+    }
+}
+```
+
+Handle snapshot codec defaulting (with `snapshot-json` feature):
+
+```rust
+#[cfg(all(feature = "snapshot-json"))]
+impl<S, C, U, SS> RepositoryBuilder<S, C, U, WithSnapshot<SS, NeedsSnapshotCodec>> {
+    // Auto-fill JsonCodec as default snapshot codec
+}
+```
+
+Add `.build()` for `WithSnapshot`:
+
+```rust
+#[cfg(feature = "snapshot")]
+impl<S, C, U, SS, SC> RepositoryBuilder<S, C, U, WithSnapshot<SS, SC>>
+where
+    S: RawEventStore,
+    C: Send + Sync + 'static,
+    SC: Send + Sync + 'static,
+{
+    #[must_use]
+    pub fn build(self) -> Snapshotting<EventStore<S, C, U>, SS, SC> {
+        let inner = EventStore::new(self.store, self.codec, self.upcaster);
+        let snap = self.snapshot;
+        Snapshotting::new(inner, snap.store, snap.codec, snap.trigger, snap.schema_version)
+    }
+
+    #[must_use]
+    pub fn build_zero_copy(self) -> Snapshotting<ZeroCopyEventStore<S, C, U>, SS, SC> {
+        let inner = ZeroCopyEventStore::new(self.store, self.codec, self.upcaster);
+        let snap = self.snapshot;
+        Snapshotting::new(inner, snap.store, snap.codec, snap.trigger, snap.schema_version)
+    }
+}
+```
+
+**Note:** The existing `.build()` for `NoSnapshot` returns `EventStore` — unchanged. The new `.build()` for `WithSnapshot` returns `Snapshotting<EventStore, ...>`. Both implement `Repository<A>`, so callers don't care which one they get.
+
+Exact method signatures, `NeedsSnapshotCodec` guard, and `snapshot-json` defaulting should follow the same pattern as the existing `NeedsCodec` / `json` feature for event codecs.
+
+**Step 3: Update module exports**
+
+In `store/mod.rs`, add:
+
+```rust
+pub use builder::NoSnapshot;
+#[cfg(feature = "snapshot")]
+pub use builder::WithSnapshot;
+```
+
+**Step 4: Run tests**
+
+Run: `cargo test -p nexus-store --features "snapshot,json,testing" -- builder_tests`
+
+**Step 5: Commit**
+
+```
+feat(store): integrate snapshot config into RepositoryBuilder
+```
+
+---
+
+### Task 11: Full integration test suite
+
+**Files:**
+- Modify: `crates/nexus-store/tests/snapshot_integration_tests.rs`
+
+Write comprehensive tests covering the 4 mandatory test categories from CLAUDE.md:
+
+**1. Sequence/Protocol Tests:**
+- Save N events → snapshot triggers → load → partial replay → save more → snapshot again
+- Save below threshold → no snapshot → save more → crosses threshold → snapshot
+- Multiple save/load cycles with snapshot invalidation in between
+
+**2. Lifecycle Tests:**
+- Create aggregate → save → snapshot → load from snapshot → verify state
+- Load from snapshot → save more events → load again → verify new snapshot version used
+
+**3. Defensive Boundary Tests:**
+- Empty event slice save (no-op, no snapshot trigger)
+- Schema version 0 rejection in PendingSnapshot
+- Snapshot at Version u64::MAX (no next version — edge case)
+- Snapshot codec returns error → fallback to full replay
+- Snapshot store returns error on load → fallback to full replay
+- Snapshot store returns error on save → event save still succeeds
+
+**4. Linearizability/Isolation Tests:**
+- Concurrent loads from same snapshot → each gets independent copy
+- Save while another load is reading → no corruption (if applicable with InMemoryStore)
+
+Run: `cargo test -p nexus-store --features "snapshot,json,testing" -- snapshot_integration`
+
+**Commit:**
+
+```
+test(store): comprehensive snapshot integration tests
+```
+
+---
+
+### Task 12: Fjall snapshot adapter
+
+**Files:**
+- Modify: `crates/nexus-fjall/Cargo.toml`
+- Create: `crates/nexus-fjall/src/snapshot_store.rs`
+- Create: `crates/nexus-fjall/src/snapshot_encoding.rs`
+- Modify: `crates/nexus-fjall/src/store.rs`
+- Modify: `crates/nexus-fjall/src/builder.rs`
+- Modify: `crates/nexus-fjall/src/lib.rs`
+- Test: `crates/nexus-fjall/tests/snapshot_tests.rs`
+
+**Step 1: Add snapshot feature to nexus-fjall**
+
+In `crates/nexus-fjall/Cargo.toml`:
+
+```toml
+[features]
+snapshot = ["nexus-store/snapshot"]
+```
+
+**Step 2: Design the snapshot partition**
+
+Third partition in fjall, point-read optimized (like `streams`, not scan-optimized like `events`).
+
+Key: numeric stream ID (`u64 BE`) — reuse the same numeric ID mapping from the `streams` partition.
+Value: `[u32 LE schema_version][u64 BE version][payload]`
+
+This means snapshot load/save needs access to the numeric stream ID, which requires the `streams` partition for lookup.
+
+**Step 3: Implement snapshot encoding**
+
+Create `crates/nexus-fjall/src/snapshot_encoding.rs`:
+
+```rust
+pub(crate) const SNAPSHOT_KEY_SIZE: usize = 8;  // u64 BE stream numeric ID
+pub(crate) const SNAPSHOT_VALUE_HEADER_SIZE: usize = 12;  // u32 LE schema + u64 BE version
+
+pub(crate) fn encode_snapshot_key(stream_numeric_id: u64) -> [u8; SNAPSHOT_KEY_SIZE] {
+    stream_numeric_id.to_be_bytes()
+}
+
+pub(crate) fn encode_snapshot_value(
+    buf: &mut Vec<u8>,
+    schema_version: u32,
+    version: u64,
+    payload: &[u8],
+) {
+    buf.clear();
+    buf.reserve(SNAPSHOT_VALUE_HEADER_SIZE + payload.len());
+    buf.extend_from_slice(&schema_version.to_le_bytes());
+    buf.extend_from_slice(&version.to_be_bytes());
+    buf.extend_from_slice(payload);
+}
+
+pub(crate) fn decode_snapshot_value(
+    value: &[u8],
+) -> Result<(u32, u64, &[u8]), DecodeError> {
+    if value.len() < SNAPSHOT_VALUE_HEADER_SIZE {
+        return Err(DecodeError::ValueTooShort { ... });
+    }
+    let schema_version = u32::from_le_bytes(value[0..4].try_into().unwrap());
+    let version = u64::from_be_bytes(value[4..12].try_into().unwrap());
+    let payload = &value[12..];
+    Ok((schema_version, version, payload))
+}
+```
+
+**Step 4: Add snapshot partition to FjallStore**
+
+Add a `snapshots: Option<TxPartitionHandle>` field to `FjallStore` (Option so it's None when snapshot feature is off, or when not configured).
+
+Extend `FjallStoreBuilder` with `.snapshots_config()` method and create the partition in `.open()`.
+
+**Step 5: Implement SnapshotStore for FjallStore**
+
+The implementation needs to:
+1. Look up numeric stream ID from the `streams` partition
+2. Read/write the `snapshots` partition using that numeric ID as key
+
+Implement behind `#[cfg(feature = "snapshot")]`.
+
+**Step 6: Write tests**
+
+Key tests:
+- Save snapshot → load snapshot roundtrip
+- Overwrite snapshot → latest returned
+- Load from nonexistent stream → None
+- Corrupt snapshot value → error
+- Close and reopen → snapshot persisted
+
+**Step 7: Commit**
+
+```
+feat(fjall): add FjallSnapshotStore with dedicated snapshot partition
+```
+
+---
+
+### Task 13: Update re-exports and run full CI suite
+
+**Files:**
+- Modify: `crates/nexus-store/src/lib.rs` (ensure all snapshot types re-exported)
+- Modify: `crates/nexus-store/src/snapshot/mod.rs`
+
+**Step 1: Verify all public types are re-exported**
+
+Ensure `lib.rs` has:
+
+```rust
+#[cfg(feature = "snapshot")]
+pub use snapshot::{
+    EveryNEvents, InMemorySnapshotStore, NeverSnapshot,
+    PendingSnapshot, SnapshotRead, SnapshotStore, SnapshotTrigger,
+};
+```
+
+**Step 2: Run full test suite**
+
+```bash
+# Without snapshot feature — nothing breaks
+cargo test --all
+
+# With snapshot feature
+cargo test --all --features nexus-store/snapshot,nexus-store/testing
+
+# With snapshot-json
+cargo test --all --features nexus-store/snapshot-json,nexus-store/testing
+
+# Clippy
+cargo clippy --all-targets -- --deny warnings
+cargo clippy --all-targets --features nexus-store/snapshot -- --deny warnings
+
+# Format
+cargo fmt --all --check
+taplo fmt --check
+```
+
+**Step 3: Update workspace-hack if needed**
+
+```bash
+cargo hakari generate
+cargo hakari manage-deps
+cargo hakari verify
+```
+
+**Step 4: Commit**
+
+```
+chore(store): finalize snapshot re-exports and verify CI
+```

--- a/docs/plans/2026-04-10-snapshot-implementation.md
+++ b/docs/plans/2026-04-10-snapshot-implementation.md
@@ -4,9 +4,25 @@
 
 **Goal:** Add feature-gated aggregate snapshot support to nexus-store so rehydration skips replaying the full event stream.
 
-**Architecture:** `Snapshotting<R, SS, SC>` decorator wraps `EventStore`/`ZeroCopyEventStore`, intercepts `load()`/`save()` to check/write snapshots. Extract shared replay logic into a `pub(crate)` trait `ReplayFrom<A>` to avoid duplicating the stream replay loop. All snapshot types live behind `#[cfg(feature = "snapshot")]`. `()` serves as no-op `SnapshotStore`. Builder typestate gains a `Snap` param (`NoSnapshot` or `WithSnapshot<SS, SC>`) to produce either plain `EventStore` or `Snapshotting<EventStore, SS, SC>`.
+**Architecture:** `Snapshotting<R, SS, SC, T>` decorator wraps `EventStore`/`ZeroCopyEventStore`, intercepts `load()`/`save()` to check/write snapshots. Extract shared replay logic into a `pub(crate)` trait `ReplayFrom<A>` to avoid duplicating the stream replay loop. All snapshot types live behind `#[cfg(feature = "snapshot")]`. `()` serves as no-op `SnapshotStore`. Builder typestate gains a `Snap` param (`NoSnapshot` or `WithSnapshot<SS, SC, T>`) to produce either plain `EventStore` or `Snapshotting<EventStore, SS, SC, T>`.
 
 **Tech Stack:** Rust, nexus kernel (`AggregateRoot`), nexus-store traits, fjall LSM storage.
+
+**Audit applied:** Plan revised based on competitive analysis of Axon 5, Pekko, Marten, Equinox, eventsourced-rs, cqrs-es, disintegrate. See `docs/plans/2026-04-10-snapshot-design.md` for design decisions.
+
+---
+
+## Key Changes from Audit
+
+| Issue | Resolution |
+|-------|------------|
+| **Critical: modulo trigger bug** | `SnapshotTrigger::should_snapshot` now receives `old_version` + `new_version` + `event_names`; `EveryNEvents` uses boundary-crossing check instead of modulo |
+| **High: GAT Holder complexity** | Simplified to owned `PersistedSnapshot` struct; borrowing variant deferred to when benchmarks justify it |
+| **High: `Box<dyn SnapshotTrigger>`** | Trigger is now a type parameter `T` on `Snapshotting` — monomorphized, zero-cost |
+| **Medium: event-type triggers** | `AfterEventTypes` trigger added; trigger signature includes `event_names: &[&str]` |
+| **Medium: lazy snapshotting** | Snapshotting facade supports snapshot-on-read (after full replay exceeds threshold) |
+| **Low: snapshot retention** | `delete_snapshot` added to `SnapshotStore` trait |
+| **Low: performance docs** | Guidance on when snapshots help vs. hurt included in design doc |
 
 ---
 
@@ -42,10 +58,11 @@ feat(store): add snapshot and snapshot-json feature flags
 
 ---
 
-### Task 2: Create PendingSnapshot struct
+### Task 2: Create PendingSnapshot and PersistedSnapshot structs
 
 **Files:**
 - Create: `crates/nexus-store/src/snapshot/pending.rs`
+- Create: `crates/nexus-store/src/snapshot/persisted.rs`
 - Create: `crates/nexus-store/src/snapshot/mod.rs`
 - Modify: `crates/nexus-store/src/lib.rs`
 - Test: `crates/nexus-store/tests/snapshot_tests.rs`
@@ -57,8 +74,8 @@ Create `crates/nexus-store/tests/snapshot_tests.rs`:
 ```rust
 #![cfg(feature = "snapshot")]
 
-use nexus_store::snapshot::{PendingSnapshot};
 use nexus::Version;
+use nexus_store::snapshot::{PendingSnapshot, PersistedSnapshot};
 
 #[test]
 fn pending_snapshot_stores_version_and_payload() {
@@ -77,6 +94,16 @@ fn pending_snapshot_schema_version_must_be_nonzero() {
     let result = PendingSnapshot::try_new(version, 0, vec![]);
     assert!(result.is_err());
 }
+
+#[test]
+fn persisted_snapshot_stores_version_and_payload() {
+    let version = Version::new(10).unwrap();
+    let snap = PersistedSnapshot::new(version, 2, vec![4, 5, 6]);
+
+    assert_eq!(snap.version(), version);
+    assert_eq!(snap.schema_version(), 2);
+    assert_eq!(snap.payload(), &[4, 5, 6]);
+}
 ```
 
 **Step 2: Run test to verify it fails**
@@ -90,8 +117,10 @@ Create `crates/nexus-store/src/snapshot/mod.rs`:
 
 ```rust
 mod pending;
+mod persisted;
 
 pub use pending::PendingSnapshot;
+pub use persisted::PersistedSnapshot;
 ```
 
 Create `crates/nexus-store/src/snapshot/pending.rs`:
@@ -165,6 +194,75 @@ impl PendingSnapshot {
 }
 ```
 
+Create `crates/nexus-store/src/snapshot/persisted.rs`:
+
+```rust
+use nexus::Version;
+
+use crate::error::InvalidSchemaVersion;
+
+/// Persisted snapshot loaded from storage (read path).
+///
+/// Owns the payload bytes. This is the simplified owned variant —
+/// a borrowing variant with GAT lifetimes can be added later if
+/// benchmarks show the extra allocation matters for specific backends.
+#[derive(Debug, Clone)]
+pub struct PersistedSnapshot {
+    version: Version,
+    schema_version: u32,
+    payload: Vec<u8>,
+}
+
+impl PersistedSnapshot {
+    /// Create a new persisted snapshot.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `schema_version` is 0.
+    #[must_use]
+    pub fn new(version: Version, schema_version: u32, payload: Vec<u8>) -> Self {
+        match Self::try_new(version, schema_version, payload) {
+            Ok(snap) => snap,
+            Err(e) => panic!("{e}"),
+        }
+    }
+
+    /// Try to create a new persisted snapshot.
+    pub fn try_new(
+        version: Version,
+        schema_version: u32,
+        payload: Vec<u8>,
+    ) -> Result<Self, InvalidSchemaVersion> {
+        if schema_version == 0 {
+            return Err(InvalidSchemaVersion);
+        }
+        Ok(Self {
+            version,
+            schema_version,
+            payload,
+        })
+    }
+
+    /// The aggregate version at the time of the snapshot.
+    #[must_use]
+    pub const fn version(&self) -> Version {
+        self.version
+    }
+
+    /// The schema version for invalidation checking.
+    #[must_use]
+    pub const fn schema_version(&self) -> u32 {
+        self.schema_version
+    }
+
+    /// The serialized state bytes.
+    #[must_use]
+    pub fn payload(&self) -> &[u8] {
+        &self.payload
+    }
+}
+```
+
 Add to `crates/nexus-store/src/lib.rs`:
 
 ```rust
@@ -180,103 +278,12 @@ Expected: PASS
 **Step 5: Commit**
 
 ```
-feat(store): add PendingSnapshot type for snapshot write path
+feat(store): add PendingSnapshot and PersistedSnapshot types
 ```
 
 ---
 
-### Task 3: Create SnapshotRead trait
-
-**Files:**
-- Create: `crates/nexus-store/src/snapshot/read.rs`
-- Modify: `crates/nexus-store/src/snapshot/mod.rs`
-- Test: `crates/nexus-store/tests/snapshot_tests.rs`
-
-**Step 1: Write the failing test**
-
-Add to `snapshot_tests.rs`:
-
-```rust
-use nexus_store::snapshot::SnapshotRead;
-
-struct TestHolder {
-    version: Version,
-    schema_version: u32,
-    data: Vec<u8>,
-}
-
-impl SnapshotRead for TestHolder {
-    fn version(&self) -> Version { self.version }
-    fn schema_version(&self) -> u32 { self.schema_version }
-    fn payload(&self) -> &[u8] { &self.data }
-}
-
-#[test]
-fn snapshot_read_impl_provides_borrowed_access() {
-    let holder = TestHolder {
-        version: Version::new(10).unwrap(),
-        schema_version: 2,
-        data: vec![4, 5, 6],
-    };
-    assert_eq!(holder.version(), Version::new(10).unwrap());
-    assert_eq!(holder.schema_version(), 2);
-    assert_eq!(holder.payload(), &[4, 5, 6]);
-}
-```
-
-**Step 2: Run test to verify it fails**
-
-Run: `cargo test -p nexus-store --features snapshot -- snapshot_read`
-Expected: FAIL — `SnapshotRead` doesn't exist
-
-**Step 3: Create SnapshotRead trait**
-
-Create `crates/nexus-store/src/snapshot/read.rs`:
-
-```rust
-use nexus::Version;
-
-/// Borrowed access to a persisted snapshot (read path).
-///
-/// Implemented by adapter-specific holder types. The holder owns
-/// the raw bytes read from storage; `payload()` borrows from it,
-/// enabling zero-copy decode via [`BorrowingCodec`](crate::BorrowingCodec).
-pub trait SnapshotRead {
-    /// The aggregate version at the time of the snapshot.
-    fn version(&self) -> Version;
-
-    /// The schema version for invalidation checking.
-    fn schema_version(&self) -> u32;
-
-    /// The serialized state bytes, borrowed from the holder.
-    fn payload(&self) -> &[u8];
-}
-```
-
-Update `snapshot/mod.rs`:
-
-```rust
-mod pending;
-mod read;
-
-pub use pending::PendingSnapshot;
-pub use read::SnapshotRead;
-```
-
-**Step 4: Run test**
-
-Run: `cargo test -p nexus-store --features snapshot -- snapshot_read`
-Expected: PASS
-
-**Step 5: Commit**
-
-```
-feat(store): add SnapshotRead trait for borrowed snapshot access
-```
-
----
-
-### Task 4: Create SnapshotStore trait + () no-op
+### Task 3: Create SnapshotStore trait + () no-op
 
 **Files:**
 - Create: `crates/nexus-store/src/snapshot/store.rs`
@@ -306,6 +313,14 @@ async fn unit_snapshot_store_save_succeeds() {
     let result = store.save_snapshot(&id, &snap).await;
     assert!(result.is_ok());
 }
+
+#[tokio::test]
+async fn unit_snapshot_store_delete_succeeds() {
+    let store = ();
+    let id = String::from("agg-1");
+    let result = store.delete_snapshot(&id).await;
+    assert!(result.is_ok());
+}
 ```
 
 **Step 2: Run test — expected FAIL**
@@ -321,26 +336,19 @@ use std::future::Future;
 use nexus::Id;
 
 use super::pending::PendingSnapshot;
-use super::read::SnapshotRead;
+use super::persisted::PersistedSnapshot;
 
 /// Byte-level snapshot storage trait.
 ///
 /// Adapters (fjall, postgres, etc.) implement this to persist and
-/// retrieve serialized aggregate state. The GAT `Holder<'a>` enables
-/// zero-copy reads — the holder owns the raw bytes and
-/// [`SnapshotRead::payload()`] borrows from it.
+/// retrieve serialized aggregate state.
 ///
 /// `()` is the no-op implementation: `load_snapshot` always returns
-/// `None`, `save_snapshot` silently discards. Used when snapshot
-/// support is not configured.
+/// `None`, `save_snapshot` and `delete_snapshot` silently discard.
+/// Used when snapshot support is not configured.
 pub trait SnapshotStore: Send + Sync {
     /// Adapter-specific error type.
     type Error: std::error::Error + Send + Sync + 'static;
-
-    /// Type that owns snapshot bytes on the read path.
-    type Holder<'a>: SnapshotRead + 'a
-    where
-        Self: 'a;
 
     /// Load the most recent snapshot for the given aggregate.
     ///
@@ -348,7 +356,7 @@ pub trait SnapshotStore: Send + Sync {
     fn load_snapshot(
         &self,
         id: &impl Id,
-    ) -> impl Future<Output = Result<Option<Self::Holder<'_>>, Self::Error>> + Send;
+    ) -> impl Future<Output = Result<Option<PersistedSnapshot>, Self::Error>> + Send;
 
     /// Persist a snapshot for the given aggregate.
     ///
@@ -358,38 +366,27 @@ pub trait SnapshotStore: Send + Sync {
         id: &impl Id,
         snapshot: &PendingSnapshot,
     ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+
+    /// Delete the snapshot for the given aggregate.
+    ///
+    /// Returns `Ok(())` if no snapshot exists (idempotent).
+    fn delete_snapshot(
+        &self,
+        id: &impl Id,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
 // No-op implementation — snapshots disabled
 // ═══════════════════════════════════════════════════════════════════════════
 
-/// Uninhabited holder for the `()` no-op snapshot store.
-///
-/// This type can never be constructed, matching the fact that
-/// the no-op store always returns `None` from `load_snapshot`.
-pub enum NeverSnapshot {}
-
-impl SnapshotRead for NeverSnapshot {
-    fn version(&self) -> nexus::Version {
-        match *self {}
-    }
-    fn schema_version(&self) -> u32 {
-        match *self {}
-    }
-    fn payload(&self) -> &[u8] {
-        match *self {}
-    }
-}
-
 impl SnapshotStore for () {
     type Error = Infallible;
-    type Holder<'a> = NeverSnapshot;
 
     async fn load_snapshot(
         &self,
         _id: &impl Id,
-    ) -> Result<Option<NeverSnapshot>, Infallible> {
+    ) -> Result<Option<PersistedSnapshot>, Infallible> {
         Ok(None)
     }
 
@@ -400,6 +397,13 @@ impl SnapshotStore for () {
     ) -> Result<(), Infallible> {
         Ok(())
     }
+
+    async fn delete_snapshot(
+        &self,
+        _id: &impl Id,
+    ) -> Result<(), Infallible> {
+        Ok(())
+    }
 }
 ```
 
@@ -407,12 +411,12 @@ Update `snapshot/mod.rs`:
 
 ```rust
 mod pending;
-mod read;
+mod persisted;
 mod store;
 
 pub use pending::PendingSnapshot;
-pub use read::SnapshotRead;
-pub use store::{NeverSnapshot, SnapshotStore};
+pub use persisted::PersistedSnapshot;
+pub use store::SnapshotStore;
 ```
 
 **Step 4: Run tests — expected PASS**
@@ -420,12 +424,12 @@ pub use store::{NeverSnapshot, SnapshotStore};
 **Step 5: Commit**
 
 ```
-feat(store): add SnapshotStore trait with () no-op implementation
+feat(store): add SnapshotStore trait with () no-op and delete_snapshot
 ```
 
 ---
 
-### Task 5: Create SnapshotTrigger trait + EveryNEvents
+### Task 4: Create SnapshotTrigger trait + EveryNEvents + AfterEventTypes
 
 **Files:**
 - Create: `crates/nexus-store/src/snapshot/trigger.rs`
@@ -438,24 +442,85 @@ Add to `snapshot_tests.rs`:
 
 ```rust
 use std::num::NonZeroU64;
-use nexus_store::snapshot::{SnapshotTrigger, EveryNEvents};
+use nexus_store::snapshot::{SnapshotTrigger, EveryNEvents, AfterEventTypes};
+
+// ── EveryNEvents ────────────────────────────────────────────────
 
 #[test]
-fn every_n_events_triggers_at_multiples() {
+fn every_n_events_triggers_on_boundary_crossing() {
     let trigger = EveryNEvents(NonZeroU64::new(100).unwrap());
-    assert!(!trigger.should_snapshot(Version::new(1).unwrap()));
-    assert!(!trigger.should_snapshot(Version::new(99).unwrap()));
-    assert!(trigger.should_snapshot(Version::new(100).unwrap()));
-    assert!(!trigger.should_snapshot(Version::new(101).unwrap()));
-    assert!(trigger.should_snapshot(Version::new(200).unwrap()));
+
+    // Single-event saves crossing the boundary
+    let v99 = Some(Version::new(99).unwrap());
+    let v100 = Version::new(100).unwrap();
+    assert!(trigger.should_snapshot(v99, v100, &[]));
+
+    // Not yet at boundary
+    let v98 = Some(Version::new(98).unwrap());
+    let v99_ver = Version::new(99).unwrap();
+    assert!(!trigger.should_snapshot(v98, v99_ver, &[]));
+}
+
+#[test]
+fn every_n_events_triggers_on_batch_crossing_boundary() {
+    let trigger = EveryNEvents(NonZeroU64::new(100).unwrap());
+
+    // Batch of 7 events crossing the 100 boundary: 96 → 103
+    let old = Some(Version::new(96).unwrap());
+    let new = Version::new(103).unwrap();
+    assert!(trigger.should_snapshot(old, new, &[]));
+}
+
+#[test]
+fn every_n_events_first_save_triggers_at_boundary() {
+    let trigger = EveryNEvents(NonZeroU64::new(100).unwrap());
+
+    // Fresh aggregate, first save crosses boundary
+    let new = Version::new(100).unwrap();
+    assert!(trigger.should_snapshot(None, new, &[]));
+
+    // Fresh aggregate, first save below boundary
+    let new_50 = Version::new(50).unwrap();
+    assert!(!trigger.should_snapshot(None, new_50, &[]));
 }
 
 #[test]
 fn every_1_event_always_triggers() {
     let trigger = EveryNEvents(NonZeroU64::new(1).unwrap());
-    assert!(trigger.should_snapshot(Version::new(1).unwrap()));
-    assert!(trigger.should_snapshot(Version::new(2).unwrap()));
-    assert!(trigger.should_snapshot(Version::new(999).unwrap()));
+    assert!(trigger.should_snapshot(None, Version::new(1).unwrap(), &[]));
+    assert!(trigger.should_snapshot(
+        Some(Version::new(1).unwrap()),
+        Version::new(2).unwrap(),
+        &[],
+    ));
+}
+
+// ── AfterEventTypes ─────────────────────────────────────────────
+
+#[test]
+fn after_event_types_triggers_on_matching_event() {
+    let trigger = AfterEventTypes::new(&["OrderCompleted", "OrderCancelled"]);
+
+    assert!(trigger.should_snapshot(None, Version::new(5).unwrap(), &["OrderCompleted"]));
+    assert!(trigger.should_snapshot(None, Version::new(5).unwrap(), &["OrderCancelled"]));
+    assert!(!trigger.should_snapshot(None, Version::new(5).unwrap(), &["ItemAdded"]));
+}
+
+#[test]
+fn after_event_types_triggers_if_any_event_in_batch_matches() {
+    let trigger = AfterEventTypes::new(&["OrderCompleted"]);
+
+    assert!(trigger.should_snapshot(
+        None,
+        Version::new(5).unwrap(),
+        &["ItemAdded", "OrderCompleted"],
+    ));
+}
+
+#[test]
+fn after_event_types_does_not_trigger_on_empty_events() {
+    let trigger = AfterEventTypes::new(&["OrderCompleted"]);
+    assert!(!trigger.should_snapshot(None, Version::new(5).unwrap(), &[]));
 }
 ```
 
@@ -472,39 +537,94 @@ use nexus::Version;
 
 /// Strategy for deciding when to take a snapshot.
 ///
-/// Checked after each successful `save()`. The trigger receives the
-/// aggregate's new version and returns whether a snapshot should be taken.
+/// Checked after each successful `save()`. The trigger receives both the
+/// old and new aggregate version (to detect boundary crossings regardless
+/// of batch size) and the names of events just persisted (for semantic
+/// triggers).
 pub trait SnapshotTrigger: Send + Sync {
-    /// Whether a snapshot should be taken at this version.
-    fn should_snapshot(&self, new_version: Version) -> bool;
+    /// Whether a snapshot should be taken after this save.
+    ///
+    /// - `old_version`: aggregate version before save (`None` for new aggregates)
+    /// - `new_version`: aggregate version after save
+    /// - `event_names`: names of events just persisted (from `DomainEvent::name()`)
+    fn should_snapshot(
+        &self,
+        old_version: Option<Version>,
+        new_version: Version,
+        event_names: &[&str],
+    ) -> bool;
 }
 
-/// Trigger a snapshot every N events (at version multiples of N).
+/// Trigger a snapshot every N events.
 ///
-/// For example, `EveryNEvents(100)` triggers at versions 100, 200, 300, etc.
+/// Detects when a save crosses an N-event boundary, regardless of batch
+/// size. For example, `EveryNEvents(100)` triggers when the aggregate
+/// crosses version 100, 200, 300, etc. — even if the batch was 7 events
+/// jumping from version 96 to 103.
 #[derive(Debug, Clone, Copy)]
 pub struct EveryNEvents(pub NonZeroU64);
 
 impl SnapshotTrigger for EveryNEvents {
-    fn should_snapshot(&self, new_version: Version) -> bool {
-        new_version.as_u64() % self.0.get() == 0
+    fn should_snapshot(
+        &self,
+        old_version: Option<Version>,
+        new_version: Version,
+        _event_names: &[&str],
+    ) -> bool {
+        let n = self.0.get();
+        let old_bucket = old_version.map_or(0, |v| v.as_u64() / n);
+        let new_bucket = new_version.as_u64() / n;
+        new_bucket > old_bucket
+    }
+}
+
+/// Trigger a snapshot after specific event types are persisted.
+///
+/// Useful for domain milestones (e.g., `OrderCompleted`, `AccountClosed`)
+/// where the aggregate is unlikely to change further, or where a stable
+/// snapshot point aligns with business semantics.
+#[derive(Debug, Clone)]
+pub struct AfterEventTypes {
+    types: Vec<&'static str>,
+}
+
+impl AfterEventTypes {
+    /// Create a trigger that fires when any of the given event types is persisted.
+    #[must_use]
+    pub fn new(types: &[&'static str]) -> Self {
+        Self {
+            types: types.to_vec(),
+        }
+    }
+}
+
+impl SnapshotTrigger for AfterEventTypes {
+    fn should_snapshot(
+        &self,
+        _old_version: Option<Version>,
+        _new_version: Version,
+        event_names: &[&str],
+    ) -> bool {
+        event_names
+            .iter()
+            .any(|name| self.types.iter().any(|t| t == name))
     }
 }
 ```
 
-Update `snapshot/mod.rs` to export `SnapshotTrigger` and `EveryNEvents`.
+Update `snapshot/mod.rs` to export `SnapshotTrigger`, `EveryNEvents`, and `AfterEventTypes`.
 
 **Step 4: Run tests — expected PASS**
 
 **Step 5: Commit**
 
 ```
-feat(store): add SnapshotTrigger trait and EveryNEvents strategy
+feat(store): add SnapshotTrigger trait with EveryNEvents and AfterEventTypes
 ```
 
 ---
 
-### Task 6: Add AggregateRoot::restore to kernel
+### Task 5: Add AggregateRoot::restore to kernel
 
 **Files:**
 - Modify: `crates/nexus/src/aggregate.rs`
@@ -605,7 +725,7 @@ feat(kernel): add AggregateRoot::restore for snapshot rehydration
 
 ---
 
-### Task 7: Extract ReplayFrom trait from EventStore/ZeroCopyEventStore
+### Task 6: Extract ReplayFrom trait from EventStore/ZeroCopyEventStore
 
 **Files:**
 - Create: `crates/nexus-store/src/store/replay.rs`
@@ -645,13 +765,7 @@ pub(crate) trait ReplayFrom<A: Aggregate>: Send + Sync {
 
 **Step 3: Implement for EventStore**
 
-In `event_store.rs`, add:
-
-```rust
-use super::replay::ReplayFrom;
-```
-
-Then add the impl block:
+In `event_store.rs`, add `use super::replay::ReplayFrom;` and implement:
 
 ```rust
 impl<A, S, C, U> ReplayFrom<A> for EventStore<S, C, U>
@@ -709,64 +823,11 @@ async fn load(&self, id: A::Id) -> Result<AggregateRoot<A>, StoreError> {
 
 **Step 4: Implement for ZeroCopyEventStore**
 
-Same pattern but using `BorrowingCodec`:
-
-```rust
-impl<A, S, C, U> ReplayFrom<A> for ZeroCopyEventStore<S, C, U>
-where
-    A: Aggregate,
-    S: RawEventStore,
-    C: BorrowingCodec<EventOf<A>>,
-    U: Upcaster,
-    EventOf<A>: DomainEvent,
-    for<'a> S::Stream<'a>: Send,
-{
-    async fn replay_from(
-        &self,
-        mut root: AggregateRoot<A>,
-        from: Version,
-    ) -> Result<AggregateRoot<A>, StoreError> {
-        let mut stream = self
-            .store
-            .raw()
-            .read_stream(root.id(), from)
-            .await
-            .map_err(|e| StoreError::Adapter(Box::new(e)))?;
-
-        while let Some(result) = stream.next().await {
-            let env = result.map_err(|e| StoreError::Adapter(Box::new(e)))?;
-            let morsel = EventMorsel::borrowed(
-                env.event_type(),
-                env.schema_version_as_version(),
-                env.payload(),
-            );
-            let transformed = self
-                .upcaster
-                .apply(morsel)
-                .map_err(|e| StoreError::Codec(Box::new(e)))?;
-            let event: &EventOf<A> = self
-                .codec
-                .decode(transformed.event_type(), transformed.payload())
-                .map_err(|e| StoreError::Codec(Box::new(e)))?;
-            root.replay(env.version(), event)?;
-        }
-
-        Ok(root)
-    }
-}
-```
-
-Refactor `ZeroCopyEventStore::load` to delegate similarly.
+Same pattern using `BorrowingCodec`. Refactor its `load()` to delegate to `replay_from` as well.
 
 **Step 5: Update store/mod.rs**
 
-Add:
-
-```rust
-mod replay;
-```
-
-No public re-export — `replay` is `pub(crate)`.
+Add `mod replay;` — no public re-export (it's `pub(crate)`).
 
 **Step 6: Run all existing tests — expected PASS (no behavior change)**
 
@@ -780,7 +841,7 @@ refactor(store): extract ReplayFrom trait for shared replay logic
 
 ---
 
-### Task 8: Create InMemorySnapshotStore for testing
+### Task 7: Create InMemorySnapshotStore for testing
 
 **Files:**
 - Create: `crates/nexus-store/src/snapshot/testing.rs`
@@ -850,6 +911,26 @@ mod in_memory_tests {
         assert_eq!(loaded1.version(), Version::new(5).unwrap());
         assert_eq!(loaded2.version(), Version::new(10).unwrap());
     }
+
+    #[tokio::test]
+    async fn delete_removes_snapshot() {
+        let store = InMemorySnapshotStore::new();
+        let id = String::from("agg-1");
+
+        let snap = PendingSnapshot::new(Version::new(10).unwrap(), 1, vec![1]);
+        store.save_snapshot(&id, &snap).await.unwrap();
+
+        store.delete_snapshot(&id).await.unwrap();
+        let loaded = store.load_snapshot(&id).await.unwrap();
+        assert!(loaded.is_none());
+    }
+
+    #[tokio::test]
+    async fn delete_nonexistent_is_ok() {
+        let store = InMemorySnapshotStore::new();
+        let result = store.delete_snapshot(&String::from("nope")).await;
+        assert!(result.is_ok());
+    }
 }
 ```
 
@@ -863,11 +944,11 @@ Create `crates/nexus-store/src/snapshot/testing.rs`:
 use std::collections::HashMap;
 use std::convert::Infallible;
 
-use nexus::{Id, Version};
+use nexus::Id;
 use tokio::sync::RwLock;
 
 use super::pending::PendingSnapshot;
-use super::read::SnapshotRead;
+use super::persisted::PersistedSnapshot;
 use super::store::SnapshotStore;
 
 /// In-memory snapshot store for tests.
@@ -880,29 +961,9 @@ pub struct InMemorySnapshotStore {
 
 #[derive(Debug, Clone)]
 struct StoredSnapshot {
-    version: Version,
+    version: nexus::Version,
     schema_version: u32,
     payload: Vec<u8>,
-}
-
-/// Holder type for borrowed snapshot access.
-#[derive(Debug)]
-pub struct InMemorySnapshotHolder {
-    version: Version,
-    schema_version: u32,
-    payload: Vec<u8>,
-}
-
-impl SnapshotRead for InMemorySnapshotHolder {
-    fn version(&self) -> Version {
-        self.version
-    }
-    fn schema_version(&self) -> u32 {
-        self.schema_version
-    }
-    fn payload(&self) -> &[u8] {
-        &self.payload
-    }
 }
 
 impl InMemorySnapshotStore {
@@ -915,18 +976,15 @@ impl InMemorySnapshotStore {
 
 impl SnapshotStore for InMemorySnapshotStore {
     type Error = Infallible;
-    type Holder<'a> = InMemorySnapshotHolder;
 
     async fn load_snapshot(
         &self,
         id: &impl Id,
-    ) -> Result<Option<InMemorySnapshotHolder>, Infallible> {
+    ) -> Result<Option<PersistedSnapshot>, Infallible> {
         let snapshots = self.snapshots.read().await;
         let key = id.to_string();
-        Ok(snapshots.get(&key).map(|s| InMemorySnapshotHolder {
-            version: s.version,
-            schema_version: s.schema_version,
-            payload: s.payload.clone(),
+        Ok(snapshots.get(&key).map(|s| {
+            PersistedSnapshot::new(s.version, s.schema_version, s.payload.clone())
         }))
     }
 
@@ -947,6 +1005,15 @@ impl SnapshotStore for InMemorySnapshotStore {
         );
         Ok(())
     }
+
+    async fn delete_snapshot(
+        &self,
+        id: &impl Id,
+    ) -> Result<(), Infallible> {
+        let mut snapshots = self.snapshots.write().await;
+        snapshots.remove(&id.to_string());
+        Ok(())
+    }
 }
 ```
 
@@ -956,7 +1023,7 @@ Feature-gate in `snapshot/mod.rs`:
 #[cfg(feature = "testing")]
 mod testing;
 #[cfg(feature = "testing")]
-pub use testing::{InMemorySnapshotStore, InMemorySnapshotHolder};
+pub use testing::InMemorySnapshotStore;
 ```
 
 **Step 4: Run tests — expected PASS**
@@ -971,30 +1038,29 @@ feat(store): add InMemorySnapshotStore for snapshot testing
 
 ---
 
-### Task 9: Create Snapshotting facade
+### Task 8: Create Snapshotting facade
 
 **Files:**
 - Create: `crates/nexus-store/src/store/snapshotting.rs`
 - Modify: `crates/nexus-store/src/store/mod.rs`
+- Modify: `crates/nexus-store/src/lib.rs`
 - Test: `crates/nexus-store/tests/snapshot_integration_tests.rs`
 
-This is the core task — the `Snapshotting` decorator that wraps a `Repository` and adds snapshot load/save logic.
+This is the core task — the `Snapshotting` decorator that wraps a `Repository` and adds snapshot load/save logic. The trigger is a type parameter (monomorphized, zero-cost) instead of `Box<dyn>`.
 
 **Step 1: Write integration tests**
 
-Create `crates/nexus-store/tests/snapshot_integration_tests.rs`. These tests need a full test aggregate. Reference existing test aggregates from `event_store_tests.rs` or define test helpers.
-
-Key test cases:
+Create `crates/nexus-store/tests/snapshot_integration_tests.rs`. Define or reuse test aggregate types. Key test cases:
 
 ```rust
-#![cfg(feature = "snapshot")]
+#![cfg(all(feature = "snapshot", feature = "json", feature = "testing"))]
 
-// (Use existing test aggregate types or define minimal ones)
+// (use existing test aggregate types or define minimal ones)
 
 #[tokio::test]
 async fn load_without_snapshot_does_full_replay() {
     // Setup: EventStore with InMemoryStore, save 5 events
-    // Add Snapshotting with InMemorySnapshotStore (empty)
+    // Wrap with Snapshotting + empty InMemorySnapshotStore
     // Load: should replay all 5 events, aggregate at version 5
 }
 
@@ -1006,8 +1072,15 @@ async fn save_triggers_snapshot_at_threshold() {
 }
 
 #[tokio::test]
+async fn save_triggers_snapshot_on_boundary_crossing_batch() {
+    // Setup: Snapshotting with EveryNEvents(5)
+    // Save 3 events (v1-3), then 3 more (v4-6, crossing 5-boundary)
+    // Verify snapshot taken at v6
+}
+
+#[tokio::test]
 async fn load_from_snapshot_skips_replayed_events() {
-    // Setup: Save 10 events, snapshot at version 5
+    // Setup: Save 10 events, manually insert snapshot at version 5
     // Load: should restore from snapshot + replay events 6-10
     // Verify aggregate state matches full replay
 }
@@ -1020,15 +1093,24 @@ async fn schema_version_mismatch_falls_back_to_full_replay() {
 }
 
 #[tokio::test]
-async fn snapshot_load_failure_falls_back_to_full_replay() {
-    // Setup: Use a SnapshotStore that returns Err on load
-    // Load: should fall back to full event replay, not propagate error
-}
-
-#[tokio::test]
 async fn snapshot_save_failure_does_not_fail_event_save() {
     // Setup: Use a SnapshotStore that returns Err on save
     // Save: should succeed (events persisted), snapshot failure ignored
+}
+
+#[tokio::test]
+async fn after_event_types_trigger_snapshots_on_domain_milestone() {
+    // Setup: Snapshotting with AfterEventTypes(["OrderCompleted"])
+    // Save ItemAdded events → no snapshot
+    // Save OrderCompleted → snapshot taken
+}
+
+#[tokio::test]
+async fn lazy_snapshot_on_read_after_full_replay() {
+    // Setup: Snapshotting with EveryNEvents(5) + on_read=true
+    // Save 10 events without any snapshot
+    // Load: full replay → snapshot created as side effect
+    // Load again: snapshot hit + partial replay
 }
 ```
 
@@ -1041,8 +1123,8 @@ Create `crates/nexus-store/src/store/snapshotting.rs`:
 ```rust
 use crate::codec::Codec;
 use crate::error::StoreError;
-use crate::snapshot::{PendingSnapshot, SnapshotStore, SnapshotTrigger};
-use nexus::{Aggregate, AggregateRoot, EventOf, Version};
+use crate::snapshot::{PendingSnapshot, PersistedSnapshot, SnapshotStore, SnapshotTrigger};
+use nexus::{Aggregate, AggregateRoot, DomainEvent, EventOf, Version};
 
 use super::replay::ReplayFrom;
 use super::repository::Repository;
@@ -1055,27 +1137,34 @@ use super::repository::Repository;
 /// - **Load:** tries the snapshot store first; on hit with matching schema
 ///   version, restores state from snapshot and replays only subsequent events.
 ///   On miss or schema mismatch, falls back to full event replay via the
-///   inner repository.
+///   inner repository. Optionally creates a snapshot after a full replay
+///   (lazy/on-read snapshotting) if `snapshot_on_read` is enabled.
 ///
 /// - **Save:** delegates event persistence to the inner repository, then
 ///   checks the trigger to optionally persist a snapshot of the current state.
 ///   Snapshot save is best-effort — failures are silently ignored.
-pub struct Snapshotting<R, SS, SC> {
+///
+/// The trigger type `T` is a generic parameter (not `Box<dyn>`) for
+/// zero-cost monomorphization — the compiler inlines `should_snapshot()`
+/// calls entirely.
+pub struct Snapshotting<R, SS, SC, T> {
     inner: R,
     snapshot_store: SS,
     snapshot_codec: SC,
-    trigger: Box<dyn SnapshotTrigger>,
+    trigger: T,
     schema_version: u32,
+    snapshot_on_read: bool,
 }
 
-impl<R, SS, SC> Snapshotting<R, SS, SC> {
+impl<R, SS, SC, T> Snapshotting<R, SS, SC, T> {
     /// Create a new snapshot-aware repository.
     pub(crate) fn new(
         inner: R,
         snapshot_store: SS,
         snapshot_codec: SC,
-        trigger: Box<dyn SnapshotTrigger>,
+        trigger: T,
         schema_version: u32,
+        snapshot_on_read: bool,
     ) -> Self {
         Self {
             inner,
@@ -1083,48 +1172,42 @@ impl<R, SS, SC> Snapshotting<R, SS, SC> {
             snapshot_codec,
             trigger,
             schema_version,
+            snapshot_on_read,
         }
     }
 }
 
-impl<A, R, SS, SC> Repository<A> for Snapshotting<R, SS, SC>
+impl<A, R, SS, SC, T> Repository<A> for Snapshotting<R, SS, SC, T>
 where
     A: Aggregate,
     R: Repository<A, Error = StoreError> + ReplayFrom<A>,
     SS: SnapshotStore,
     SC: Codec<A::State>,
-    EventOf<A>: nexus::DomainEvent,
+    T: SnapshotTrigger,
+    EventOf<A>: DomainEvent,
 {
     type Error = StoreError;
 
     async fn load(&self, id: A::Id) -> Result<AggregateRoot<A>, StoreError> {
         // Try snapshot first.
-        if let Ok(Some(holder)) = self
-            .snapshot_store
-            .load_snapshot(&id)
-            .await
-            .map_err(|_| ()) // discard error — snapshot is best-effort
-        {
-            if holder.schema_version() == self.schema_version {
-                // Schema matches — decode state.
-                if let Ok(state) = self
-                    .snapshot_codec
-                    .decode("", holder.payload())
-                    .map_err(|_| ()) // discard decode error
-                {
-                    let root = AggregateRoot::<A>::restore(id, state, holder.version());
-                    // Replay events after snapshot version.
-                    if let Some(next) = holder.version().next() {
-                        return self.inner.replay_from(root, next).await;
-                    }
-                    // Snapshot is at u64::MAX — no more events possible.
-                    return Ok(root);
-                }
-            }
+        let snapshot_hit = self.try_load_from_snapshot(&id).await;
+
+        if let Some((root, from)) = snapshot_hit {
+            // Snapshot hit — partial replay from snapshot version.
+            return self.inner.replay_from(root, from).await;
         }
 
         // Fallback: full replay.
-        self.inner.load(id).await
+        let root = self.inner.load(id.clone()).await?;
+
+        // Lazy snapshot: if enabled and aggregate has events, snapshot now.
+        if self.snapshot_on_read {
+            if let Some(version) = root.version() {
+                self.try_save_snapshot(&root, version).await;
+            }
+        }
+
+        Ok(root)
     }
 
     async fn save(
@@ -1132,22 +1215,70 @@ where
         aggregate: &mut AggregateRoot<A>,
         events: &[EventOf<A>],
     ) -> Result<(), StoreError> {
+        let old_version = aggregate.version();
+
         // Delegate event persistence to inner.
         self.inner.save(aggregate, events).await?;
 
         // Check trigger — maybe snapshot.
-        if let Some(version) = aggregate.version() {
-            if self.trigger.should_snapshot(version) {
-                // Best-effort: encode state and save snapshot.
-                if let Ok(payload) = self.snapshot_codec.encode(aggregate.state()) {
-                    let snap = PendingSnapshot::new(version, self.schema_version, payload);
-                    // Ignore save errors — snapshot is an optimization.
-                    let _ = self.snapshot_store.save_snapshot(aggregate.id(), &snap).await;
+        if !events.is_empty() {
+            if let Some(new_version) = aggregate.version() {
+                let event_names: Vec<&str> = events.iter().map(|e| e.name()).collect();
+                if self.trigger.should_snapshot(old_version, new_version, &event_names) {
+                    self.try_save_snapshot(aggregate, new_version).await;
                 }
             }
         }
 
         Ok(())
+    }
+}
+
+impl<R, SS, SC, T> Snapshotting<R, SS, SC, T>
+where
+    SS: SnapshotStore,
+{
+    /// Try to load a snapshot. Returns (root, next_version_to_replay) on hit.
+    /// Returns None on miss, schema mismatch, or any error (best-effort).
+    async fn try_load_from_snapshot<A>(
+        &self,
+        id: &A::Id,
+    ) -> Option<(AggregateRoot<A>, Version)>
+    where
+        A: Aggregate,
+        SC: Codec<A::State>,
+    {
+        let holder = self.snapshot_store.load_snapshot(id).await.ok()??;
+
+        if holder.schema_version() != self.schema_version {
+            return None;
+        }
+
+        let state = self
+            .snapshot_codec
+            .decode("", holder.payload())
+            .ok()?;
+
+        let version = holder.version();
+        let root = AggregateRoot::<A>::restore(id.clone(), state, version);
+        let next = version.next()?;
+        Some((root, next))
+    }
+
+    /// Best-effort snapshot save. Errors are silently ignored.
+    async fn try_save_snapshot<A>(
+        &self,
+        aggregate: &AggregateRoot<A>,
+        version: Version,
+    )
+    where
+        A: Aggregate,
+        SC: Codec<A::State>,
+    {
+        if let Ok(payload) = self.snapshot_codec.encode(aggregate.state()) {
+            let snap = PendingSnapshot::new(version, self.schema_version, payload);
+            let _ = self.snapshot_store.save_snapshot(aggregate.id(), &snap).await;
+        }
     }
 }
 ```
@@ -1164,12 +1295,7 @@ mod snapshotting;
 pub use snapshotting::Snapshotting;
 ```
 
-Update `lib.rs` to re-export:
-
-```rust
-#[cfg(feature = "snapshot")]
-pub use store::Snapshotting;
-```
+Update `lib.rs` to re-export `Snapshotting`.
 
 **Step 4: Run tests**
 
@@ -1179,12 +1305,12 @@ Expected: PASS
 **Step 5: Commit**
 
 ```
-feat(store): add Snapshotting repository decorator
+feat(store): add Snapshotting repository decorator with lazy on-read support
 ```
 
 ---
 
-### Task 10: Builder integration
+### Task 9: Builder integration
 
 **Files:**
 - Modify: `crates/nexus-store/src/store/builder.rs`
@@ -1194,64 +1320,24 @@ feat(store): add Snapshotting repository decorator
 
 **Step 1: Write builder tests**
 
-Add to `snapshot_tests.rs`:
-
-```rust
-#[cfg(all(feature = "snapshot", feature = "testing", feature = "json"))]
-mod builder_tests {
-    use std::num::NonZeroU64;
-    use nexus_store::{Store, Repository};
-    use nexus_store::snapshot::{EveryNEvents, InMemorySnapshotStore};
-    use nexus_store::testing::InMemoryStore;
-
-    #[tokio::test]
-    async fn builder_produces_snapshotting_repository() {
-        let raw = InMemoryStore::default();
-        let store = Store::new(raw);
-        let snap_store = InMemorySnapshotStore::new();
-
-        let repo = store
-            .repository()
-            .snapshot_store(snap_store)
-            .snapshot_trigger(EveryNEvents(NonZeroU64::new(100).unwrap()))
-            .snapshot_schema_version(1)
-            .build();
-
-        // Verify it compiles and implements Repository — load an empty aggregate
-        // (use existing test aggregate type)
-    }
-
-    #[tokio::test]
-    async fn builder_without_snapshot_produces_plain_event_store() {
-        let raw = InMemoryStore::default();
-        let store = Store::new(raw);
-
-        let repo = store.repository().build();
-        // This should still work exactly as before
-    }
-}
-```
+Add to `snapshot_tests.rs` a `builder_tests` module that verifies the builder API compiles and produces working repositories. Test both `build()` and `build_zero_copy()` with snapshot config.
 
 **Step 2: Implement builder changes**
 
 Add typestate marker and snapshot config to `builder.rs`:
 
 ```rust
-#[cfg(feature = "snapshot")]
-use crate::snapshot::{SnapshotStore, SnapshotTrigger, EveryNEvents};
-#[cfg(feature = "snapshot")]
-use super::snapshotting::Snapshotting;
-
 /// Marker: no snapshot configured (default).
 pub struct NoSnapshot;
 
-/// Snapshot configuration.
+/// Snapshot configuration, created by builder methods.
 #[cfg(feature = "snapshot")]
-pub struct WithSnapshot<SS, SC> {
+pub struct WithSnapshot<SS, SC, T> {
     store: SS,
     codec: SC,
-    trigger: Box<dyn SnapshotTrigger>,
+    trigger: T,
     schema_version: u32,
+    snapshot_on_read: bool,
 }
 ```
 
@@ -1266,80 +1352,80 @@ pub struct RepositoryBuilder<S, C, U, Snap = NoSnapshot> {
 }
 ```
 
+Existing `.codec()` and `.upcaster()` methods carry `Snap` through. Existing `.build()` for `NoSnapshot` returns `EventStore` unchanged.
+
 Add snapshot builder methods (feature-gated):
 
 ```rust
 #[cfg(feature = "snapshot")]
 impl<S, C, U> RepositoryBuilder<S, C, U, NoSnapshot> {
     /// Configure a snapshot store, transitioning the builder to snapshot mode.
-    ///
-    /// After calling this, `.build()` will produce a `Snapshotting` repository
-    /// instead of a plain `EventStore`.
-    #[must_use]
     pub fn snapshot_store<SS: SnapshotStore>(
         self,
         snapshot_store: SS,
-    ) -> RepositoryBuilder<S, C, U, WithSnapshot<SS, NeedsSnapshotCodec>> {
-        // NeedsSnapshotCodec is !Send, like NeedsCodec
-        // ... (or default to JsonCodec with snapshot-json feature)
+    ) -> RepositoryBuilder<S, C, U, WithSnapshot<SS, /* codec */, EveryNEvents>> {
+        // Default trigger: EveryNEvents(100)
+        // Default schema_version: 1
+        // Default snapshot_on_read: false
+        // Snapshot codec: NeedsSnapshotCodec or JsonCodec (with snapshot-json feature)
     }
 }
 ```
 
-Handle snapshot codec defaulting (with `snapshot-json` feature):
-
-```rust
-#[cfg(all(feature = "snapshot-json"))]
-impl<S, C, U, SS> RepositoryBuilder<S, C, U, WithSnapshot<SS, NeedsSnapshotCodec>> {
-    // Auto-fill JsonCodec as default snapshot codec
-}
-```
+Add `.snapshot_codec()`, `.snapshot_trigger()`, `.snapshot_schema_version()`, `.snapshot_on_read()` methods on the `WithSnapshot` state.
 
 Add `.build()` for `WithSnapshot`:
 
 ```rust
 #[cfg(feature = "snapshot")]
-impl<S, C, U, SS, SC> RepositoryBuilder<S, C, U, WithSnapshot<SS, SC>>
+impl<S, C, U, SS, SC, T> RepositoryBuilder<S, C, U, WithSnapshot<SS, SC, T>>
 where
     S: RawEventStore,
     C: Send + Sync + 'static,
     SC: Send + Sync + 'static,
 {
     #[must_use]
-    pub fn build(self) -> Snapshotting<EventStore<S, C, U>, SS, SC> {
+    pub fn build(self) -> Snapshotting<EventStore<S, C, U>, SS, SC, T> {
         let inner = EventStore::new(self.store, self.codec, self.upcaster);
         let snap = self.snapshot;
-        Snapshotting::new(inner, snap.store, snap.codec, snap.trigger, snap.schema_version)
+        Snapshotting::new(inner, snap.store, snap.codec, snap.trigger, snap.schema_version, snap.snapshot_on_read)
     }
 
     #[must_use]
-    pub fn build_zero_copy(self) -> Snapshotting<ZeroCopyEventStore<S, C, U>, SS, SC> {
+    pub fn build_zero_copy(self) -> Snapshotting<ZeroCopyEventStore<S, C, U>, SS, SC, T> {
         let inner = ZeroCopyEventStore::new(self.store, self.codec, self.upcaster);
         let snap = self.snapshot;
-        Snapshotting::new(inner, snap.store, snap.codec, snap.trigger, snap.schema_version)
+        Snapshotting::new(inner, snap.store, snap.codec, snap.trigger, snap.schema_version, snap.snapshot_on_read)
     }
 }
 ```
 
-**Note:** The existing `.build()` for `NoSnapshot` returns `EventStore` — unchanged. The new `.build()` for `WithSnapshot` returns `Snapshotting<EventStore, ...>`. Both implement `Repository<A>`, so callers don't care which one they get.
-
-Exact method signatures, `NeedsSnapshotCodec` guard, and `snapshot-json` defaulting should follow the same pattern as the existing `NeedsCodec` / `json` feature for event codecs.
-
-**Step 3: Update module exports**
-
-In `store/mod.rs`, add:
+**Usage:**
 
 ```rust
-pub use builder::NoSnapshot;
-#[cfg(feature = "snapshot")]
-pub use builder::WithSnapshot;
+// No snapshots — unchanged
+let repo = store.repository().build();
+
+// With snapshots (snapshot-json feature auto-wires JsonCodec)
+let repo = store.repository()
+    .snapshot_store(fjall_snapshots)
+    .snapshot_trigger(EveryNEvents(NonZeroU64::new(100).unwrap()))
+    .build();
+
+// Custom snapshot codec + semantic trigger + lazy on-read
+let repo = store.repository()
+    .snapshot_store(fjall_snapshots)
+    .snapshot_codec(RkyvCodec)
+    .snapshot_trigger(AfterEventTypes::new(&["OrderCompleted"]))
+    .snapshot_on_read(true)
+    .build();
 ```
 
-**Step 4: Run tests**
+**Step 3: Run tests**
 
 Run: `cargo test -p nexus-store --features "snapshot,json,testing" -- builder_tests`
 
-**Step 5: Commit**
+**Step 4: Commit**
 
 ```
 feat(store): integrate snapshot config into RepositoryBuilder
@@ -1347,7 +1433,7 @@ feat(store): integrate snapshot config into RepositoryBuilder
 
 ---
 
-### Task 11: Full integration test suite
+### Task 10: Full integration test suite
 
 **Files:**
 - Modify: `crates/nexus-store/tests/snapshot_integration_tests.rs`
@@ -1358,10 +1444,12 @@ Write comprehensive tests covering the 4 mandatory test categories from CLAUDE.m
 - Save N events → snapshot triggers → load → partial replay → save more → snapshot again
 - Save below threshold → no snapshot → save more → crosses threshold → snapshot
 - Multiple save/load cycles with snapshot invalidation in between
+- Batch saves that cross boundaries at non-multiples (the audit-discovered bug scenario)
 
 **2. Lifecycle Tests:**
 - Create aggregate → save → snapshot → load from snapshot → verify state
 - Load from snapshot → save more events → load again → verify new snapshot version used
+- Lazy on-read: full replay creates snapshot → subsequent load uses it
 
 **3. Defensive Boundary Tests:**
 - Empty event slice save (no-op, no snapshot trigger)
@@ -1370,6 +1458,7 @@ Write comprehensive tests covering the 4 mandatory test categories from CLAUDE.m
 - Snapshot codec returns error → fallback to full replay
 - Snapshot store returns error on load → fallback to full replay
 - Snapshot store returns error on save → event save still succeeds
+- AfterEventTypes with empty event names → no trigger
 
 **4. Linearizability/Isolation Tests:**
 - Concurrent loads from same snapshot → each gets independent copy
@@ -1385,7 +1474,7 @@ test(store): comprehensive snapshot integration tests
 
 ---
 
-### Task 12: Fjall snapshot adapter
+### Task 11: Fjall snapshot adapter
 
 **Files:**
 - Modify: `crates/nexus-fjall/Cargo.toml`
@@ -1443,7 +1532,7 @@ pub(crate) fn decode_snapshot_value(
     value: &[u8],
 ) -> Result<(u32, u64, &[u8]), DecodeError> {
     if value.len() < SNAPSHOT_VALUE_HEADER_SIZE {
-        return Err(DecodeError::ValueTooShort { ... });
+        return Err(DecodeError::ValueTooShort { min: SNAPSHOT_VALUE_HEADER_SIZE, actual: value.len() });
     }
     let schema_version = u32::from_le_bytes(value[0..4].try_into().unwrap());
     let version = u64::from_be_bytes(value[4..12].try_into().unwrap());
@@ -1463,17 +1552,17 @@ Extend `FjallStoreBuilder` with `.snapshots_config()` method and create the part
 The implementation needs to:
 1. Look up numeric stream ID from the `streams` partition
 2. Read/write the `snapshots` partition using that numeric ID as key
+3. `delete_snapshot`: remove the key from the `snapshots` partition
 
 Implement behind `#[cfg(feature = "snapshot")]`.
 
 **Step 6: Write tests**
 
-Key tests:
-- Save snapshot → load snapshot roundtrip
-- Overwrite snapshot → latest returned
-- Load from nonexistent stream → None
-- Corrupt snapshot value → error
-- Close and reopen → snapshot persisted
+Key tests (4 categories):
+- **Sequence:** Save snapshot → load → overwrite → load latest
+- **Lifecycle:** Save → close → reopen → snapshot persisted
+- **Defensive:** Load from nonexistent stream → None; corrupt snapshot value → error
+- **Isolation:** Concurrent snapshot reads don't interfere
 
 **Step 7: Commit**
 
@@ -1483,7 +1572,7 @@ feat(fjall): add FjallSnapshotStore with dedicated snapshot partition
 
 ---
 
-### Task 13: Update re-exports and run full CI suite
+### Task 12: Update re-exports and run full CI suite
 
 **Files:**
 - Modify: `crates/nexus-store/src/lib.rs` (ensure all snapshot types re-exported)
@@ -1496,9 +1585,11 @@ Ensure `lib.rs` has:
 ```rust
 #[cfg(feature = "snapshot")]
 pub use snapshot::{
-    EveryNEvents, InMemorySnapshotStore, NeverSnapshot,
-    PendingSnapshot, SnapshotRead, SnapshotStore, SnapshotTrigger,
+    AfterEventTypes, EveryNEvents, PendingSnapshot, PersistedSnapshot,
+    SnapshotStore, SnapshotTrigger,
 };
+#[cfg(all(feature = "snapshot", feature = "testing"))]
+pub use snapshot::InMemorySnapshotStore;
 ```
 
 **Step 2: Run full test suite**
@@ -1534,4 +1625,29 @@ cargo hakari verify
 
 ```
 chore(store): finalize snapshot re-exports and verify CI
+```
+
+---
+
+### Task 13: Update design doc with performance guidance
+
+**Files:**
+- Modify: `docs/plans/2026-04-10-snapshot-design.md`
+
+Add a "When to use snapshots" section with benchmark guidance:
+
+| Event Count | Snapshot Value |
+|-------------|---------------|
+| < 50 | Always hurts — overhead exceeds benefit |
+| 50–200 | Rarely helps unless deserialization is expensive |
+| 200–500 | Measure. Depends on event size and apply complexity |
+| 500+ | Likely helps |
+| 10,000+ | Essential — but also consider "Closing the Books" pattern (see #139) |
+
+Document the preferred alternative: short-lived streams with natural lifecycle boundaries eliminate the need for snapshots entirely. Reference issue #139.
+
+**Commit:**
+
+```
+docs: add snapshot performance guidance and alternatives
 ```


### PR DESCRIPTION
## Summary

- Aggregate snapshot infrastructure for fast rehydration — load latest snapshot, replay only subsequent events
- `SnapshotStore` trait (raw bytes, adapter-implemented) with `()` no-op eliminating dead code at compile time
- `SnapshotTrigger` as monomorphized type parameter — `EveryNEvents` (boundary-crossing safe) and `AfterEventTypes` (semantic)
- `Snapshotting` repository decorator, transparent to callers (same `Repository<A>` trait)
- `FjallSnapshotStore` with dedicated point-read partition
- `AggregateRoot::restore()` kernel constructor for snapshot rehydration
- `ReplayFrom` trait for shared replay logic
- `NonZeroU32` schema version — compile-time elimination of invalid version 0
- Feature-gated: `snapshot` / `snapshot-json`, zero overhead when disabled
- Lazy snapshotting (snapshot-on-read) for write-heavy/IoT workloads

## Test coverage

- Unit tests for snapshot types, triggers, `InMemorySnapshotStore`
- Integration tests for `Snapshotting` decorator (load/save, schema mismatch, lazy snapshotting)
- Fjall snapshot tests (persistence, lifecycle, concurrent access)

Closes #123