### PR TITLE
feat(store): projection core traits + runner design (#155, #157)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,120 +1,103 @@
 # Nexus
 
-> A zero-compromise **event-sourcing** & **CQRS** kernel for Rust.
+Event sourcing for Rust — no `Box<dyn>`, no runtime downcasting, no hidden allocations.
 
-[![crates.io](https://img.shields.io/crates/v/nexus.svg)](https://crates.io/crates/nexus)
-[![docs.rs](https://img.shields.io/docsrs/nexus/latest)](https://docs.rs/nexus)
 [![CI](https://github.com/devrandom-labs/nexus/actions/workflows/checks.yml/badge.svg)](https://github.com/devrandom-labs/nexus/actions/workflows/checks.yml)
-[![license](https://img.shields.io/crates/l/nexus)](LICENSE-MIT)
-
-Nexus is a pure, synchronous, zero-dependency kernel for building event-sourced applications in Rust. It provides maximum compile-time type safety with no `Box<dyn>`, no runtime downcasting, and no hidden allocations.
-
-## Quick Start
+[![license](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](LICENSE-MIT)
 
 ```rust
-use nexus::prelude::*;
+use nexus::*;
 
-// 1. Define your events
+#[derive(Debug, Clone, DomainEvent)]
+enum Event {
+    Deposited(Deposited),
+    Withdrawn(Withdrawn),
+}
+
 #[derive(Debug, Clone)]
-enum UserEvent {
-    Created { name: String },
-    Activated,
-}
+struct Deposited { amount: u64 }
+#[derive(Debug, Clone)]
+struct Withdrawn { amount: u64 }
 
-impl DomainEvent for UserEvent {
-    fn name(&self) -> &'static str {
-        match self {
-            Self::Created { .. } => "UserCreated",
-            Self::Activated => "UserActivated",
-        }
-    }
-}
+#[derive(Default, Debug, Clone)]
+struct Account { balance: u64 }
 
-// 2. Define your state
-#[derive(Default, Debug)]
-struct UserState {
-    name: String,
-    active: bool,
-}
-
-impl AggregateState for UserState {
-    type Event = UserEvent;
-
+impl AggregateState for Account {
+    type Event = Event;
     fn initial() -> Self { Self::default() }
-
-    fn apply(mut self, event: &UserEvent) -> Self {
+    fn apply(mut self, event: &Event) -> Self {
         match event {
-            UserEvent::Created { name } => self.name = name.clone(),
-            UserEvent::Activated => self.active = true,
+            Event::Deposited(e) => self.balance += e.amount,
+            Event::Withdrawn(e) => self.balance -= e.amount,
         }
         self
     }
-
-    fn name(&self) -> &'static str { "User" }
 }
 
-// 3. Use it
-let mut user = AggregateRoot::<UserAggregate>::new(id);
-user.apply(UserEvent::Created { name: "Alice".into() });
-user.apply(UserEvent::Activated);
+#[nexus::aggregate(state = Account, error = BankError, id = AccountId)]
+struct BankAccount;
 
-let events = user.take_uncommitted_events();
-assert_eq!(events.len(), 2);
+struct Deposit { amount: u64 }
+
+impl Handle<Deposit> for BankAccount {
+    fn handle(&self, cmd: Deposit) -> Result<Events<Event>, BankError> {
+        Ok(events![Event::Deposited(Deposited { amount: cmd.amount })])
+    }
+}
 ```
 
-## Design Principles
+## Why Nexus?
 
-- **Concrete event enums** -- the compiler enforces exhaustive event handling via `match`. No `Box<dyn Any>`.
-- **Marker-trait aggregates** -- `Aggregate` binds `State`, `Error`, and `Id` at the type level. One generic parameter.
-- **Encapsulated versioning** -- `Version` and `VersionedEvent` cannot be forged. The kernel controls all version assignment.
-- **Value-semantic state transitions** -- `apply(self, &Event) -> Self` consumes and returns state for atomic transitions.
-- **Minimal error surface** -- `KernelError` has a single variant. Infrastructure errors belong in outer layers.
+**Concrete event enums, not trait objects.** Events are plain Rust enums. `match` is exhaustive — the compiler catches every missing handler at build time. No `Box<dyn Any>`, no runtime downcasting, no message bus plumbing.
+
+**`no_std` / `no_alloc` kernel.** The core crate has zero dependencies on `std` allocation. `Events<E, N>` uses `ArrayVec` with const generics — `N = 0` (the default) means a single event with no heap allocation at all. The kernel compiles for embedded and WASM targets.
+
+**Zero-copy read path.** `BorrowingCodec` decodes events directly from database buffers via GAT lending iterators. No deserialization into owned structs on the read path — rkyv and flatbuffers plug in directly.
 
 ## Crates
 
 | Crate | Description |
 |-------|-------------|
-| [`nexus`](https://crates.io/crates/nexus) | Core kernel -- aggregates, events, versioning |
-| [`nexus-macros`](https://crates.io/crates/nexus-macros) | Derive macros (`DomainEvent`, `Command`, `Query`, `Aggregate`) |
-| [`nexus-store`](https://crates.io/crates/nexus-store) | Event store edge layer -- codecs, streams, upcasters, repositories |
+| [`nexus`](crates/nexus) | Kernel — aggregates, events, versioning, command handling |
+| [`nexus-macros`](crates/nexus-macros) | Derive macros — `DomainEvent`, `#[aggregate]`, `#[transforms]` |
+| [`nexus-store`](crates/nexus-store) | Persistence edge — codecs, event streams, upcasters, repositories |
+| [`nexus-fjall`](crates/nexus-fjall) | Embedded LSM-tree event store adapter (fjall) |
 
-## Verification
+## Features
 
-The kernel is tested with 10 verification techniques:
+- Schema evolution via `#[nexus::transforms]` upcasters
+- Optimistic concurrency with version-checked appends
+- Allocation-free errors (`ArrayString`-based, no heap on error paths)
+- Aggregate snapshots with `AggregateRoot::restore`
+- Verified with proptest, miri, mutation testing, trybuild, and criterion
 
-| Technique | What it proves |
-|-----------|---------------|
-| Unit tests + edge cases | Correct behavior |
-| Property-based testing (proptest) | Algebraic properties hold for all random inputs |
-| Compile-failure tests (trybuild) | Invalid code fails to compile |
-| Static assertions | Send, Sync, size, trait bounds enforced at compile time |
-| Miri | Zero undefined behavior under strict provenance |
-| Mutation testing (cargo-mutants) | Every viable mutation caught |
-| Contract invariants (debug_assert!) | Version arithmetic verified in debug builds |
-| Benchmarks (criterion) | Performance regression detection |
-| Doc tests | All examples compile and run |
-| Architecture tests | Kernel imports nothing from outer layers |
+## Getting Started
 
-## Development
+Kernel only (pure domain logic, no persistence):
 
-Prerequisites: [Nix](https://nixos.org/) with flakes enabled.
-
-```bash
-nix develop          # enter dev shell
-cargo test --all     # run all tests
-cargo clippy --all-targets -- --deny warnings
-nix flake check      # full CI suite locally
+```toml
+[dependencies]
+nexus = { git = "https://github.com/devrandom-labs/nexus", features = ["derive"] }
 ```
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
+With persistence (fjall embedded store):
+
+```toml
+[dependencies]
+nexus = { git = "https://github.com/devrandom-labs/nexus", features = ["derive"] }
+nexus-store = { git = "https://github.com/devrandom-labs/nexus" }
+nexus-fjall = { git = "https://github.com/devrandom-labs/nexus" }
+```
+
+See the [examples](examples/) for complete working code:
+- [`inmemory`](examples/inmemory) — pure in-memory event sourcing (bank account domain)
+- [`store-inmemory`](examples/store-inmemory) — all store traits with `InMemoryStore`, including codec and upcasting
+- [`store-and-kernel`](examples/store-and-kernel) — full lifecycle: create, decide, encode, persist, read, decode, rehydrate
 
 ## Status
 
-Nexus is **experimental** with an unstable API. The kernel layer is solid and heavily tested; the store layer is under active development.
+Nexus is **experimental** with an unstable API. The kernel is well-tested (proptest, miri, mutation testing, trybuild). The store and fjall adapter are under active development.
 
 ## License
 
-Licensed under your choice of:
-
-- [MIT license](LICENSE-MIT)
-- [Apache License, Version 2.0](LICENSE-APACHE)
+Licensed under your choice of [MIT](LICENSE-MIT) or [Apache-2.0](LICENSE-APACHE).

--- a/crates/nexus-macros/README.md
+++ b/crates/nexus-macros/README.md
@@ -1,33 +1,43 @@
 # nexus-macros
 
-Procedural macros that eliminate boilerplate when using [`nexus`](https://crates.io/crates/nexus).
+Procedural macros for [`nexus`](../nexus). Three macros, zero boilerplate.
 
-Currently exported derives:
+## `#[derive(DomainEvent)]`
 
-* `Command`
-* `Query`
-* `DomainEvent`
-
-## Example
+Derive on an enum. Generates `Message` + `DomainEvent` impls with `name()` returning variant names as `&'static str`.
 
 ```rust
-use nexus_macros::{Command, DomainEvent};
-
-#[derive(Command)]
-#[command(result = "()", error = "MyError")]
-pub struct DoSomething {
-    pub id: u32,
-}
-
-#[derive(DomainEvent)]
-#[domain_event(name = "SomethingHappened")]
-pub struct SomethingHappened {
-    pub id: u32,
+#[derive(Debug, Clone, DomainEvent)]
+enum AccountEvent {
+    Opened(AccountOpened),
+    Deposited(MoneyDeposited),
+    Closed(AccountClosed),
 }
 ```
 
-See the crate documentation (`cargo doc --open`) for detailed usage.
+## `#[nexus::aggregate]`
 
----
+Attribute macro on a unit struct. Generates `Aggregate` impl, `AggregateEntity` impl, newtype wrapping `AggregateRoot`, `new(id)` constructor, and redacted `Debug`.
 
-Licensed under Apache-2.0. 
+```rust
+#[nexus::aggregate(state = AccountState, error = AccountError, id = AccountId)]
+struct BankAccount;
+```
+
+## `#[nexus::transforms]`
+
+Attribute macro on an impl block. Generates an `Upcaster` impl for schema evolution. Transform functions are annotated with `#[transform(event = "...", from = N, to = N+1)]`.
+
+```rust
+#[nexus::transforms(aggregate = BankAccount, error = MyUpcastError)]
+impl BankAccountTransforms {
+    #[transform(event = "Deposited", from = 1, to = 2)]
+    fn add_currency(payload: &[u8]) -> Result<Vec<u8>, MyUpcastError> {
+        // migrate v1 → v2
+    }
+}
+```
+
+## License
+
+Licensed under your choice of [MIT](../../LICENSE-MIT) or [Apache-2.0](../../LICENSE-APACHE).

--- a/crates/nexus-store/Cargo.toml
+++ b/crates/nexus-store/Cargo.toml
@@ -16,6 +16,8 @@ serde = ["dep:serde"]
 json = ["serde", "dep:serde_json"]
 snapshot = []
 snapshot-json = ["snapshot", "json"]
+projection = []
+projection-json = ["projection", "json"]
 
 [dependencies]
 arrayvec = { workspace = true }

--- a/crates/nexus-store/src/lib.rs
+++ b/crates/nexus-store/src/lib.rs
@@ -20,7 +20,10 @@ pub use envelope::{PendingEnvelope, PersistedEnvelope, pending_envelope};
 pub use error::{AppendError, InvalidSchemaVersion, StoreError, UpcastError};
 pub use nexus::Version;
 #[cfg(feature = "projection")]
-pub use projection::{PendingState, PersistedState, StateStore};
+pub use projection::{
+    AfterEventTypes as ProjAfterEventTypes, EveryNEvents as ProjEveryNEvents, PendingState,
+    PersistedState, ProjectionTrigger, StateStore,
+};
 #[cfg(all(feature = "snapshot", feature = "testing"))]
 pub use snapshot::InMemorySnapshotStore;
 #[cfg(feature = "snapshot")]

--- a/crates/nexus-store/src/lib.rs
+++ b/crates/nexus-store/src/lib.rs
@@ -20,7 +20,7 @@ pub use envelope::{PendingEnvelope, PersistedEnvelope, pending_envelope};
 pub use error::{AppendError, InvalidSchemaVersion, StoreError, UpcastError};
 pub use nexus::Version;
 #[cfg(feature = "projection")]
-pub use projection::{PendingState, PersistedState};
+pub use projection::{PendingState, PersistedState, StateStore};
 #[cfg(all(feature = "snapshot", feature = "testing"))]
 pub use snapshot::InMemorySnapshotStore;
 #[cfg(feature = "snapshot")]

--- a/crates/nexus-store/src/lib.rs
+++ b/crates/nexus-store/src/lib.rs
@@ -19,6 +19,8 @@ pub use codec::{BorrowingCodec, Codec};
 pub use envelope::{PendingEnvelope, PersistedEnvelope, pending_envelope};
 pub use error::{AppendError, InvalidSchemaVersion, StoreError, UpcastError};
 pub use nexus::Version;
+#[cfg(all(feature = "projection", feature = "testing"))]
+pub use projection::InMemoryStateStore;
 #[cfg(feature = "projection")]
 pub use projection::{
     AfterEventTypes as ProjAfterEventTypes, EveryNEvents as ProjEveryNEvents, PendingState,

--- a/crates/nexus-store/src/lib.rs
+++ b/crates/nexus-store/src/lib.rs
@@ -24,7 +24,7 @@ pub use projection::InMemoryStateStore;
 #[cfg(feature = "projection")]
 pub use projection::{
     AfterEventTypes as ProjAfterEventTypes, EveryNEvents as ProjEveryNEvents, PendingState,
-    PersistedState, ProjectionTrigger, StateStore,
+    PersistedState, ProjectionTrigger, Projector, StateStore,
 };
 #[cfg(all(feature = "snapshot", feature = "testing"))]
 pub use snapshot::InMemorySnapshotStore;

--- a/crates/nexus-store/src/lib.rs
+++ b/crates/nexus-store/src/lib.rs
@@ -1,6 +1,8 @@
 pub mod codec;
 pub mod envelope;
 pub mod error;
+#[cfg(feature = "projection")]
+pub mod projection;
 #[cfg(feature = "snapshot")]
 pub mod snapshot;
 pub mod store;
@@ -17,6 +19,8 @@ pub use codec::{BorrowingCodec, Codec};
 pub use envelope::{PendingEnvelope, PersistedEnvelope, pending_envelope};
 pub use error::{AppendError, InvalidSchemaVersion, StoreError, UpcastError};
 pub use nexus::Version;
+#[cfg(feature = "projection")]
+pub use projection::{PendingState, PersistedState};
 #[cfg(all(feature = "snapshot", feature = "testing"))]
 pub use snapshot::InMemorySnapshotStore;
 #[cfg(feature = "snapshot")]

--- a/crates/nexus-store/src/projection/mod.rs
+++ b/crates/nexus-store/src/projection/mod.rs
@@ -1,5 +1,7 @@
 mod pending;
 mod persisted;
+mod store;
 
 pub use pending::PendingState;
 pub use persisted::PersistedState;
+pub use store::StateStore;

--- a/crates/nexus-store/src/projection/mod.rs
+++ b/crates/nexus-store/src/projection/mod.rs
@@ -1,0 +1,5 @@
+mod pending;
+mod persisted;
+
+pub use pending::PendingState;
+pub use persisted::PersistedState;

--- a/crates/nexus-store/src/projection/mod.rs
+++ b/crates/nexus-store/src/projection/mod.rs
@@ -1,9 +1,13 @@
 mod pending;
 mod persisted;
 mod store;
+#[cfg(feature = "testing")]
+mod testing;
 mod trigger;
 
 pub use pending::PendingState;
 pub use persisted::PersistedState;
 pub use store::StateStore;
+#[cfg(feature = "testing")]
+pub use testing::InMemoryStateStore;
 pub use trigger::{AfterEventTypes, EveryNEvents, ProjectionTrigger};

--- a/crates/nexus-store/src/projection/mod.rs
+++ b/crates/nexus-store/src/projection/mod.rs
@@ -1,5 +1,6 @@
 mod pending;
 mod persisted;
+mod projector;
 mod store;
 #[cfg(feature = "testing")]
 mod testing;
@@ -7,6 +8,7 @@ mod trigger;
 
 pub use pending::PendingState;
 pub use persisted::PersistedState;
+pub use projector::Projector;
 pub use store::StateStore;
 #[cfg(feature = "testing")]
 pub use testing::InMemoryStateStore;

--- a/crates/nexus-store/src/projection/mod.rs
+++ b/crates/nexus-store/src/projection/mod.rs
@@ -1,7 +1,9 @@
 mod pending;
 mod persisted;
 mod store;
+mod trigger;
 
 pub use pending::PendingState;
 pub use persisted::PersistedState;
 pub use store::StateStore;
+pub use trigger::{AfterEventTypes, EveryNEvents, ProjectionTrigger};

--- a/crates/nexus-store/src/projection/pending.rs
+++ b/crates/nexus-store/src/projection/pending.rs
@@ -1,0 +1,44 @@
+use std::num::NonZeroU32;
+
+use nexus::Version;
+
+/// Projection state payload ready for persistence (write path).
+///
+/// Contains the serialized projection state, the stream version at
+/// state computation time, and a schema version for invalidation.
+#[derive(Debug, Clone)]
+pub struct PendingState {
+    version: Version,
+    schema_version: NonZeroU32,
+    payload: Vec<u8>,
+}
+
+impl PendingState {
+    /// Create a new pending projection state.
+    #[must_use]
+    pub const fn new(version: Version, schema_version: NonZeroU32, payload: Vec<u8>) -> Self {
+        Self {
+            version,
+            schema_version,
+            payload,
+        }
+    }
+
+    /// The stream version at the time of state computation.
+    #[must_use]
+    pub const fn version(&self) -> Version {
+        self.version
+    }
+
+    /// The schema version for invalidation checking.
+    #[must_use]
+    pub const fn schema_version(&self) -> NonZeroU32 {
+        self.schema_version
+    }
+
+    /// The serialized state bytes.
+    #[must_use]
+    pub fn payload(&self) -> &[u8] {
+        &self.payload
+    }
+}

--- a/crates/nexus-store/src/projection/persisted.rs
+++ b/crates/nexus-store/src/projection/persisted.rs
@@ -1,0 +1,44 @@
+use std::num::NonZeroU32;
+
+use nexus::Version;
+
+/// Persisted projection state loaded from storage (read path).
+///
+/// Owns the payload bytes. A borrowing variant with GAT lifetimes
+/// can be added later if benchmarks justify it.
+#[derive(Debug, Clone)]
+pub struct PersistedState {
+    version: Version,
+    schema_version: NonZeroU32,
+    payload: Vec<u8>,
+}
+
+impl PersistedState {
+    /// Create a new persisted projection state.
+    #[must_use]
+    pub const fn new(version: Version, schema_version: NonZeroU32, payload: Vec<u8>) -> Self {
+        Self {
+            version,
+            schema_version,
+            payload,
+        }
+    }
+
+    /// The stream version at the time of state computation.
+    #[must_use]
+    pub const fn version(&self) -> Version {
+        self.version
+    }
+
+    /// The schema version for invalidation checking.
+    #[must_use]
+    pub const fn schema_version(&self) -> NonZeroU32 {
+        self.schema_version
+    }
+
+    /// The serialized state bytes.
+    #[must_use]
+    pub fn payload(&self) -> &[u8] {
+        &self.payload
+    }
+}

--- a/crates/nexus-store/src/projection/projector.rs
+++ b/crates/nexus-store/src/projection/projector.rs
@@ -35,5 +35,10 @@ pub trait Projector: Send + Sync + 'static {
     /// Must use checked arithmetic for all computations. Return `Err`
     /// on overflow, underflow, or any domain-specific invariant
     /// violation. The framework decides recovery policy.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Self::Error` when the event cannot be applied — e.g.,
+    /// arithmetic overflow, underflow, or domain invariant violation.
     fn apply(&self, state: Self::State, event: &Self::Event) -> Result<Self::State, Self::Error>;
 }

--- a/crates/nexus-store/src/projection/projector.rs
+++ b/crates/nexus-store/src/projection/projector.rs
@@ -1,0 +1,39 @@
+use nexus::DomainEvent;
+
+/// A pure fold function over domain events.
+///
+/// Processes events one at a time to produce derived state. The
+/// framework handles all IO (reading events, persisting state,
+/// checkpointing). The projector is only responsible for computation.
+///
+/// Fallible: `apply` returns `Result` because projections may perform
+/// checked arithmetic or encounter domain-specific edge cases.
+/// Recovery policy (skip, fail, dead-letter) is handled by middleware
+/// layers, not the projector itself.
+///
+/// # Comparison with `AggregateState`
+///
+/// `AggregateState::apply` is infallible because an aggregate always
+/// applies its own events. A projector may process events from any
+/// source, and may do derived computations (sums, counts) that can
+/// overflow.
+pub trait Projector: Send + Sync + 'static {
+    /// The domain event type this projector handles.
+    type Event: DomainEvent;
+
+    /// The derived state produced by folding events.
+    type State: Send + Sync + 'static;
+
+    /// Error type for fallible projection logic.
+    type Error: core::error::Error + Send + Sync + 'static;
+
+    /// The initial state before any events have been applied.
+    fn initial(&self) -> Self::State;
+
+    /// Apply a single event to the current state, producing new state.
+    ///
+    /// Must use checked arithmetic for all computations. Return `Err`
+    /// on overflow, underflow, or any domain-specific invariant
+    /// violation. The framework decides recovery policy.
+    fn apply(&self, state: Self::State, event: &Self::Event) -> Result<Self::State, Self::Error>;
+}

--- a/crates/nexus-store/src/projection/store.rs
+++ b/crates/nexus-store/src/projection/store.rs
@@ -1,0 +1,94 @@
+use std::convert::Infallible;
+use std::future::Future;
+use std::num::NonZeroU32;
+
+use nexus::Id;
+
+use super::pending::PendingState;
+use super::persisted::PersistedState;
+
+/// Byte-level projection state storage trait.
+///
+/// Adapters (fjall, postgres, etc.) implement this to persist and
+/// retrieve serialized projection state.
+///
+/// `()` is the no-op implementation: `load` always returns `None`,
+/// `save` and `delete` silently discard. Used when projection state
+/// storage is not configured.
+pub trait StateStore: Send + Sync {
+    /// Adapter-specific error type.
+    type Error: std::error::Error + Send + Sync + 'static;
+
+    /// Load the most recent state for the given projection.
+    ///
+    /// Returns `None` if no state exists or if the stored state's
+    /// schema version does not match `schema_version`. Filtering at the
+    /// store level avoids loading payload bytes for stale state.
+    fn load(
+        &self,
+        id: &impl Id,
+        schema_version: NonZeroU32,
+    ) -> impl Future<Output = Result<Option<PersistedState>, Self::Error>> + Send;
+
+    /// Persist projection state.
+    ///
+    /// Overwrites any existing state for this projection.
+    fn save(
+        &self,
+        id: &impl Id,
+        state: &PendingState,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+
+    /// Delete projection state.
+    ///
+    /// Returns `Ok(())` if no state exists (idempotent).
+    fn delete(&self, id: &impl Id) -> impl Future<Output = Result<(), Self::Error>> + Send;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Delegation implementation — share via reference
+// ═══════════════════════════════════════════════════════════════════════════
+
+impl<T: StateStore> StateStore for &T {
+    type Error = T::Error;
+
+    async fn load(
+        &self,
+        id: &impl Id,
+        schema_version: NonZeroU32,
+    ) -> Result<Option<PersistedState>, Self::Error> {
+        (**self).load(id, schema_version).await
+    }
+
+    async fn save(&self, id: &impl Id, state: &PendingState) -> Result<(), Self::Error> {
+        (**self).save(id, state).await
+    }
+
+    async fn delete(&self, id: &impl Id) -> Result<(), Self::Error> {
+        (**self).delete(id).await
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// No-op implementation — projection state storage disabled
+// ═══════════════════════════════════════════════════════════════════════════
+
+impl StateStore for () {
+    type Error = Infallible;
+
+    async fn load(
+        &self,
+        _id: &impl Id,
+        _schema_version: NonZeroU32,
+    ) -> Result<Option<PersistedState>, Infallible> {
+        Ok(None)
+    }
+
+    async fn save(&self, _id: &impl Id, _state: &PendingState) -> Result<(), Infallible> {
+        Ok(())
+    }
+
+    async fn delete(&self, _id: &impl Id) -> Result<(), Infallible> {
+        Ok(())
+    }
+}

--- a/crates/nexus-store/src/projection/testing.rs
+++ b/crates/nexus-store/src/projection/testing.rs
@@ -49,9 +49,8 @@ impl StateStore for InMemoryStateStore {
     }
 
     async fn save(&self, id: &impl Id, state: &PendingState) -> Result<(), Infallible> {
-        let mut states = self.states.write().await;
         let key = id.to_string();
-        states.insert(
+        self.states.write().await.insert(
             key,
             StoredState {
                 version: state.version(),
@@ -63,8 +62,7 @@ impl StateStore for InMemoryStateStore {
     }
 
     async fn delete(&self, id: &impl Id) -> Result<(), Infallible> {
-        let mut states = self.states.write().await;
-        states.remove(&id.to_string());
+        self.states.write().await.remove(&id.to_string());
         Ok(())
     }
 }

--- a/crates/nexus-store/src/projection/testing.rs
+++ b/crates/nexus-store/src/projection/testing.rs
@@ -1,0 +1,70 @@
+use std::collections::HashMap;
+use std::convert::Infallible;
+use std::num::NonZeroU32;
+
+use nexus::Id;
+use tokio::sync::RwLock;
+
+use super::pending::PendingState;
+use super::persisted::PersistedState;
+use super::store::StateStore;
+
+/// In-memory projection state store for tests.
+///
+/// Stores projection state in a `HashMap` protected by a `RwLock`.
+#[derive(Debug, Default)]
+pub struct InMemoryStateStore {
+    states: RwLock<HashMap<String, StoredState>>,
+}
+
+#[derive(Debug, Clone)]
+struct StoredState {
+    version: nexus::Version,
+    schema_version: NonZeroU32,
+    payload: Vec<u8>,
+}
+
+impl InMemoryStateStore {
+    /// Create a new empty in-memory state store.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl StateStore for InMemoryStateStore {
+    type Error = Infallible;
+
+    async fn load(
+        &self,
+        id: &impl Id,
+        schema_version: NonZeroU32,
+    ) -> Result<Option<PersistedState>, Infallible> {
+        let states = self.states.read().await;
+        let key = id.to_string();
+        Ok(states
+            .get(&key)
+            .filter(|s| s.schema_version == schema_version)
+            .map(|s| PersistedState::new(s.version, s.schema_version, s.payload.clone())))
+    }
+
+    async fn save(&self, id: &impl Id, state: &PendingState) -> Result<(), Infallible> {
+        let mut states = self.states.write().await;
+        let key = id.to_string();
+        states.insert(
+            key,
+            StoredState {
+                version: state.version(),
+                schema_version: state.schema_version(),
+                payload: state.payload().to_vec(),
+            },
+        );
+        Ok(())
+    }
+
+    async fn delete(&self, id: &impl Id) -> Result<(), Infallible> {
+        let mut states = self.states.write().await;
+        states.remove(&id.to_string());
+        Ok(())
+    }
+}

--- a/crates/nexus-store/src/projection/trigger.rs
+++ b/crates/nexus-store/src/projection/trigger.rs
@@ -1,0 +1,73 @@
+use std::num::NonZeroU64;
+
+use nexus::Version;
+
+/// Strategy for deciding when to update projection state.
+///
+/// Checked after each successful `save()`. The trigger receives both the
+/// old and new version (to detect boundary crossings regardless of batch
+/// size) and the names of events just persisted (for semantic triggers).
+pub trait ProjectionTrigger: Send + Sync {
+    /// Whether a projection state update should happen after this save.
+    ///
+    /// - `old_version`: version before save (`None` for new streams)
+    /// - `new_version`: version after save
+    /// - `event_names`: names of events just persisted (from `DomainEvent::name()`).
+    fn should_project(
+        &self,
+        old_version: Option<Version>,
+        new_version: Version,
+        event_names: impl Iterator<Item: AsRef<str>>,
+    ) -> bool;
+}
+
+/// Trigger a projection state update every N events.
+///
+/// Uses a bucket-crossing algorithm to detect when a save crosses an
+/// N-event boundary, regardless of batch size.
+#[derive(Debug, Clone, Copy)]
+pub struct EveryNEvents(pub NonZeroU64);
+
+impl ProjectionTrigger for EveryNEvents {
+    fn should_project(
+        &self,
+        old_version: Option<Version>,
+        new_version: Version,
+        _event_names: impl Iterator<Item: AsRef<str>>,
+    ) -> bool {
+        let n = self.0.get();
+        let old_bucket = old_version.map_or(0, |v| v.as_u64() / n);
+        let new_bucket = new_version.as_u64() / n;
+        new_bucket > old_bucket
+    }
+}
+
+/// Trigger a projection state update after specific event types.
+///
+/// Useful for domain milestones where a projection update aligns with
+/// business semantics.
+#[derive(Debug, Clone)]
+pub struct AfterEventTypes {
+    types: Vec<&'static str>,
+}
+
+impl AfterEventTypes {
+    /// Create a trigger that fires when any of the given event types is persisted.
+    #[must_use]
+    pub fn new(types: &[&'static str]) -> Self {
+        Self {
+            types: types.to_vec(),
+        }
+    }
+}
+
+impl ProjectionTrigger for AfterEventTypes {
+    fn should_project(
+        &self,
+        _old_version: Option<Version>,
+        _new_version: Version,
+        mut event_names: impl Iterator<Item: AsRef<str>>,
+    ) -> bool {
+        event_names.any(|name| self.types.iter().any(|t| *t == name.as_ref()))
+    }
+}

--- a/crates/nexus-store/tests/projection_tests.rs
+++ b/crates/nexus-store/tests/projection_tests.rs
@@ -175,3 +175,134 @@ fn proj_after_event_types_does_not_trigger_on_empty_events() {
     let trigger = ProjAfterEventTypes::new(&["OrderCompleted"]);
     assert!(!trigger.should_project(None, Version::new(5).unwrap(), std::iter::empty::<&str>()));
 }
+
+// ── InMemoryStateStore ───────────────────────────────────────────
+
+#[cfg(feature = "testing")]
+mod in_memory_tests {
+    use super::*;
+    use nexus_store::projection::InMemoryStateStore;
+
+    #[tokio::test]
+    async fn load_returns_none_when_empty() {
+        let store = InMemoryStateStore::new();
+        let result = store.load(&TestId("proj-1".into()), SV1).await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn save_then_load_roundtrips() {
+        let store = InMemoryStateStore::new();
+        let id = TestId("proj-1".into());
+        let version = Version::new(10).unwrap();
+        let state = PendingState::new(version, NonZeroU32::new(1).unwrap(), vec![1, 2, 3]);
+
+        store.save(&id, &state).await.unwrap();
+        let loaded = store.load(&id, SV1).await.unwrap().unwrap();
+
+        assert_eq!(loaded.version(), version);
+        assert_eq!(loaded.schema_version(), NonZeroU32::new(1).unwrap());
+        assert_eq!(loaded.payload(), &[1, 2, 3]);
+    }
+
+    #[tokio::test]
+    async fn save_overwrites_previous_state() {
+        let store = InMemoryStateStore::new();
+        let id = TestId("proj-1".into());
+
+        let state1 = PendingState::new(
+            Version::new(10).unwrap(),
+            NonZeroU32::new(1).unwrap(),
+            vec![1],
+        );
+        store.save(&id, &state1).await.unwrap();
+
+        let state2 = PendingState::new(
+            Version::new(20).unwrap(),
+            NonZeroU32::new(1).unwrap(),
+            vec![2],
+        );
+        store.save(&id, &state2).await.unwrap();
+
+        let loaded = store.load(&id, SV1).await.unwrap().unwrap();
+        assert_eq!(loaded.version(), Version::new(20).unwrap());
+        assert_eq!(loaded.payload(), &[2]);
+    }
+
+    #[tokio::test]
+    async fn different_projections_have_separate_state() {
+        let store = InMemoryStateStore::new();
+
+        let state1 = PendingState::new(
+            Version::new(5).unwrap(),
+            NonZeroU32::new(1).unwrap(),
+            vec![1],
+        );
+        store.save(&TestId("proj-1".into()), &state1).await.unwrap();
+
+        let state2 = PendingState::new(
+            Version::new(10).unwrap(),
+            NonZeroU32::new(1).unwrap(),
+            vec![2],
+        );
+        store.save(&TestId("proj-2".into()), &state2).await.unwrap();
+
+        let loaded1 = store
+            .load(&TestId("proj-1".into()), SV1)
+            .await
+            .unwrap()
+            .unwrap();
+        let loaded2 = store
+            .load(&TestId("proj-2".into()), SV1)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(loaded1.version(), Version::new(5).unwrap());
+        assert_eq!(loaded2.version(), Version::new(10).unwrap());
+    }
+
+    #[tokio::test]
+    async fn delete_removes_state() {
+        let store = InMemoryStateStore::new();
+        let id = TestId("proj-1".into());
+
+        let state = PendingState::new(
+            Version::new(10).unwrap(),
+            NonZeroU32::new(1).unwrap(),
+            vec![1],
+        );
+        store.save(&id, &state).await.unwrap();
+
+        store.delete(&id).await.unwrap();
+        let loaded = store.load(&id, SV1).await.unwrap();
+        assert!(loaded.is_none());
+    }
+
+    #[tokio::test]
+    async fn delete_nonexistent_is_ok() {
+        let store = InMemoryStateStore::new();
+        let result = store.delete(&TestId("nope".into())).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn load_filters_by_schema_version() {
+        let store = InMemoryStateStore::new();
+        let id = TestId("proj-1".into());
+
+        let state = PendingState::new(
+            Version::new(10).unwrap(),
+            NonZeroU32::new(1).unwrap(),
+            vec![1, 2, 3],
+        );
+        store.save(&id, &state).await.unwrap();
+
+        // Matching schema version returns state
+        let loaded = store.load(&id, NonZeroU32::new(1).unwrap()).await.unwrap();
+        assert!(loaded.is_some());
+
+        // Mismatched schema version returns None
+        let loaded = store.load(&id, NonZeroU32::new(2).unwrap()).await.unwrap();
+        assert!(loaded.is_none());
+    }
+}

--- a/crates/nexus-store/tests/projection_tests.rs
+++ b/crates/nexus-store/tests/projection_tests.rs
@@ -16,7 +16,7 @@ use std::num::{NonZeroU32, NonZeroU64};
 use nexus::Version;
 use nexus_store::projection::{
     AfterEventTypes as ProjAfterEventTypes, EveryNEvents as ProjEveryNEvents, PendingState,
-    PersistedState, ProjectionTrigger, StateStore,
+    PersistedState, ProjectionTrigger, Projector, StateStore,
 };
 
 const SV1: NonZeroU32 = NonZeroU32::MIN;
@@ -305,4 +305,117 @@ mod in_memory_tests {
         let loaded = store.load(&id, NonZeroU32::new(2).unwrap()).await.unwrap();
         assert!(loaded.is_none());
     }
+}
+
+// ── Projector trait ─────────────────────────────────────────────────
+
+/// A test projector that counts events and sums a field.
+struct CountingProjector;
+
+#[derive(Debug, Clone, PartialEq)]
+struct CountState {
+    count: u64,
+    total: u64,
+}
+
+#[derive(Debug)]
+enum TestEvent {
+    Added(u64),
+    Removed(u64),
+}
+
+impl nexus::Message for TestEvent {}
+impl nexus::DomainEvent for TestEvent {
+    fn name(&self) -> &'static str {
+        match self {
+            TestEvent::Added(_) => "Added",
+            TestEvent::Removed(_) => "Removed",
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("overflow")]
+struct ProjectionError;
+
+impl Projector for CountingProjector {
+    type Event = TestEvent;
+    type State = CountState;
+    type Error = ProjectionError;
+
+    fn initial(&self) -> CountState {
+        CountState { count: 0, total: 0 }
+    }
+
+    fn apply(&self, state: CountState, event: &TestEvent) -> Result<CountState, ProjectionError> {
+        match event {
+            TestEvent::Added(n) => Ok(CountState {
+                count: state.count.checked_add(1).ok_or(ProjectionError)?,
+                total: state.total.checked_add(*n).ok_or(ProjectionError)?,
+            }),
+            TestEvent::Removed(n) => Ok(CountState {
+                count: state.count.checked_add(1).ok_or(ProjectionError)?,
+                total: state.total.checked_sub(*n).ok_or(ProjectionError)?,
+            }),
+        }
+    }
+}
+
+#[test]
+fn projector_initial_state() {
+    let proj = CountingProjector;
+    let state = proj.initial();
+    assert_eq!(state, CountState { count: 0, total: 0 });
+}
+
+#[test]
+fn projector_folds_events() {
+    let proj = CountingProjector;
+    let state = proj.initial();
+
+    let state = proj.apply(state, &TestEvent::Added(10)).unwrap();
+    assert_eq!(
+        state,
+        CountState {
+            count: 1,
+            total: 10
+        }
+    );
+
+    let state = proj.apply(state, &TestEvent::Added(20)).unwrap();
+    assert_eq!(
+        state,
+        CountState {
+            count: 2,
+            total: 30
+        }
+    );
+
+    let state = proj.apply(state, &TestEvent::Removed(5)).unwrap();
+    assert_eq!(
+        state,
+        CountState {
+            count: 3,
+            total: 25
+        }
+    );
+}
+
+#[test]
+fn projector_returns_error_on_overflow() {
+    let proj = CountingProjector;
+    let state = CountState {
+        count: 0,
+        total: u64::MAX,
+    };
+    let result = proj.apply(state, &TestEvent::Added(1));
+    assert!(result.is_err());
+}
+
+#[test]
+fn projector_returns_error_on_underflow() {
+    let proj = CountingProjector;
+    let state = CountState { count: 0, total: 0 };
+    let result = proj.apply(state, &TestEvent::Removed(1));
+    assert!(result.is_err());
 }

--- a/crates/nexus-store/tests/projection_tests.rs
+++ b/crates/nexus-store/tests/projection_tests.rs
@@ -11,10 +11,13 @@
 )]
 
 use std::fmt;
-use std::num::NonZeroU32;
+use std::num::{NonZeroU32, NonZeroU64};
 
 use nexus::Version;
-use nexus_store::projection::{PendingState, PersistedState, StateStore};
+use nexus_store::projection::{
+    AfterEventTypes as ProjAfterEventTypes, EveryNEvents as ProjEveryNEvents, PendingState,
+    PersistedState, ProjectionTrigger, StateStore,
+};
 
 const SV1: NonZeroU32 = NonZeroU32::MIN;
 
@@ -89,4 +92,86 @@ async fn unit_state_store_delete_succeeds() {
     let id = TestId("proj-1".into());
     let result = store.delete(&id).await;
     assert!(result.is_ok());
+}
+
+// ── EveryNEvents ────────────────────────────────────────────────────
+
+#[test]
+fn proj_every_n_events_triggers_on_boundary_crossing() {
+    let trigger = ProjEveryNEvents(NonZeroU64::new(100).unwrap());
+
+    let v99 = Some(Version::new(99).unwrap());
+    let v100 = Version::new(100).unwrap();
+    assert!(trigger.should_project(v99, v100, std::iter::empty::<&str>()));
+
+    let v98 = Some(Version::new(98).unwrap());
+    let v99_ver = Version::new(99).unwrap();
+    assert!(!trigger.should_project(v98, v99_ver, std::iter::empty::<&str>()));
+}
+
+#[test]
+fn proj_every_n_events_triggers_on_batch_crossing_boundary() {
+    let trigger = ProjEveryNEvents(NonZeroU64::new(100).unwrap());
+
+    let old = Some(Version::new(96).unwrap());
+    let new = Version::new(103).unwrap();
+    assert!(trigger.should_project(old, new, std::iter::empty::<&str>()));
+}
+
+#[test]
+fn proj_every_n_events_first_save_triggers_at_boundary() {
+    let trigger = ProjEveryNEvents(NonZeroU64::new(100).unwrap());
+
+    let new = Version::new(100).unwrap();
+    assert!(trigger.should_project(None, new, std::iter::empty::<&str>()));
+
+    let new_50 = Version::new(50).unwrap();
+    assert!(!trigger.should_project(None, new_50, std::iter::empty::<&str>()));
+}
+
+#[test]
+fn proj_every_1_event_always_triggers() {
+    let trigger = ProjEveryNEvents(NonZeroU64::new(1).unwrap());
+    assert!(trigger.should_project(None, Version::new(1).unwrap(), std::iter::empty::<&str>()));
+    assert!(trigger.should_project(
+        Some(Version::new(1).unwrap()),
+        Version::new(2).unwrap(),
+        std::iter::empty::<&str>(),
+    ));
+}
+
+// ── AfterEventTypes ─────────────────────────────────────────────────
+
+#[test]
+fn proj_after_event_types_triggers_on_matching_event() {
+    let trigger = ProjAfterEventTypes::new(&["OrderCompleted", "OrderCancelled"]);
+
+    assert!(trigger.should_project(
+        None,
+        Version::new(5).unwrap(),
+        ["OrderCompleted"].into_iter()
+    ));
+    assert!(trigger.should_project(
+        None,
+        Version::new(5).unwrap(),
+        ["OrderCancelled"].into_iter()
+    ));
+    assert!(!trigger.should_project(None, Version::new(5).unwrap(), ["ItemAdded"].into_iter()));
+}
+
+#[test]
+fn proj_after_event_types_triggers_if_any_event_in_batch_matches() {
+    let trigger = ProjAfterEventTypes::new(&["OrderCompleted"]);
+
+    assert!(trigger.should_project(
+        None,
+        Version::new(5).unwrap(),
+        ["ItemAdded", "OrderCompleted"].into_iter(),
+    ));
+}
+
+#[test]
+fn proj_after_event_types_does_not_trigger_on_empty_events() {
+    let trigger = ProjAfterEventTypes::new(&["OrderCompleted"]);
+    assert!(!trigger.should_project(None, Version::new(5).unwrap(), std::iter::empty::<&str>()));
 }

--- a/crates/nexus-store/tests/projection_tests.rs
+++ b/crates/nexus-store/tests/projection_tests.rs
@@ -14,7 +14,7 @@ use std::fmt;
 use std::num::NonZeroU32;
 
 use nexus::Version;
-use nexus_store::projection::{PendingState, PersistedState};
+use nexus_store::projection::{PendingState, PersistedState, StateStore};
 
 const SV1: NonZeroU32 = NonZeroU32::MIN;
 
@@ -58,4 +58,35 @@ fn persisted_state_stores_version_and_payload() {
     assert_eq!(state.version(), version);
     assert_eq!(state.schema_version(), sv);
     assert_eq!(state.payload(), &[4, 5, 6]);
+}
+
+// ── () no-op StateStore ─────────────────────────────────────────
+
+#[tokio::test]
+async fn unit_state_store_returns_none() {
+    let store = ();
+    let id = TestId("proj-1".into());
+    let result = store.load(&id, SV1).await;
+    assert!(result.unwrap().is_none());
+}
+
+#[tokio::test]
+async fn unit_state_store_save_succeeds() {
+    let store = ();
+    let id = TestId("proj-1".into());
+    let state = PendingState::new(
+        Version::new(1).unwrap(),
+        NonZeroU32::new(1).unwrap(),
+        vec![1, 2, 3],
+    );
+    let result = store.save(&id, &state).await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn unit_state_store_delete_succeeds() {
+    let store = ();
+    let id = TestId("proj-1".into());
+    let result = store.delete(&id).await;
+    assert!(result.is_ok());
 }

--- a/crates/nexus-store/tests/projection_tests.rs
+++ b/crates/nexus-store/tests/projection_tests.rs
@@ -1,0 +1,61 @@
+#![cfg(feature = "projection")]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::shadow_reuse,
+    clippy::shadow_same,
+    clippy::shadow_unrelated,
+    clippy::as_conversions,
+    reason = "test harness — relaxed lints for test code"
+)]
+
+use std::fmt;
+use std::num::NonZeroU32;
+
+use nexus::Version;
+use nexus_store::projection::{PendingState, PersistedState};
+
+const SV1: NonZeroU32 = NonZeroU32::MIN;
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+struct TestId(String);
+
+impl fmt::Display for TestId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl AsRef<[u8]> for TestId {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_bytes()
+    }
+}
+
+impl nexus::Id for TestId {
+    const BYTE_LEN: usize = 0;
+}
+
+#[test]
+fn pending_state_stores_version_and_payload() {
+    let version = Version::new(42).unwrap();
+    let payload = vec![1, 2, 3];
+    let sv = NonZeroU32::new(1).unwrap();
+    let state = PendingState::new(version, sv, payload.clone());
+
+    assert_eq!(state.version(), version);
+    assert_eq!(state.schema_version(), sv);
+    assert_eq!(state.payload(), &payload);
+}
+
+#[test]
+fn persisted_state_stores_version_and_payload() {
+    let version = Version::new(10).unwrap();
+    let sv = NonZeroU32::new(2).unwrap();
+    let state = PersistedState::new(version, sv, vec![4, 5, 6]);
+
+    assert_eq!(state.version(), version);
+    assert_eq!(state.schema_version(), sv);
+    assert_eq!(state.payload(), &[4, 5, 6]);
+}

--- a/crates/nexus/README.md
+++ b/crates/nexus/README.md
@@ -1,108 +1,25 @@
-# Nexus
+# nexus
 
-> A zero-compromise, **event-sourcing** & **CQRS** framework for Rust that puts type-safety and performance first.
+Event-sourcing kernel — aggregates, events, versioning, command handling. No `Box<dyn>`, no runtime downcasting, no `std` allocation.
 
-[![crate](https://img.shields.io/crates/v/nexus.svg)](https://crates.io/crates/nexus)
-[![docs](https://img.shields.io/docsrs/nexus/latest)](https://docs.rs/nexus)
-[![license](https://img.shields.io/crates/l/nexus)](LICENSE)
+See the [root README](../../README.md) for usage and examples.
 
-Nexus helps you build robust, evolvable applications with first-class support for:
+## Verification
 
-* **Domain-Driven Design (DDD)**
-* **Event Sourcing (ES)**
-* **Command Query Responsibility Segregation (CQRS)**
-* **Hexagonal Architecture**
-
-## The Kernel
-
-The kernel is the innermost layer of Nexus — a pure, synchronous, zero-dependency core that provides maximum compile-time type safety.
-
-### Design Principles
-
-- **Concrete event enums** — no `Box<dyn>`, no runtime downcasting. The compiler enforces exhaustive event handling via `match`.
-- **Marker-trait aggregates** — `Aggregate` binds `State`, `Error`, and `Id` at the type level. `AggregateRoot<A>` is parameterized by a single generic.
-- **Encapsulated versioning** — `Version` and `VersionedEvent` cannot be forged. The kernel controls all version assignment.
-- **Minimal error surface** — `KernelError` has a single variant (`VersionMismatch`). Infrastructure errors belong in outer layers.
-
-### Quick Example
-
-```rust
-use nexus::kernel::*;
-use nexus::kernel::aggregate::AggregateRoot;
-
-// 1. Define events
-#[derive(Debug, Clone)]
-struct UserCreated { name: String }
-
-#[derive(Debug, Clone)]
-struct UserActivated;
-
-#[derive(Debug, Clone, nexus::DomainEvent)]
-enum UserEvent {
-    Created(UserCreated),
-    Activated(UserActivated),
-}
-
-// 2. Define state
-#[derive(Default, Debug)]
-struct UserState { name: String, active: bool }
-
-impl AggregateState for UserState {
-    type Event = UserEvent;
-    fn apply(&mut self, event: &UserEvent) {
-        match event {
-            UserEvent::Created(e) => self.name = e.name.clone(),
-            UserEvent::Activated(_) => self.active = true,
-        }
-    }
-    fn name(&self) -> &'static str { "User" }
-}
-
-// 3. Define aggregate
-struct UserAggregate;
-
-impl Aggregate for UserAggregate {
-    type State = UserState;
-    type Error = UserError;
-    type Id = UserId;
-}
-
-// 4. Use it
-let mut user = AggregateRoot::<UserAggregate>::new(id);
-user.apply(UserEvent::Created(UserCreated { name: "Alice".into() }));
-user.apply(UserEvent::Activated(UserActivated));
-
-let events = user.take_uncommitted_events();
-assert_eq!(events.len(), 2);
-```
-
-### Verification
-
-The kernel is tested with 10 different verification techniques:
+The kernel is tested with 9 verification techniques:
 
 | Technique | What it proves |
 |-----------|---------------|
-| Unit tests + edge cases | Correct behavior, caught a real version-tracking bug |
-| Property-based testing (proptest) | 8 algebraic properties hold for all random inputs |
-| Compile-failure tests (trybuild) | Invalid code fails to compile (type safety works) |
+| Unit tests + edge cases | Correct behavior |
+| Property-based testing (proptest) | Algebraic properties hold for all random inputs |
+| Compile-failure tests (trybuild) | Invalid code fails to compile |
 | Static assertions | Send, Sync, size, trait bounds enforced at compile time |
 | Miri | Zero undefined behavior under strict provenance |
-| Mutation testing (cargo-mutants) | 100% kill rate — every viable mutation caught |
-| Contract invariants (debug_assert!) | Version arithmetic verified in debug builds |
-| Benchmarks (criterion) | 15ns/event apply, 4.1us/10K event replay |
+| Mutation testing (cargo-mutants) | Every viable mutation caught |
+| Benchmarks (criterion) | Performance regression detection |
 | Doc tests | All examples compile and run |
 | Architecture tests | Kernel imports nothing from outer layers |
 
-## Development
-
-Prerequisites: [Nix](https://nixos.org/) with flakes enabled.
-
-```bash
-nix develop
-cargo test -p nexus --test kernel
-cargo bench --bench kernel_bench -p nexus
-```
-
 ## License
 
-Licensed under MIT OR Apache-2.0.
+Licensed under your choice of [MIT](../../LICENSE-MIT) or [Apache-2.0](../../LICENSE-APACHE).

--- a/docs/plans/2026-04-27-projection-core-traits.md
+++ b/docs/plans/2026-04-27-projection-core-traits.md
@@ -1,0 +1,1216 @@
+# Projection Core Traits Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Define the trait-based foundation for projections — `Projector`, `StateStore`, `ProjectionTrigger`, and data types — as a parallel module to `snapshot/`, closing #155.
+
+**Architecture:** Copy the `snapshot/` module structure into a new `projection/` module, rename types, and add the one genuinely new trait (`Projector`). Both modules coexist until subtask 5 (#159) unifies them. Feature-gated behind `projection` flag.
+
+**Tech Stack:** Rust (edition 2024), nexus-store crate, tokio (testing only), proptest
+
+---
+
+### Task 1: Add `projection` feature flag
+
+**Files:**
+- Modify: `crates/nexus-store/Cargo.toml`
+
+**Step 1: Add the feature flags**
+
+In `crates/nexus-store/Cargo.toml`, add to the `[features]` section:
+
+```toml
+projection = []
+projection-json = ["projection", "json"]
+```
+
+**Step 2: Verify it compiles**
+
+Run: `cargo check -p nexus-store --features projection`
+Expected: PASS (no projection code yet, feature just exists)
+
+**Step 3: Commit**
+
+```bash
+git add crates/nexus-store/Cargo.toml
+git commit -m "feat(store): add projection feature flags"
+```
+
+---
+
+### Task 2: Create `PendingState` and `PersistedState` types
+
+**Files:**
+- Create: `crates/nexus-store/src/projection/pending.rs`
+- Create: `crates/nexus-store/src/projection/persisted.rs`
+- Create: `crates/nexus-store/src/projection/mod.rs`
+- Modify: `crates/nexus-store/src/lib.rs`
+- Create: `crates/nexus-store/tests/projection_tests.rs`
+
+**Step 1: Write failing tests**
+
+Create `crates/nexus-store/tests/projection_tests.rs`:
+
+```rust
+#![cfg(feature = "projection")]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::shadow_reuse,
+    clippy::shadow_same,
+    clippy::shadow_unrelated,
+    clippy::as_conversions,
+    reason = "test harness — relaxed lints for test code"
+)]
+
+use std::num::NonZeroU32;
+
+use nexus::Version;
+use nexus_store::projection::{PendingState, PersistedState};
+
+#[test]
+fn pending_state_stores_version_and_payload() {
+    let version = Version::new(42).unwrap();
+    let payload = vec![1, 2, 3];
+    let sv = NonZeroU32::new(1).unwrap();
+    let state = PendingState::new(version, sv, payload.clone());
+
+    assert_eq!(state.version(), version);
+    assert_eq!(state.schema_version(), sv);
+    assert_eq!(state.payload(), &payload);
+}
+
+#[test]
+fn persisted_state_stores_version_and_payload() {
+    let version = Version::new(10).unwrap();
+    let sv = NonZeroU32::new(2).unwrap();
+    let state = PersistedState::new(version, sv, vec![4, 5, 6]);
+
+    assert_eq!(state.version(), version);
+    assert_eq!(state.schema_version(), sv);
+    assert_eq!(state.payload(), &[4, 5, 6]);
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p nexus-store --features projection -- projection_tests`
+Expected: FAIL — module `projection` not found
+
+**Step 3: Create the projection module and types**
+
+Create `crates/nexus-store/src/projection/pending.rs` — copy from `snapshot/pending.rs`, rename `PendingSnapshot` → `PendingState`:
+
+```rust
+use std::num::NonZeroU32;
+
+use nexus::Version;
+
+/// Projection state payload ready for persistence (write path).
+///
+/// Contains the serialized projection state, the stream version at
+/// state computation time, and a schema version for invalidation.
+#[derive(Debug, Clone)]
+pub struct PendingState {
+    version: Version,
+    schema_version: NonZeroU32,
+    payload: Vec<u8>,
+}
+
+impl PendingState {
+    /// Create a new pending projection state.
+    #[must_use]
+    pub const fn new(version: Version, schema_version: NonZeroU32, payload: Vec<u8>) -> Self {
+        Self {
+            version,
+            schema_version,
+            payload,
+        }
+    }
+
+    /// The stream version at the time of state computation.
+    #[must_use]
+    pub const fn version(&self) -> Version {
+        self.version
+    }
+
+    /// The schema version for invalidation checking.
+    #[must_use]
+    pub const fn schema_version(&self) -> NonZeroU32 {
+        self.schema_version
+    }
+
+    /// The serialized state bytes.
+    #[must_use]
+    pub fn payload(&self) -> &[u8] {
+        &self.payload
+    }
+}
+```
+
+Create `crates/nexus-store/src/projection/persisted.rs` — copy from `snapshot/persisted.rs`, rename `PersistedSnapshot` → `PersistedState`:
+
+```rust
+use std::num::NonZeroU32;
+
+use nexus::Version;
+
+/// Persisted projection state loaded from storage (read path).
+///
+/// Owns the payload bytes. A borrowing variant with GAT lifetimes
+/// can be added later if benchmarks justify it.
+#[derive(Debug, Clone)]
+pub struct PersistedState {
+    version: Version,
+    schema_version: NonZeroU32,
+    payload: Vec<u8>,
+}
+
+impl PersistedState {
+    /// Create a new persisted projection state.
+    #[must_use]
+    pub const fn new(version: Version, schema_version: NonZeroU32, payload: Vec<u8>) -> Self {
+        Self {
+            version,
+            schema_version,
+            payload,
+        }
+    }
+
+    /// The stream version at the time of state computation.
+    #[must_use]
+    pub const fn version(&self) -> Version {
+        self.version
+    }
+
+    /// The schema version for invalidation checking.
+    #[must_use]
+    pub const fn schema_version(&self) -> NonZeroU32 {
+        self.schema_version
+    }
+
+    /// The serialized state bytes.
+    #[must_use]
+    pub fn payload(&self) -> &[u8] {
+        &self.payload
+    }
+}
+```
+
+Create `crates/nexus-store/src/projection/mod.rs`:
+
+```rust
+mod pending;
+mod persisted;
+
+pub use pending::PendingState;
+pub use persisted::PersistedState;
+```
+
+Add to `crates/nexus-store/src/lib.rs`:
+
+```rust
+#[cfg(feature = "projection")]
+pub mod projection;
+```
+
+And re-exports:
+
+```rust
+#[cfg(feature = "projection")]
+pub use projection::{PendingState, PersistedState};
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p nexus-store --features projection -- projection_tests`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add crates/nexus-store/src/projection/ crates/nexus-store/src/lib.rs crates/nexus-store/tests/projection_tests.rs
+git commit -m "feat(store): add PendingState and PersistedState for projection module"
+```
+
+---
+
+### Task 3: Add `StateStore` trait
+
+**Files:**
+- Create: `crates/nexus-store/src/projection/store.rs`
+- Modify: `crates/nexus-store/src/projection/mod.rs`
+- Modify: `crates/nexus-store/tests/projection_tests.rs`
+
+**Step 1: Write failing tests**
+
+Append to `crates/nexus-store/tests/projection_tests.rs`:
+
+```rust
+use nexus_store::projection::StateStore;
+
+// ── () no-op StateStore ─────────────────────────────────────────
+
+#[tokio::test]
+async fn unit_state_store_returns_none() {
+    let store = ();
+    let id = TestId("proj-1".into());
+    let result = store.load(&id, SV1).await;
+    assert!(result.unwrap().is_none());
+}
+
+#[tokio::test]
+async fn unit_state_store_save_succeeds() {
+    let store = ();
+    let id = TestId("proj-1".into());
+    let state = PendingState::new(
+        Version::new(1).unwrap(),
+        NonZeroU32::new(1).unwrap(),
+        vec![1, 2, 3],
+    );
+    let result = store.save(&id, &state).await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn unit_state_store_delete_succeeds() {
+    let store = ();
+    let id = TestId("proj-1".into());
+    let result = store.delete(&id).await;
+    assert!(result.is_ok());
+}
+```
+
+Also add the `TestId` and `SV1` definitions at the top of the file (same pattern as snapshot_tests.rs):
+
+```rust
+use std::fmt;
+
+const SV1: NonZeroU32 = NonZeroU32::MIN;
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+struct TestId(String);
+
+impl fmt::Display for TestId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl AsRef<[u8]> for TestId {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_bytes()
+    }
+}
+
+impl nexus::Id for TestId {
+    const BYTE_LEN: usize = 0;
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p nexus-store --features projection -- projection_tests`
+Expected: FAIL — `StateStore` not found
+
+**Step 3: Create the StateStore trait**
+
+Create `crates/nexus-store/src/projection/store.rs` — copy from `snapshot/store.rs`, rename:
+
+```rust
+use std::convert::Infallible;
+use std::future::Future;
+use std::num::NonZeroU32;
+
+use nexus::Id;
+
+use super::pending::PendingState;
+use super::persisted::PersistedState;
+
+/// Byte-level projection state storage trait.
+///
+/// Adapters (fjall, postgres, etc.) implement this to persist and
+/// retrieve serialized projection state.
+///
+/// `()` is the no-op implementation: `load` always returns `None`,
+/// `save` and `delete` silently discard. Used when projection state
+/// storage is not configured.
+pub trait StateStore: Send + Sync {
+    /// Adapter-specific error type.
+    type Error: std::error::Error + Send + Sync + 'static;
+
+    /// Load the most recent state for the given projection.
+    ///
+    /// Returns `None` if no state exists or if the stored state's
+    /// schema version does not match `schema_version`. Filtering at the
+    /// store level avoids loading payload bytes for stale state.
+    fn load(
+        &self,
+        id: &impl Id,
+        schema_version: NonZeroU32,
+    ) -> impl Future<Output = Result<Option<PersistedState>, Self::Error>> + Send;
+
+    /// Persist projection state.
+    ///
+    /// Overwrites any existing state for this projection.
+    fn save(
+        &self,
+        id: &impl Id,
+        state: &PendingState,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+
+    /// Delete projection state.
+    ///
+    /// Returns `Ok(())` if no state exists (idempotent).
+    fn delete(&self, id: &impl Id) -> impl Future<Output = Result<(), Self::Error>> + Send;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Delegation implementation — share via reference
+// ═══════════════════════════════════════════════════════════════════════════
+
+impl<T: StateStore> StateStore for &T {
+    type Error = T::Error;
+
+    async fn load(
+        &self,
+        id: &impl Id,
+        schema_version: NonZeroU32,
+    ) -> Result<Option<PersistedState>, Self::Error> {
+        (**self).load(id, schema_version).await
+    }
+
+    async fn save(&self, id: &impl Id, state: &PendingState) -> Result<(), Self::Error> {
+        (**self).save(id, state).await
+    }
+
+    async fn delete(&self, id: &impl Id) -> Result<(), Self::Error> {
+        (**self).delete(id).await
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// No-op implementation — projection state storage disabled
+// ═══════════════════════════════════════════════════════════════════════════
+
+impl StateStore for () {
+    type Error = Infallible;
+
+    async fn load(
+        &self,
+        _id: &impl Id,
+        _schema_version: NonZeroU32,
+    ) -> Result<Option<PersistedState>, Infallible> {
+        Ok(None)
+    }
+
+    async fn save(&self, _id: &impl Id, _state: &PendingState) -> Result<(), Infallible> {
+        Ok(())
+    }
+
+    async fn delete(&self, _id: &impl Id) -> Result<(), Infallible> {
+        Ok(())
+    }
+}
+```
+
+Update `crates/nexus-store/src/projection/mod.rs`:
+
+```rust
+mod pending;
+mod persisted;
+mod store;
+
+pub use pending::PendingState;
+pub use persisted::PersistedState;
+pub use store::StateStore;
+```
+
+Add re-export in `crates/nexus-store/src/lib.rs`:
+
+```rust
+#[cfg(feature = "projection")]
+pub use projection::{PendingState, PersistedState, StateStore};
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p nexus-store --features projection -- projection_tests`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add crates/nexus-store/src/projection/store.rs crates/nexus-store/src/projection/mod.rs crates/nexus-store/src/lib.rs crates/nexus-store/tests/projection_tests.rs
+git commit -m "feat(store): add StateStore trait for projection state persistence"
+```
+
+---
+
+### Task 4: Add `ProjectionTrigger` with `EveryNEvents` and `AfterEventTypes`
+
+**Files:**
+- Create: `crates/nexus-store/src/projection/trigger.rs`
+- Modify: `crates/nexus-store/src/projection/mod.rs`
+- Modify: `crates/nexus-store/tests/projection_tests.rs`
+
+**Step 1: Write failing tests**
+
+Append to `crates/nexus-store/tests/projection_tests.rs`:
+
+```rust
+use std::num::NonZeroU64;
+
+use nexus_store::projection::{
+    AfterEventTypes as ProjAfterEventTypes, EveryNEvents as ProjEveryNEvents, ProjectionTrigger,
+};
+
+// ── EveryNEvents ────────────────────────────────────────────────────
+
+#[test]
+fn proj_every_n_events_triggers_on_boundary_crossing() {
+    let trigger = ProjEveryNEvents(NonZeroU64::new(100).unwrap());
+
+    let v99 = Some(Version::new(99).unwrap());
+    let v100 = Version::new(100).unwrap();
+    assert!(trigger.should_project(v99, v100, std::iter::empty::<&str>()));
+
+    let v98 = Some(Version::new(98).unwrap());
+    let v99_ver = Version::new(99).unwrap();
+    assert!(!trigger.should_project(v98, v99_ver, std::iter::empty::<&str>()));
+}
+
+#[test]
+fn proj_every_n_events_triggers_on_batch_crossing_boundary() {
+    let trigger = ProjEveryNEvents(NonZeroU64::new(100).unwrap());
+
+    let old = Some(Version::new(96).unwrap());
+    let new = Version::new(103).unwrap();
+    assert!(trigger.should_project(old, new, std::iter::empty::<&str>()));
+}
+
+#[test]
+fn proj_every_n_events_first_save_triggers_at_boundary() {
+    let trigger = ProjEveryNEvents(NonZeroU64::new(100).unwrap());
+
+    let new = Version::new(100).unwrap();
+    assert!(trigger.should_project(None, new, std::iter::empty::<&str>()));
+
+    let new_50 = Version::new(50).unwrap();
+    assert!(!trigger.should_project(None, new_50, std::iter::empty::<&str>()));
+}
+
+#[test]
+fn proj_every_1_event_always_triggers() {
+    let trigger = ProjEveryNEvents(NonZeroU64::new(1).unwrap());
+    assert!(trigger.should_project(None, Version::new(1).unwrap(), std::iter::empty::<&str>()));
+    assert!(trigger.should_project(
+        Some(Version::new(1).unwrap()),
+        Version::new(2).unwrap(),
+        std::iter::empty::<&str>(),
+    ));
+}
+
+// ── AfterEventTypes ─────────────────────────────────────────────────
+
+#[test]
+fn proj_after_event_types_triggers_on_matching_event() {
+    let trigger = ProjAfterEventTypes::new(&["OrderCompleted", "OrderCancelled"]);
+
+    assert!(trigger.should_project(None, Version::new(5).unwrap(), ["OrderCompleted"].into_iter()));
+    assert!(trigger.should_project(
+        None,
+        Version::new(5).unwrap(),
+        ["OrderCancelled"].into_iter()
+    ));
+    assert!(!trigger.should_project(None, Version::new(5).unwrap(), ["ItemAdded"].into_iter()));
+}
+
+#[test]
+fn proj_after_event_types_triggers_if_any_event_in_batch_matches() {
+    let trigger = ProjAfterEventTypes::new(&["OrderCompleted"]);
+
+    assert!(trigger.should_project(
+        None,
+        Version::new(5).unwrap(),
+        ["ItemAdded", "OrderCompleted"].into_iter(),
+    ));
+}
+
+#[test]
+fn proj_after_event_types_does_not_trigger_on_empty_events() {
+    let trigger = ProjAfterEventTypes::new(&["OrderCompleted"]);
+    assert!(!trigger.should_project(None, Version::new(5).unwrap(), std::iter::empty::<&str>()));
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p nexus-store --features projection -- projection_tests`
+Expected: FAIL — `ProjectionTrigger` not found
+
+**Step 3: Create the trigger trait and implementations**
+
+Create `crates/nexus-store/src/projection/trigger.rs` — copy from `snapshot/trigger.rs`, rename `SnapshotTrigger` → `ProjectionTrigger`, `should_snapshot` → `should_project`:
+
+```rust
+use std::num::NonZeroU64;
+
+use nexus::Version;
+
+/// Strategy for deciding when to update projection state.
+///
+/// Checked after each successful `save()`. The trigger receives both the
+/// old and new version (to detect boundary crossings regardless of batch
+/// size) and the names of events just persisted (for semantic triggers).
+pub trait ProjectionTrigger: Send + Sync {
+    /// Whether a projection state update should happen after this save.
+    ///
+    /// - `old_version`: version before save (`None` for new streams)
+    /// - `new_version`: version after save
+    /// - `event_names`: names of events just persisted (from `DomainEvent::name()`).
+    fn should_project(
+        &self,
+        old_version: Option<Version>,
+        new_version: Version,
+        event_names: impl Iterator<Item: AsRef<str>>,
+    ) -> bool;
+}
+
+/// Trigger a projection state update every N events.
+///
+/// Uses a bucket-crossing algorithm to detect when a save crosses an
+/// N-event boundary, regardless of batch size.
+#[derive(Debug, Clone, Copy)]
+pub struct EveryNEvents(pub NonZeroU64);
+
+impl ProjectionTrigger for EveryNEvents {
+    fn should_project(
+        &self,
+        old_version: Option<Version>,
+        new_version: Version,
+        _event_names: impl Iterator<Item: AsRef<str>>,
+    ) -> bool {
+        let n = self.0.get();
+        let old_bucket = old_version.map_or(0, |v| v.as_u64() / n);
+        let new_bucket = new_version.as_u64() / n;
+        new_bucket > old_bucket
+    }
+}
+
+/// Trigger a projection state update after specific event types.
+///
+/// Useful for domain milestones where a projection update aligns with
+/// business semantics.
+#[derive(Debug, Clone)]
+pub struct AfterEventTypes {
+    types: Vec<&'static str>,
+}
+
+impl AfterEventTypes {
+    /// Create a trigger that fires when any of the given event types is persisted.
+    #[must_use]
+    pub fn new(types: &[&'static str]) -> Self {
+        Self {
+            types: types.to_vec(),
+        }
+    }
+}
+
+impl ProjectionTrigger for AfterEventTypes {
+    fn should_project(
+        &self,
+        _old_version: Option<Version>,
+        _new_version: Version,
+        mut event_names: impl Iterator<Item: AsRef<str>>,
+    ) -> bool {
+        event_names.any(|name| self.types.iter().any(|t| *t == name.as_ref()))
+    }
+}
+```
+
+Update `crates/nexus-store/src/projection/mod.rs`:
+
+```rust
+mod pending;
+mod persisted;
+mod store;
+mod trigger;
+
+pub use pending::PendingState;
+pub use persisted::PersistedState;
+pub use store::StateStore;
+pub use trigger::{AfterEventTypes, EveryNEvents, ProjectionTrigger};
+```
+
+Update re-exports in `crates/nexus-store/src/lib.rs`:
+
+```rust
+#[cfg(feature = "projection")]
+pub use projection::{
+    AfterEventTypes as ProjAfterEventTypes, EveryNEvents as ProjEveryNEvents, PendingState,
+    PersistedState, ProjectionTrigger, StateStore,
+};
+```
+
+**Note:** The trigger type names (`EveryNEvents`, `AfterEventTypes`) collide with the snapshot re-exports. Use aliased re-exports at the crate root. The `projection::` module path remains unaliased for direct use.
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p nexus-store --features projection -- projection_tests`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add crates/nexus-store/src/projection/trigger.rs crates/nexus-store/src/projection/mod.rs crates/nexus-store/src/lib.rs crates/nexus-store/tests/projection_tests.rs
+git commit -m "feat(store): add ProjectionTrigger trait with EveryNEvents and AfterEventTypes"
+```
+
+---
+
+### Task 5: Add `InMemoryStateStore` (testing)
+
+**Files:**
+- Create: `crates/nexus-store/src/projection/testing.rs`
+- Modify: `crates/nexus-store/src/projection/mod.rs`
+- Modify: `crates/nexus-store/tests/projection_tests.rs`
+
+**Step 1: Write failing tests**
+
+Append to `crates/nexus-store/tests/projection_tests.rs`:
+
+```rust
+// ── InMemoryStateStore ───────────────────────────────────────────
+
+#[cfg(feature = "testing")]
+mod in_memory_tests {
+    use super::*;
+    use nexus_store::projection::InMemoryStateStore;
+
+    #[tokio::test]
+    async fn load_returns_none_when_empty() {
+        let store = InMemoryStateStore::new();
+        let result = store.load(&TestId("proj-1".into()), SV1).await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn save_then_load_roundtrips() {
+        let store = InMemoryStateStore::new();
+        let id = TestId("proj-1".into());
+        let version = Version::new(10).unwrap();
+        let state = PendingState::new(version, NonZeroU32::new(1).unwrap(), vec![1, 2, 3]);
+
+        store.save(&id, &state).await.unwrap();
+        let loaded = store.load(&id, SV1).await.unwrap().unwrap();
+
+        assert_eq!(loaded.version(), version);
+        assert_eq!(loaded.schema_version(), NonZeroU32::new(1).unwrap());
+        assert_eq!(loaded.payload(), &[1, 2, 3]);
+    }
+
+    #[tokio::test]
+    async fn save_overwrites_previous_state() {
+        let store = InMemoryStateStore::new();
+        let id = TestId("proj-1".into());
+
+        let state1 = PendingState::new(
+            Version::new(10).unwrap(),
+            NonZeroU32::new(1).unwrap(),
+            vec![1],
+        );
+        store.save(&id, &state1).await.unwrap();
+
+        let state2 = PendingState::new(
+            Version::new(20).unwrap(),
+            NonZeroU32::new(1).unwrap(),
+            vec![2],
+        );
+        store.save(&id, &state2).await.unwrap();
+
+        let loaded = store.load(&id, SV1).await.unwrap().unwrap();
+        assert_eq!(loaded.version(), Version::new(20).unwrap());
+        assert_eq!(loaded.payload(), &[2]);
+    }
+
+    #[tokio::test]
+    async fn different_projections_have_separate_state() {
+        let store = InMemoryStateStore::new();
+
+        let state1 = PendingState::new(
+            Version::new(5).unwrap(),
+            NonZeroU32::new(1).unwrap(),
+            vec![1],
+        );
+        store
+            .save(&TestId("proj-1".into()), &state1)
+            .await
+            .unwrap();
+
+        let state2 = PendingState::new(
+            Version::new(10).unwrap(),
+            NonZeroU32::new(1).unwrap(),
+            vec![2],
+        );
+        store
+            .save(&TestId("proj-2".into()), &state2)
+            .await
+            .unwrap();
+
+        let loaded1 = store
+            .load(&TestId("proj-1".into()), SV1)
+            .await
+            .unwrap()
+            .unwrap();
+        let loaded2 = store
+            .load(&TestId("proj-2".into()), SV1)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(loaded1.version(), Version::new(5).unwrap());
+        assert_eq!(loaded2.version(), Version::new(10).unwrap());
+    }
+
+    #[tokio::test]
+    async fn delete_removes_state() {
+        let store = InMemoryStateStore::new();
+        let id = TestId("proj-1".into());
+
+        let state = PendingState::new(
+            Version::new(10).unwrap(),
+            NonZeroU32::new(1).unwrap(),
+            vec![1],
+        );
+        store.save(&id, &state).await.unwrap();
+
+        store.delete(&id).await.unwrap();
+        let loaded = store.load(&id, SV1).await.unwrap();
+        assert!(loaded.is_none());
+    }
+
+    #[tokio::test]
+    async fn delete_nonexistent_is_ok() {
+        let store = InMemoryStateStore::new();
+        let result = store.delete(&TestId("nope".into())).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn load_filters_by_schema_version() {
+        let store = InMemoryStateStore::new();
+        let id = TestId("proj-1".into());
+
+        let state = PendingState::new(
+            Version::new(10).unwrap(),
+            NonZeroU32::new(1).unwrap(),
+            vec![1, 2, 3],
+        );
+        store.save(&id, &state).await.unwrap();
+
+        // Matching schema version returns state
+        let loaded = store.load(&id, NonZeroU32::new(1).unwrap()).await.unwrap();
+        assert!(loaded.is_some());
+
+        // Mismatched schema version returns None
+        let loaded = store.load(&id, NonZeroU32::new(2).unwrap()).await.unwrap();
+        assert!(loaded.is_none());
+    }
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p nexus-store --features "projection,testing" -- projection_tests`
+Expected: FAIL — `InMemoryStateStore` not found
+
+**Step 3: Create the InMemoryStateStore**
+
+Create `crates/nexus-store/src/projection/testing.rs` — copy from `snapshot/testing.rs`, rename:
+
+```rust
+use std::collections::HashMap;
+use std::convert::Infallible;
+use std::num::NonZeroU32;
+
+use nexus::Id;
+use tokio::sync::RwLock;
+
+use super::pending::PendingState;
+use super::persisted::PersistedState;
+use super::store::StateStore;
+
+/// In-memory projection state store for tests.
+///
+/// Stores projection state in a `HashMap` protected by a `RwLock`.
+#[derive(Debug, Default)]
+pub struct InMemoryStateStore {
+    states: RwLock<HashMap<String, StoredState>>,
+}
+
+#[derive(Debug, Clone)]
+struct StoredState {
+    version: nexus::Version,
+    schema_version: NonZeroU32,
+    payload: Vec<u8>,
+}
+
+impl InMemoryStateStore {
+    /// Create a new empty in-memory state store.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl StateStore for InMemoryStateStore {
+    type Error = Infallible;
+
+    async fn load(
+        &self,
+        id: &impl Id,
+        schema_version: NonZeroU32,
+    ) -> Result<Option<PersistedState>, Infallible> {
+        let states = self.states.read().await;
+        let key = id.to_string();
+        Ok(states
+            .get(&key)
+            .filter(|s| s.schema_version == schema_version)
+            .map(|s| PersistedState::new(s.version, s.schema_version, s.payload.clone())))
+    }
+
+    async fn save(&self, id: &impl Id, state: &PendingState) -> Result<(), Infallible> {
+        let mut states = self.states.write().await;
+        let key = id.to_string();
+        states.insert(
+            key,
+            StoredState {
+                version: state.version(),
+                schema_version: state.schema_version(),
+                payload: state.payload().to_vec(),
+            },
+        );
+        Ok(())
+    }
+
+    async fn delete(&self, id: &impl Id) -> Result<(), Infallible> {
+        let mut states = self.states.write().await;
+        states.remove(&id.to_string());
+        Ok(())
+    }
+}
+```
+
+Update `crates/nexus-store/src/projection/mod.rs`:
+
+```rust
+mod pending;
+mod persisted;
+mod store;
+#[cfg(feature = "testing")]
+mod testing;
+mod trigger;
+
+pub use pending::PendingState;
+pub use persisted::PersistedState;
+pub use store::StateStore;
+#[cfg(feature = "testing")]
+pub use testing::InMemoryStateStore;
+pub use trigger::{AfterEventTypes, EveryNEvents, ProjectionTrigger};
+```
+
+Update re-exports in `crates/nexus-store/src/lib.rs`:
+
+```rust
+#[cfg(all(feature = "projection", feature = "testing"))]
+pub use projection::InMemoryStateStore;
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p nexus-store --features "projection,testing" -- projection_tests`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add crates/nexus-store/src/projection/testing.rs crates/nexus-store/src/projection/mod.rs crates/nexus-store/src/lib.rs crates/nexus-store/tests/projection_tests.rs
+git commit -m "feat(store): add InMemoryStateStore for projection testing"
+```
+
+---
+
+### Task 6: Add `Projector` trait
+
+**Files:**
+- Create: `crates/nexus-store/src/projection/projector.rs`
+- Modify: `crates/nexus-store/src/projection/mod.rs`
+- Modify: `crates/nexus-store/src/lib.rs`
+- Modify: `crates/nexus-store/tests/projection_tests.rs`
+
+**Step 1: Write failing tests**
+
+Append to `crates/nexus-store/tests/projection_tests.rs`:
+
+```rust
+use nexus_store::projection::Projector;
+
+// ── Projector trait ─────────────────────────────────────────────────
+
+/// A test projector that counts events and sums a field.
+struct CountingProjector;
+
+#[derive(Debug, Clone, PartialEq)]
+struct CountState {
+    count: u64,
+    total: u64,
+}
+
+#[derive(Debug)]
+enum TestEvent {
+    Added(u64),
+    Removed(u64),
+}
+
+impl nexus::Message for TestEvent {}
+impl nexus::DomainEvent for TestEvent {
+    fn name(&self) -> &'static str {
+        match self {
+            TestEvent::Added(_) => "Added",
+            TestEvent::Removed(_) => "Removed",
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("overflow")]
+struct ProjectionError;
+
+impl Projector for CountingProjector {
+    type Event = TestEvent;
+    type State = CountState;
+    type Error = ProjectionError;
+
+    fn initial(&self) -> CountState {
+        CountState { count: 0, total: 0 }
+    }
+
+    fn apply(&self, state: CountState, event: &TestEvent) -> Result<CountState, ProjectionError> {
+        match event {
+            TestEvent::Added(n) => Ok(CountState {
+                count: state.count.checked_add(1).ok_or(ProjectionError)?,
+                total: state.total.checked_add(*n).ok_or(ProjectionError)?,
+            }),
+            TestEvent::Removed(n) => Ok(CountState {
+                count: state.count.checked_add(1).ok_or(ProjectionError)?,
+                total: state.total.checked_sub(*n).ok_or(ProjectionError)?,
+            }),
+        }
+    }
+}
+
+#[test]
+fn projector_initial_state() {
+    let proj = CountingProjector;
+    let state = proj.initial();
+    assert_eq!(state, CountState { count: 0, total: 0 });
+}
+
+#[test]
+fn projector_folds_events() {
+    let proj = CountingProjector;
+    let state = proj.initial();
+
+    let state = proj.apply(state, &TestEvent::Added(10)).unwrap();
+    assert_eq!(state, CountState { count: 1, total: 10 });
+
+    let state = proj.apply(state, &TestEvent::Added(20)).unwrap();
+    assert_eq!(state, CountState { count: 2, total: 30 });
+
+    let state = proj.apply(state, &TestEvent::Removed(5)).unwrap();
+    assert_eq!(state, CountState { count: 3, total: 25 });
+}
+
+#[test]
+fn projector_returns_error_on_overflow() {
+    let proj = CountingProjector;
+    let state = CountState {
+        count: 0,
+        total: u64::MAX,
+    };
+    let result = proj.apply(state, &TestEvent::Added(1));
+    assert!(result.is_err());
+}
+
+#[test]
+fn projector_returns_error_on_underflow() {
+    let proj = CountingProjector;
+    let state = CountState { count: 0, total: 0 };
+    let result = proj.apply(state, &TestEvent::Removed(1));
+    assert!(result.is_err());
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p nexus-store --features projection -- projection_tests`
+Expected: FAIL — `Projector` not found
+
+**Step 3: Create the Projector trait**
+
+Create `crates/nexus-store/src/projection/projector.rs`:
+
+```rust
+use nexus::DomainEvent;
+
+/// A pure fold function over domain events.
+///
+/// Processes events one at a time to produce derived state. The
+/// framework handles all IO (reading events, persisting state,
+/// checkpointing). The projector is only responsible for computation.
+///
+/// Fallible: `apply` returns `Result` because projections may perform
+/// checked arithmetic or encounter domain-specific edge cases.
+/// Recovery policy (skip, fail, dead-letter) is handled by middleware
+/// layers, not the projector itself.
+///
+/// # Comparison with `AggregateState`
+///
+/// `AggregateState::apply` is infallible because an aggregate always
+/// applies its own events. A projector may process events from any
+/// source, and may do derived computations (sums, counts) that can
+/// overflow.
+pub trait Projector: Send + Sync + 'static {
+    /// The domain event type this projector handles.
+    type Event: DomainEvent;
+
+    /// The derived state produced by folding events.
+    type State: Send + Sync + 'static;
+
+    /// Error type for fallible projection logic.
+    type Error: core::error::Error + Send + Sync + 'static;
+
+    /// The initial state before any events have been applied.
+    fn initial(&self) -> Self::State;
+
+    /// Apply a single event to the current state, producing new state.
+    ///
+    /// Must use checked arithmetic for all computations. Return `Err`
+    /// on overflow, underflow, or any domain-specific invariant
+    /// violation. The framework decides recovery policy.
+    fn apply(&self, state: Self::State, event: &Self::Event) -> Result<Self::State, Self::Error>;
+}
+```
+
+Update `crates/nexus-store/src/projection/mod.rs`:
+
+```rust
+mod pending;
+mod persisted;
+mod projector;
+mod store;
+#[cfg(feature = "testing")]
+mod testing;
+mod trigger;
+
+pub use pending::PendingState;
+pub use persisted::PersistedState;
+pub use projector::Projector;
+pub use store::StateStore;
+#[cfg(feature = "testing")]
+pub use testing::InMemoryStateStore;
+pub use trigger::{AfterEventTypes, EveryNEvents, ProjectionTrigger};
+```
+
+Update re-exports in `crates/nexus-store/src/lib.rs`:
+
+```rust
+#[cfg(feature = "projection")]
+pub use projection::{
+    AfterEventTypes as ProjAfterEventTypes, EveryNEvents as ProjEveryNEvents, PendingState,
+    PersistedState, ProjectionTrigger, Projector, StateStore,
+};
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p nexus-store --features projection -- projection_tests`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add crates/nexus-store/src/projection/projector.rs crates/nexus-store/src/projection/mod.rs crates/nexus-store/src/lib.rs crates/nexus-store/tests/projection_tests.rs
+git commit -m "feat(store): add Projector trait — pure event fold with fallible apply"
+```
+
+---
+
+### Task 7: Run full check and update hakari
+
+**Files:**
+- Possibly modify: `crates/workspace-hack/Cargo.toml`
+
+**Step 1: Generate hakari**
+
+Run: `cargo hakari generate`
+
+If it changes `crates/workspace-hack/Cargo.toml`, stage and include in the commit.
+
+**Step 2: Run clippy**
+
+Run: `cargo clippy -p nexus-store --features "projection,testing" -- -D warnings`
+Expected: PASS — no warnings
+
+**Step 3: Run fmt**
+
+Run: `cargo fmt --all -- --check`
+Expected: PASS
+
+**Step 4: Run full test suite**
+
+Run: `cargo test --workspace`
+Expected: PASS — no regressions. Existing snapshot tests unaffected.
+
+**Step 5: Run tests with all feature combinations**
+
+Run: `cargo test -p nexus-store --features "projection"`
+Run: `cargo test -p nexus-store --features "projection,testing"`
+Run: `cargo test -p nexus-store --features "projection,snapshot"`
+Run: `cargo test -p nexus-store --features "projection,snapshot,testing"`
+Expected: All PASS — no feature interaction issues
+
+**Step 6: Commit**
+
+```bash
+git add -A
+git commit -m "chore: update workspace-hack after projection feature"
+```
+
+---
+
+### Task 8: Final review and PR
+
+**Step 1: Review the complete diff**
+
+Run: `git diff main --stat`
+
+Verify:
+- Only `crates/nexus-store/` files changed (plus workspace-hack if applicable)
+- No changes to `snapshot/` module
+- New `projection/` module with 6 files: `mod.rs`, `pending.rs`, `persisted.rs`, `store.rs`, `trigger.rs`, `projector.rs`, `testing.rs`
+- Feature flags added to `Cargo.toml`
+- Re-exports added to `lib.rs`
+- Tests in `projection_tests.rs`
+
+**Step 2: Create PR**
+
+PR title: `feat(store): projection core traits (#155)`
+
+Body should reference:
+- Parent issue #124
+- Subtask #155
+- That `SnapshotStore` is intentionally untouched (coexistence until #159)
+- That `Projector` is the one genuinely new trait
+- Feature flags: `projection`, `projection-json`

--- a/docs/plans/2026-04-27-projection-runner-design.md
+++ b/docs/plans/2026-04-27-projection-runner-design.md
@@ -1,0 +1,224 @@
+# Projection Runner Design
+
+**Issue:** #157 (Subtask 3 of #124)
+**Date:** 2026-04-27
+**Status:** Approved
+**Depends on:** #155 (core projection traits — completed on this branch)
+
+## Scope
+
+Subscription-powered async projection runner. Single-stream only — multi-stream projections deferred to `$all` stream (#149). Supervision/restart deferred to a separate subtask under #124.
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Hosting model | `async fn run(self, shutdown: impl Future<Output = ()>)` | Caller owns spawning. Runtime-agnostic — no tokio types in public API |
+| Shutdown signal | Generic `impl Future<Output = ()>` | Caller passes `CancellationToken::cancelled()`, channel, or anything. Keeps `nexus-store` runtime-free |
+| Error recovery | Stop on error, return it | Runner processes or dies. Supervision layer (future subtask) handles retry/skip/dead-letter |
+| Checkpoint strategy | `ProjectionTrigger`-driven + flush on shutdown | Reuses existing `EveryNEvents`, `AfterEventTypes` from subtask 1. Dirty tracking flushes partial batches on graceful shutdown |
+| State serialization | Reuse existing `Codec<State>` trait | No new serialization traits. Runner takes two codecs: one for events, one for state |
+| Construction | Typestate builder → opaque `ProjectionRunner` | Consistent with `RepositoryBuilder`. Users never name the 8-param struct directly |
+| Multi-stream | Deferred to `$all` (#149) | Single subscription per runner. `$all` is just another stream — runner works unchanged |
+| New dependencies | None | Uses existing traits only |
+
+## Runner Struct
+
+```rust
+pub struct ProjectionRunner<Id, Sub, Ckpt, SS, P, EC, SC, Trig> {
+    id: Id,              // projection identity (checkpoint + state store key)
+    subscription: Sub,    // event source (Subscription<M>)
+    checkpoint: Ckpt,     // resume position (CheckpointStore)
+    state_store: SS,      // projection state persistence (StateStore)
+    projector: P,         // pure fold (Projector)
+    event_codec: EC,      // decode events from bytes (Codec<Event>)
+    state_codec: SC,      // encode/decode projection state (Codec<State>)
+    trigger: Trig,        // when to persist (ProjectionTrigger)
+}
+```
+
+`run` consumes `self` — the runner is single-use. Restart = build a new one.
+
+## Event Loop
+
+```
+1. Load checkpoint → Option<Version>
+2. Load persisted state (if checkpoint exists) → Option<PersistedState>
+3. Initialize state:
+   - If persisted state exists: decode it via state_codec
+   - Else: projector.initial()
+4. Subscribe(id, from: checkpoint)
+5. Loop:
+   a. select! {
+        event = stream.next() => { process }
+        _ = shutdown => { flush; return Ok(()) }
+      }
+   b. Decode event via event_codec
+   c. state = projector.apply(state, &decoded_event)?
+   d. Track current version + dirty flag
+   e. If trigger.should_project(old_version, new_version, [event_name]):
+      - Encode state via state_codec → PendingState
+      - Save to state_store
+      - Save checkpoint(version)
+      - Update old_version, clear dirty flag
+6. On shutdown: if dirty:
+   - Encode + persist state
+   - Save checkpoint
+```
+
+Key invariants:
+- Checkpoint and state are always saved together — no half-state
+- Dirty flag tracks whether apply has been called since last persist
+- `stream.next()` lending lifetime requires decode before next call (naturally satisfied)
+- `select!` is the only exit from the loop since `Subscription` never returns `None`
+
+## Typestate Builder
+
+```rust
+// Entry point
+ProjectionRunner::builder(projection_id)
+    .subscription(&store)        // required
+    .checkpoint(&store)          // required
+    .projector(MyProjector)      // required
+    .event_codec(json_codec)     // required
+    .state_store(&state_store)   // optional, default: ()
+    .state_codec(json_codec)     // optional, default: ()
+    .trigger(EveryNEvents(100))  // optional, default: EveryNEvents(1)
+    .build()
+```
+
+Defaults:
+- `StateStore` → `()` (no state persistence — valid for side-effect projections)
+- `StateCodec` → `()` (not needed when state store is `()`)
+- `Trigger` → `EveryNEvents(1)` (checkpoint every event)
+
+Order-independent — each setter transitions one typestate slot. `.build()` is only available when all required slots are filled.
+
+## Error Type
+
+```rust
+#[derive(Debug, thiserror::Error)]
+pub enum ProjectionError<P, EC, SC, Ckpt, SS, Sub> {
+    #[error("projector apply failed")]
+    Projector(#[source] P),
+
+    #[error("event codec failed")]
+    EventCodec(#[source] EC),
+
+    #[error("state codec failed")]
+    StateCodec(#[source] SC),
+
+    #[error("checkpoint store failed")]
+    Checkpoint(#[source] Ckpt),
+
+    #[error("state store failed")]
+    StateStore(#[source] SS),
+
+    #[error("subscription stream failed")]
+    Subscription(#[source] Sub),
+}
+```
+
+One variant per failure domain. Generic over concrete error types from each trait. When `StateStore = ()` and `StateCodec = ()`, their error types are `Infallible` — those variants become unconstructable and the compiler dead-code eliminates them.
+
+## File Layout
+
+```
+crates/nexus-store/src/projection/
+├── mod.rs              # existing — add runner re-exports
+├── pending.rs          # existing
+├── persisted.rs        # existing
+├── projector.rs        # existing
+├── store.rs            # existing (StateStore)
+├── trigger.rs          # existing
+├── testing.rs          # existing (InMemoryStateStore)
+├── runner/
+│   ├── mod.rs          # re-exports
+│   ├── runner.rs       # ProjectionRunner struct + run()
+│   ├── builder.rs      # typestate builder
+│   └── error.rs        # ProjectionError
+```
+
+Three new files under `projection/runner/`. Behind existing `projection` feature flag — no new feature flags.
+
+## Testing Strategy
+
+### 1. Sequence/Protocol Tests
+- Subscribe from beginning, process N events, verify state after each trigger fires
+- Resume from checkpoint: process events → shutdown → rebuild runner → verify continues from checkpoint
+- Multiple trigger firings in sequence: verify checkpoint advances correctly
+
+### 2. Lifecycle Tests
+- Start → process events → graceful shutdown → verify final flush
+- Start with no events → shutdown immediately → verify no errors, no state persisted
+- Start with stale state (wrong schema version) → verify falls back to `initial()`
+
+### 3. Defensive Boundary Tests
+- Projector returns error mid-stream → verify runner stops, returns `ProjectionError::Projector`
+- Event codec fails → verify `ProjectionError::EventCodec`
+- State codec fails on encode → verify `ProjectionError::StateCodec`
+- Checkpoint store fails → verify `ProjectionError::Checkpoint`
+- State store fails → verify `ProjectionError::StateStore`
+
+### 4. Linearizability/Isolation Tests
+- Concurrent appender + runner: append events while runner is processing, verify no events lost
+- Runner shutdown during processing: verify partial batch is flushed correctly
+
+All tests use `InMemoryStore` (subscription + checkpoint) and `InMemoryStateStore`.
+
+## Architecture Diagram
+
+```
+                         ┌──────────────────┐
+                         │   Caller/Host    │
+                         │ tokio::spawn(    │
+                         │   runner.run(    │
+                         │     shutdown))   │
+                         └────────┬─────────┘
+                                  │
+                    ┌─────────────▼──────────────┐
+                    │     ProjectionRunner        │
+                    │                             │
+                    │  ┌───────────────────────┐  │
+                    │  │     Event Loop        │  │
+                    │  │                       │  │
+                    │  │  select! {            │  │
+                    │  │    stream.next() =>   │  │
+                    │  │      decode           │  │
+                    │  │      apply            │  │
+                    │  │      trigger check    │  │
+                    │  │      persist?         │  │
+                    │  │    shutdown =>        │  │
+                    │  │      flush + return   │  │
+                    │  │  }                    │  │
+                    │  └───────────────────────┘  │
+                    └──┬───┬───┬───┬───┬───┬──────┘
+                       │   │   │   │   │   │
+          ┌────────────┘   │   │   │   │   └──────────────┐
+          ▼                ▼   │   ▼   ▼                  ▼
+    Subscription      Codec(E) │ Codec(S) StateStore  Projector
+    (event source)    (decode) │ (ser/de) (persist)   (fold)
+                               ▼
+                        CheckpointStore
+                        (resume position)
+```
+
+## Out of Scope
+
+- Supervision / restart / backoff (separate subtask under #124)
+- Multi-stream fan-in (depends on `$all` stream #149)
+- Inline/same-transaction projections (#156)
+- Rebuilding from scratch (subtask 4)
+- Competing consumers / parallelism (Tier 2+)
+
+## References
+
+- Subscription trait: `crates/nexus-store/src/store/subscription/subscription.rs`
+- CheckpointStore: `crates/nexus-store/src/store/subscription/checkpoint.rs`
+- Projector: `crates/nexus-store/src/projection/projector.rs`
+- StateStore: `crates/nexus-store/src/projection/store.rs`
+- Codec: `crates/nexus-store/src/codec/owning.rs`
+- RepositoryBuilder (pattern reference): `crates/nexus-store/src/store/repository/builder.rs`
+- disintegrate PgEventListener (reference implementation): https://github.com/disintegrate-es/disintegrate
+- Axon Streaming Event Processors: https://docs.axoniq.io/axon-framework-reference/4.12/events/event-processors/streaming/
+- Marten Async Daemon: https://martendb.io/events/projections/async-daemon.html

--- a/docs/plans/2026-04-27-projection-runner-impl.md
+++ b/docs/plans/2026-04-27-projection-runner-impl.md
@@ -1,0 +1,1874 @@
+# Projection Runner Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Build the subscription-powered async projection runner that processes events via `Subscription` + `CheckpointStore` + `Projector` + `StateStore`, closing #157.
+
+**Architecture:** A `ProjectionRunner` struct composed via typestate builder. Internal event loop uses `core::future::poll_fn` for runtime-agnostic select (no tokio dependency). State persistence is polymorphic via a `StatePersistence<S>` trait with no-op and real impls, avoiding the impossible `Codec<T> for ()` problem.
+
+**Tech Stack:** Rust (edition 2024), nexus-store crate, tokio (testing only), proptest
+
+---
+
+### Task 1: Add `ProjectionError` and `StatePersistError`
+
+**Files:**
+- Create: `crates/nexus-store/src/projection/runner/error.rs`
+- Create: `crates/nexus-store/src/projection/runner/mod.rs`
+- Modify: `crates/nexus-store/src/projection/mod.rs`
+- Modify: `crates/nexus-store/tests/projection_tests.rs`
+
+**Step 1: Write failing tests**
+
+Append to `crates/nexus-store/tests/projection_tests.rs`:
+
+```rust
+// ── ProjectionError ─────────────────────────────────────────────
+use nexus_store::projection::runner::ProjectionError;
+
+#[test]
+fn projection_error_displays_projector_variant() {
+    let err: ProjectionError<ProjectionError_, std::io::Error, std::convert::Infallible, std::io::Error, std::io::Error> =
+        ProjectionError::Projector(ProjectionError_);
+    let msg = err.to_string();
+    assert!(msg.contains("projector"), "expected 'projector' in: {msg}");
+}
+
+#[test]
+fn projection_error_state_variant_is_unconstructable_when_infallible() {
+    // When StatePersistence = NoStatePersistence, SP::Error = Infallible.
+    // The State variant cannot be constructed — this is a compile-time property.
+    // We verify by constructing other variants with Infallible as the SP type param.
+    let _err: ProjectionError<ProjectionError_, std::io::Error, std::convert::Infallible, std::io::Error, std::io::Error> =
+        ProjectionError::Projector(ProjectionError_);
+    // If this compiles, the State(Infallible) variant is unconstructable. ��
+}
+
+// Rename existing test error to avoid collision
+```
+
+**Note:** The existing `ProjectionError` struct in the test file (line 338) must be renamed to `ProjectionError_` to avoid collision with the new `ProjectionError` enum. Update all references.
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p nexus-store --features "projection,testing" -- projection_tests::projection_error`
+Expected: FAIL — module `runner` not found
+
+**Step 3: Create the error types**
+
+Create `crates/nexus-store/src/projection/runner/error.rs`:
+
+```rust
+use thiserror::Error;
+
+/// Errors from the projection runner.
+///
+/// Generic over projector (`P`), event codec (`EC`), state persistence (`SP`),
+/// checkpoint store (`Ckpt`), and subscription (`Sub`) error types.
+/// When state persistence is disabled (`NoStatePersistence`), `SP = Infallible`
+/// and the `State` variant is unconstructable.
+#[derive(Debug, Error)]
+pub enum ProjectionError<P, EC, SP, Ckpt, Sub> {
+    /// Projector `apply` failed (business logic error).
+    #[error("projector apply failed: {0}")]
+    Projector(#[source] P),
+
+    /// Event deserialization failed.
+    #[error("event codec failed: {0}")]
+    EventCodec(#[source] EC),
+
+    /// State persistence failed (store or codec).
+    #[error("state persistence failed: {0}")]
+    State(#[source] SP),
+
+    /// Checkpoint load or save failed.
+    #[error("checkpoint failed: {0}")]
+    Checkpoint(#[source] Ckpt),
+
+    /// Subscription or event stream failed.
+    #[error("subscription failed: {0}")]
+    Subscription(#[source] Sub),
+}
+
+/// Errors from state persistence operations.
+///
+/// Wraps both state store and state codec errors. Used as
+/// `SP::Error` in [`ProjectionError`] when state persistence is enabled.
+#[derive(Debug, Error)]
+pub enum StatePersistError<S, C> {
+    /// State store operation failed (load or save).
+    #[error("state store error: {0}")]
+    Store(#[source] S),
+
+    /// State codec operation failed (encode or decode).
+    #[error("state codec error: {0}")]
+    Codec(#[source] C),
+}
+```
+
+Create `crates/nexus-store/src/projection/runner/mod.rs`:
+
+```rust
+mod error;
+
+pub use error::{ProjectionError, StatePersistError};
+```
+
+Update `crates/nexus-store/src/projection/mod.rs` — add the runner module:
+
+```rust
+mod pending;
+mod persisted;
+mod projector;
+pub mod runner;
+mod store;
+#[cfg(feature = "testing")]
+mod testing;
+mod trigger;
+
+pub use pending::PendingState;
+pub use persisted::PersistedState;
+pub use projector::Projector;
+pub use store::StateStore;
+#[cfg(feature = "testing")]
+pub use testing::InMemoryStateStore;
+pub use trigger::{AfterEventTypes, EveryNEvents, ProjectionTrigger};
+```
+
+**Step 4: Rename test fixture to avoid collision**
+
+In `crates/nexus-store/tests/projection_tests.rs`, rename the existing `ProjectionError` struct (line 338) to `TestProjectionError` and update all references (lines 341, 350, 353, 357):
+
+```rust
+#[derive(Debug, thiserror::Error)]
+#[error("overflow")]
+struct TestProjectionError;
+
+impl Projector for CountingProjector {
+    type Event = TestEvent;
+    type State = CountState;
+    type Error = TestProjectionError;
+
+    fn initial(&self) -> CountState {
+        CountState { count: 0, total: 0 }
+    }
+
+    fn apply(&self, state: CountState, event: &TestEvent) -> Result<CountState, TestProjectionError> {
+        match event {
+            TestEvent::Added(n) => Ok(CountState {
+                count: state.count.checked_add(1).ok_or(TestProjectionError)?,
+                total: state.total.checked_add(*n).ok_or(TestProjectionError)?,
+            }),
+            TestEvent::Removed(n) => Ok(CountState {
+                count: state.count.checked_add(1).ok_or(TestProjectionError)?,
+                total: state.total.checked_sub(*n).ok_or(TestProjectionError)?,
+            }),
+        }
+    }
+}
+```
+
+**Step 5: Run tests to verify they pass**
+
+Run: `cargo test -p nexus-store --features "projection,testing" -- projection_tests`
+Expected: PASS
+
+**Step 6: Commit**
+
+```bash
+git add crates/nexus-store/src/projection/runner/ crates/nexus-store/src/projection/mod.rs crates/nexus-store/tests/projection_tests.rs
+git commit -m "feat(store): add ProjectionError and StatePersistError for runner"
+```
+
+---
+
+### Task 2: Add `StatePersistence` trait with `NoStatePersistence` and `WithStatePersistence`
+
+**Files:**
+- Create: `crates/nexus-store/src/projection/runner/persist.rs`
+- Modify: `crates/nexus-store/src/projection/runner/mod.rs`
+- Modify: `crates/nexus-store/tests/projection_tests.rs`
+
+**Step 1: Write failing tests**
+
+Append to `crates/nexus-store/tests/projection_tests.rs`:
+
+```rust
+use nexus_store::projection::runner::NoStatePersistence;
+
+// ── NoStatePersistence ──────────────────────────────────────────
+
+#[tokio::test]
+async fn no_state_persistence_load_returns_none() {
+    let sp = NoStatePersistence;
+    let id = TestId("proj-1".into());
+    let result: Result<Option<(CountState, _)>, _> = sp.load(&id).await;
+    assert!(result.unwrap().is_none());
+}
+
+#[tokio::test]
+async fn no_state_persistence_save_succeeds() {
+    let sp = NoStatePersistence;
+    let id = TestId("proj-1".into());
+    let state = CountState { count: 1, total: 10 };
+    let version = Version::new(5).unwrap();
+    let result = sp.save(&id, version, &state).await;
+    assert!(result.is_ok());
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p nexus-store --features "projection,testing" -- projection_tests::no_state_persistence`
+Expected: FAIL — `NoStatePersistence` not found
+
+**Step 3: Create the StatePersistence trait and implementations**
+
+Create `crates/nexus-store/src/projection/runner/persist.rs`:
+
+```rust
+use std::convert::Infallible;
+use std::future::Future;
+use std::num::NonZeroU32;
+
+use nexus::{Id, Version};
+
+use crate::codec::Codec;
+use crate::projection::pending::PendingState;
+use crate::projection::store::StateStore;
+
+use super::error::StatePersistError;
+
+/// Polymorphic state persistence — either disabled or enabled with a store + codec.
+///
+/// This trait exists to solve a type-system problem: when state persistence is
+/// disabled (`StateStore = ()`), we need a no-op codec. But `Codec<T> for ()`
+/// is impossible in safe Rust (can't construct arbitrary `T` in `decode`).
+/// Instead, `NoStatePersistence` implements this trait with `Error = Infallible`
+/// and never touches any codec.
+pub trait StatePersistence<S>: Send + Sync {
+    /// Error type for state persistence operations.
+    type Error: core::error::Error + Send + Sync + 'static;
+
+    /// Load persisted state, if any.
+    ///
+    /// Returns `None` when no state exists or schema version is stale.
+    fn load(
+        &self,
+        id: &impl Id,
+    ) -> impl Future<Output = Result<Option<(S, Version)>, Self::Error>> + Send;
+
+    /// Persist state at the given version.
+    fn save(
+        &self,
+        id: &impl Id,
+        version: Version,
+        state: &S,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// NoStatePersistence — state persistence disabled
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// No-op state persistence. `load` returns `None`, `save` discards.
+///
+/// Used as the default when `.state_store()` is not called on the builder.
+#[derive(Debug, Clone, Copy)]
+pub struct NoStatePersistence;
+
+impl<S: Send + Sync> StatePersistence<S> for NoStatePersistence {
+    type Error = Infallible;
+
+    async fn load(&self, _id: &impl Id) -> Result<Option<(S, Version)>, Infallible> {
+        Ok(None)
+    }
+
+    async fn save(
+        &self,
+        _id: &impl Id,
+        _version: Version,
+        _state: &S,
+    ) -> Result<(), Infallible> {
+        Ok(())
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// WithStatePersistence — state persistence enabled
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// State persistence backed by a [`StateStore`] and [`Codec`].
+///
+/// Created by the builder's `.state_store(store, codec)` method.
+pub struct WithStatePersistence<SS, SC> {
+    pub(crate) store: SS,
+    pub(crate) codec: SC,
+    pub(crate) schema_version: NonZeroU32,
+}
+
+impl<S, SS, SC> StatePersistence<S> for WithStatePersistence<SS, SC>
+where
+    S: Send + Sync,
+    SS: StateStore,
+    SC: Codec<S>,
+{
+    type Error = StatePersistError<SS::Error, SC::Error>;
+
+    async fn load(
+        &self,
+        id: &impl Id,
+    ) -> Result<Option<(S, Version)>, Self::Error> {
+        let persisted = self
+            .store
+            .load(id, self.schema_version)
+            .await
+            .map_err(StatePersistError::Store)?;
+
+        persisted
+            .map(|p| {
+                let state = self
+                    .codec
+                    .decode("projection_state", p.payload())
+                    .map_err(StatePersistError::Codec)?;
+                Ok((state, p.version()))
+            })
+            .transpose()
+    }
+
+    async fn save(
+        &self,
+        id: &impl Id,
+        version: Version,
+        state: &S,
+    ) -> Result<(), Self::Error> {
+        let payload = self
+            .codec
+            .encode(state)
+            .map_err(StatePersistError::Codec)?;
+        let pending = PendingState::new(version, self.schema_version, payload);
+        self.store
+            .save(id, &pending)
+            .await
+            .map_err(StatePersistError::Store)
+    }
+}
+```
+
+Update `crates/nexus-store/src/projection/runner/mod.rs`:
+
+```rust
+mod error;
+mod persist;
+
+pub use error::{ProjectionError, StatePersistError};
+pub use persist::{NoStatePersistence, StatePersistence, WithStatePersistence};
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p nexus-store --features "projection,testing" -- projection_tests`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add crates/nexus-store/src/projection/runner/persist.rs crates/nexus-store/src/projection/runner/mod.rs crates/nexus-store/tests/projection_tests.rs
+git commit -m "feat(store): add StatePersistence trait with NoStatePersistence and WithStatePersistence"
+```
+
+---
+
+### Task 3: Add `WithStatePersistence` integration tests
+
+**Files:**
+- Modify: `crates/nexus-store/tests/projection_tests.rs`
+
+**Step 1: Write tests for `WithStatePersistence` load/save roundtrip**
+
+Append to `crates/nexus-store/tests/projection_tests.rs` inside the `#[cfg(feature = "testing")]` module (or create a new module):
+
+```rust
+#[cfg(feature = "testing")]
+mod state_persistence_tests {
+    use super::*;
+    use nexus_store::projection::runner::WithStatePersistence;
+    use nexus_store::projection::InMemoryStateStore;
+    use nexus_store::Codec;
+    use std::num::NonZeroU32;
+
+    /// A test codec for CountState.
+    struct CountStateCodec;
+
+    impl Codec<CountState> for CountStateCodec {
+        type Error = std::io::Error;
+
+        fn encode(&self, state: &CountState) -> Result<Vec<u8>, Self::Error> {
+            // Simple encoding: count as 8 bytes + total as 8 bytes
+            let mut buf = Vec::with_capacity(16);
+            buf.extend_from_slice(&state.count.to_le_bytes());
+            buf.extend_from_slice(&state.total.to_le_bytes());
+            Ok(buf)
+        }
+
+        fn decode(&self, _name: &str, payload: &[u8]) -> Result<CountState, Self::Error> {
+            if payload.len() != 16 {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "expected 16 bytes",
+                ));
+            }
+            let count = u64::from_le_bytes(payload[..8].try_into().unwrap());
+            let total = u64::from_le_bytes(payload[8..].try_into().unwrap());
+            Ok(CountState { count, total })
+        }
+    }
+
+    #[tokio::test]
+    async fn with_state_persistence_save_then_load_roundtrips() {
+        let store = InMemoryStateStore::new();
+        let sp = WithStatePersistence {
+            store,
+            codec: CountStateCodec,
+            schema_version: NonZeroU32::MIN,
+        };
+
+        let id = TestId("proj-1".into());
+        let state = CountState { count: 3, total: 42 };
+        let version = Version::new(10).unwrap();
+
+        use nexus_store::projection::runner::StatePersistence;
+        sp.save(&id, version, &state).await.unwrap();
+
+        let loaded = sp.load(&id).await.unwrap().unwrap();
+        assert_eq!(loaded.0, state);
+        assert_eq!(loaded.1, version);
+    }
+
+    #[tokio::test]
+    async fn with_state_persistence_load_returns_none_when_empty() {
+        let store = InMemoryStateStore::new();
+        let sp = WithStatePersistence {
+            store,
+            codec: CountStateCodec,
+            schema_version: NonZeroU32::MIN,
+        };
+
+        let id = TestId("proj-1".into());
+        use nexus_store::projection::runner::StatePersistence;
+        let result: Option<(CountState, _)> = sp.load(&id).await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn with_state_persistence_load_returns_none_on_schema_mismatch() {
+        let store = InMemoryStateStore::new();
+        let sp = WithStatePersistence {
+            store: &store,
+            codec: CountStateCodec,
+            schema_version: NonZeroU32::MIN,
+        };
+
+        let id = TestId("proj-1".into());
+        use nexus_store::projection::runner::StatePersistence;
+        sp.save(&id, Version::new(5).unwrap(), &CountState { count: 1, total: 1 })
+            .await
+            .unwrap();
+
+        // Load with a different schema version
+        let sp_v2 = WithStatePersistence {
+            store: &store,
+            codec: CountStateCodec,
+            schema_version: NonZeroU32::new(2).unwrap(),
+        };
+        let result: Option<(CountState, _)> = sp_v2.load(&id).await.unwrap();
+        assert!(result.is_none());
+    }
+}
+```
+
+**Step 2: Run tests to verify they pass**
+
+Run: `cargo test -p nexus-store --features "projection,testing" -- state_persistence_tests`
+Expected: PASS
+
+**Step 3: Commit**
+
+```bash
+git add crates/nexus-store/tests/projection_tests.rs
+git commit -m "test(store): add WithStatePersistence integration tests"
+```
+
+---
+
+### Task 4: Add `ProjectionRunner` struct and typestate builder
+
+**Files:**
+- Create: `crates/nexus-store/src/projection/runner/runner.rs`
+- Create: `crates/nexus-store/src/projection/runner/builder.rs`
+- Modify: `crates/nexus-store/src/projection/runner/mod.rs`
+- Modify: `crates/nexus-store/tests/projection_tests.rs`
+
+**Step 1: Write failing tests**
+
+Append to `crates/nexus-store/tests/projection_tests.rs`:
+
+```rust
+#[cfg(feature = "testing")]
+mod builder_tests {
+    use super::*;
+    use std::num::NonZeroU64;
+    use nexus_store::projection::runner::ProjectionRunner;
+    use nexus_store::projection::EveryNEvents as ProjEveryNEvents;
+    use nexus_store::testing::InMemoryStore;
+
+    #[test]
+    fn builder_creates_runner_with_required_fields_only() {
+        let store = InMemoryStore::new();
+        let _runner = ProjectionRunner::builder(TestId("proj-1".into()))
+            .subscription(&store)
+            .checkpoint(&store)
+            .projector(CountingProjector)
+            .event_codec(CountStateCodec)
+            .build();
+    }
+
+    #[test]
+    fn builder_creates_runner_with_all_fields() {
+        let store = InMemoryStore::new();
+        let state_store = nexus_store::projection::InMemoryStateStore::new();
+        let _runner = ProjectionRunner::builder(TestId("proj-1".into()))
+            .subscription(&store)
+            .checkpoint(&store)
+            .projector(CountingProjector)
+            .event_codec(CountStateCodec)
+            .state_store(&state_store, CountStateCodec)
+            .trigger(ProjEveryNEvents(NonZeroU64::new(10).unwrap()))
+            .build();
+    }
+}
+```
+
+Note: `CountStateCodec` from the `state_persistence_tests` module must be moved to the top-level test scope (or duplicated) so `builder_tests` can use it. Move the `CountStateCodec` definition to after `CountingProjector` at the top level of the test file.
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p nexus-store --features "projection,testing" -- builder_tests`
+Expected: FAIL — `ProjectionRunner::builder` not found
+
+**Step 3: Create the runner struct**
+
+Create `crates/nexus-store/src/projection/runner/runner.rs`:
+
+```rust
+use std::future::Future;
+
+use nexus::{DomainEvent, Id, Version};
+
+use crate::codec::Codec;
+use crate::store::stream::EventStream;
+use crate::store::subscription::checkpoint::CheckpointStore;
+use crate::store::subscription::subscription::Subscription;
+
+use super::error::ProjectionError;
+use super::persist::StatePersistence;
+use crate::projection::projector::Projector;
+use crate::projection::trigger::ProjectionTrigger;
+
+/// Subscription-powered async projection runner.
+///
+/// Subscribes to an event stream, decodes events, folds them through a
+/// [`Projector`], persists state via [`StatePersistence`], and checkpoints
+/// progress. Runs until the shutdown signal fires or an error occurs.
+///
+/// Constructed via [`ProjectionRunner::builder`]. The runner is single-use:
+/// `run` consumes `self`. Restart by building a new runner.
+pub struct ProjectionRunner<Id, Sub, Ckpt, SP, P, EC, Trig> {
+    pub(crate) id: Id,
+    pub(crate) subscription: Sub,
+    pub(crate) checkpoint: Ckpt,
+    pub(crate) state_persistence: SP,
+    pub(crate) projector: P,
+    pub(crate) event_codec: EC,
+    pub(crate) trigger: Trig,
+}
+
+impl<I, Sub, Ckpt, SP, P, EC, Trig> ProjectionRunner<I, Sub, Ckpt, SP, P, EC, Trig>
+where
+    I: Id + Clone,
+    Sub: Subscription<()>,
+    for<'a> Sub::Stream<'a>: EventStream<(), Error = Sub::Error>,
+    Ckpt: CheckpointStore,
+    SP: StatePersistence<P::State>,
+    P: Projector,
+    EC: Codec<P::Event>,
+    Trig: ProjectionTrigger,
+{
+    /// Run the projection loop until shutdown or error.
+    ///
+    /// # Event loop
+    ///
+    /// 1. Load checkpoint (resume position)
+    /// 2. Load persisted state (or use `projector.initial()`)
+    /// 3. Subscribe to the event stream from the checkpoint
+    /// 4. For each event: decode → apply → trigger check → maybe persist + checkpoint
+    /// 5. On shutdown: flush dirty state + checkpoint, return `Ok(())`
+    ///
+    /// # Errors
+    ///
+    /// Returns immediately on any error. The supervision layer (separate
+    /// component) is responsible for retry/restart policy.
+    pub async fn run(
+        self,
+        shutdown: impl Future<Output = ()>,
+    ) -> Result<
+        (),
+        ProjectionError<P::Error, EC::Error, SP::Error, Ckpt::Error, Sub::Error>,
+    > {
+        let Self {
+            id,
+            subscription,
+            checkpoint,
+            state_persistence,
+            projector,
+            event_codec,
+            trigger,
+        } = self;
+
+        // 1. Load checkpoint
+        let last_checkpoint = checkpoint
+            .load(&id)
+            .await
+            .map_err(ProjectionError::Checkpoint)?;
+
+        // 2. Load persisted state or start fresh
+        let (mut state, loaded_version) = match state_persistence
+            .load(&id)
+            .await
+            .map_err(ProjectionError::State)?
+        {
+            Some((s, v)) => (s, Some(v)),
+            None => (projector.initial(), None),
+        };
+
+        // Use the further-ahead position: checkpoint may be ahead of state
+        // (if state store failed after checkpoint succeeded on a prior run),
+        // or state may be ahead (vice versa). Use the checkpoint for resume
+        // position since it's the source of truth for "which events have
+        // been processed."
+        let resume_from = last_checkpoint;
+
+        // 3. Subscribe from checkpoint
+        let mut stream = subscription
+            .subscribe(&id, resume_from)
+            .await
+            .map_err(ProjectionError::Subscription)?;
+
+        let mut shutdown = core::pin::pin!(shutdown);
+        let mut last_persisted_version = loaded_version.or(last_checkpoint);
+        let mut current_version = resume_from;
+        let mut dirty = false;
+
+        // 4. Event loop
+        loop {
+            // Race stream.next() against shutdown using poll_fn.
+            // Decode inside the poll closure while the lending borrow is valid,
+            // extract only owned data.
+            let step = {
+                let mut next = core::pin::pin!(stream.next());
+                core::future::poll_fn(|cx| {
+                    // Check shutdown
+                    if let core::task::Poll::Ready(()) = shutdown.as_mut().poll(cx) {
+                        return core::task::Poll::Ready(Ok(None));
+                    }
+                    // Check event stream
+                    match next.as_mut().poll(cx) {
+                        core::task::Poll::Ready(Ok(Some(envelope))) => {
+                            let version = envelope.version();
+                            let decoded = event_codec
+                                .decode(envelope.event_type(), envelope.payload());
+                            core::task::Poll::Ready(
+                                decoded
+                                    .map(|event| Some((version, event)))
+                                    .map_err(ProjectionError::EventCodec),
+                            )
+                        }
+                        core::task::Poll::Ready(Ok(None)) => {
+                            // Subscription contract: never returns None.
+                            // Treat as stream ended — return gracefully.
+                            core::task::Poll::Ready(Ok(None))
+                        }
+                        core::task::Poll::Ready(Err(e)) => {
+                            core::task::Poll::Ready(Err(ProjectionError::Subscription(e)))
+                        }
+                        core::task::Poll::Pending => core::task::Poll::Pending,
+                    }
+                })
+                .await?
+            };
+
+            let Some((version, event)) = step else {
+                // Shutdown or stream ended — flush if dirty
+                if dirty {
+                    if let Some(ver) = current_version {
+                        state_persistence
+                            .save(&id, ver, &state)
+                            .await
+                            .map_err(ProjectionError::State)?;
+                        checkpoint
+                            .save(&id, ver)
+                            .await
+                            .map_err(ProjectionError::Checkpoint)?;
+                    }
+                }
+                return Ok(());
+            };
+
+            // Apply event
+            state = projector
+                .apply(state, &event)
+                .map_err(ProjectionError::Projector)?;
+            current_version = Some(version);
+            dirty = true;
+
+            // Check trigger
+            let event_name = event.name();
+            if trigger.should_project(
+                last_persisted_version,
+                version,
+                core::iter::once(event_name),
+            ) {
+                state_persistence
+                    .save(&id, version, &state)
+                    .await
+                    .map_err(ProjectionError::State)?;
+                checkpoint
+                    .save(&id, version)
+                    .await
+                    .map_err(ProjectionError::Checkpoint)?;
+                last_persisted_version = Some(version);
+                dirty = false;
+            }
+        }
+    }
+}
+```
+
+**Step 4: Create the typestate builder**
+
+Create `crates/nexus-store/src/projection/runner/builder.rs`:
+
+```rust
+use std::marker::PhantomData;
+use std::num::{NonZeroU32, NonZeroU64};
+
+use super::persist::{NoStatePersistence, WithStatePersistence};
+use super::runner::ProjectionRunner;
+use crate::projection::trigger::EveryNEvents;
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Typestate markers — compile-time guards for required fields
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Marker: subscription not yet configured. `!Send` prevents `.build()`.
+pub struct NeedsSub(PhantomData<*const ()>);
+/// Marker: checkpoint store not yet configured. `!Send` prevents `.build()`.
+pub struct NeedsCkpt(PhantomData<*const ()>);
+/// Marker: projector not yet configured. `!Send` prevents `.build()`.
+pub struct NeedsProj(PhantomData<*const ()>);
+/// Marker: event codec not yet configured. `!Send` prevents `.build()`.
+pub struct NeedsEvtCodec(PhantomData<*const ()>);
+
+/// Default trigger: checkpoint every event.
+const DEFAULT_TRIGGER_INTERVAL: u64 = 1;
+
+/// Default state schema version.
+const DEFAULT_STATE_SCHEMA_VERSION: NonZeroU32 = NonZeroU32::MIN;
+
+// ═══════════════════════════════════════════════════════════════════════════
+// ProjectionRunnerBuilder
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Typestate builder for [`ProjectionRunner`].
+///
+/// Created via [`ProjectionRunner::builder`]. Required fields must be set
+/// before `.build()` becomes available: `subscription`, `checkpoint`,
+/// `projector`, and `event_codec`.
+///
+/// Optional fields have defaults:
+/// - `state_persistence` → [`NoStatePersistence`] (state not persisted)
+/// - `trigger` → [`EveryNEvents(1)`](EveryNEvents) (checkpoint every event)
+pub struct ProjectionRunnerBuilder<Id, Sub, Ckpt, SP, P, EC, Trig> {
+    id: Id,
+    subscription: Sub,
+    checkpoint: Ckpt,
+    state_persistence: SP,
+    projector: P,
+    event_codec: EC,
+    trigger: Trig,
+}
+
+// ── Entry point ─────────────────────────────────────────────────────────
+
+impl<I> ProjectionRunner<I, NeedsSub, NeedsCkpt, NoStatePersistence, NeedsProj, NeedsEvtCodec, EveryNEvents> {
+    /// Start building a new projection runner.
+    #[must_use]
+    #[allow(
+        clippy::expect_used,
+        reason = "DEFAULT_TRIGGER_INTERVAL is non-zero by inspection"
+    )]
+    pub fn builder(id: I) -> ProjectionRunnerBuilder<I, NeedsSub, NeedsCkpt, NoStatePersistence, NeedsProj, NeedsEvtCodec, EveryNEvents> {
+        ProjectionRunnerBuilder {
+            id,
+            subscription: NeedsSub(PhantomData),
+            checkpoint: NeedsCkpt(PhantomData),
+            state_persistence: NoStatePersistence,
+            projector: NeedsProj(PhantomData),
+            event_codec: NeedsEvtCodec(PhantomData),
+            trigger: EveryNEvents(
+                NonZeroU64::new(DEFAULT_TRIGGER_INTERVAL)
+                    .expect("DEFAULT_TRIGGER_INTERVAL is non-zero"),
+            ),
+        }
+    }
+}
+
+// ── Required setters ────────────────────────────────────────────────────
+
+impl<Id, Sub, Ckpt, SP, P, EC, Trig> ProjectionRunnerBuilder<Id, Sub, Ckpt, SP, P, EC, Trig> {
+    /// Set the subscription source (event stream).
+    #[must_use]
+    pub fn subscription<NewSub>(self, sub: NewSub) -> ProjectionRunnerBuilder<Id, NewSub, Ckpt, SP, P, EC, Trig> {
+        ProjectionRunnerBuilder {
+            id: self.id,
+            subscription: sub,
+            checkpoint: self.checkpoint,
+            state_persistence: self.state_persistence,
+            projector: self.projector,
+            event_codec: self.event_codec,
+            trigger: self.trigger,
+        }
+    }
+
+    /// Set the checkpoint store (resume position persistence).
+    #[must_use]
+    pub fn checkpoint<NewCkpt>(self, ckpt: NewCkpt) -> ProjectionRunnerBuilder<Id, Sub, NewCkpt, SP, P, EC, Trig> {
+        ProjectionRunnerBuilder {
+            id: self.id,
+            subscription: self.subscription,
+            checkpoint: ckpt,
+            state_persistence: self.state_persistence,
+            projector: self.projector,
+            event_codec: self.event_codec,
+            trigger: self.trigger,
+        }
+    }
+
+    /// Set the projector (pure event fold function).
+    #[must_use]
+    pub fn projector<NewP>(self, proj: NewP) -> ProjectionRunnerBuilder<Id, Sub, Ckpt, SP, NewP, EC, Trig> {
+        ProjectionRunnerBuilder {
+            id: self.id,
+            subscription: self.subscription,
+            checkpoint: self.checkpoint,
+            state_persistence: self.state_persistence,
+            projector: proj,
+            event_codec: self.event_codec,
+            trigger: self.trigger,
+        }
+    }
+
+    /// Set the event codec (deserializes events from the stream).
+    #[must_use]
+    pub fn event_codec<NewEC>(self, codec: NewEC) -> ProjectionRunnerBuilder<Id, Sub, Ckpt, SP, P, NewEC, Trig> {
+        ProjectionRunnerBuilder {
+            id: self.id,
+            subscription: self.subscription,
+            checkpoint: self.checkpoint,
+            state_persistence: self.state_persistence,
+            projector: self.projector,
+            event_codec: codec,
+            trigger: self.trigger,
+        }
+    }
+}
+
+// ── Optional setters ────────────────────────────────────────────────────
+
+impl<Id, Sub, Ckpt, SP, P, EC, Trig> ProjectionRunnerBuilder<Id, Sub, Ckpt, SP, P, EC, Trig> {
+    /// Enable state persistence with a store and codec.
+    ///
+    /// When not called, state persistence is disabled — the runner only
+    /// checkpoints progress, it doesn't persist the folded state.
+    #[must_use]
+    pub fn state_store<SS, SC>(
+        self,
+        store: SS,
+        codec: SC,
+    ) -> ProjectionRunnerBuilder<Id, Sub, Ckpt, WithStatePersistence<SS, SC>, P, EC, Trig> {
+        ProjectionRunnerBuilder {
+            id: self.id,
+            subscription: self.subscription,
+            checkpoint: self.checkpoint,
+            state_persistence: WithStatePersistence {
+                store,
+                codec,
+                schema_version: DEFAULT_STATE_SCHEMA_VERSION,
+            },
+            projector: self.projector,
+            event_codec: self.event_codec,
+            trigger: self.trigger,
+        }
+    }
+
+    /// Set the projection trigger (when to persist state + checkpoint).
+    ///
+    /// Default: [`EveryNEvents(1)`](EveryNEvents) (checkpoint every event).
+    #[must_use]
+    pub fn trigger<NewTrig>(self, trigger: NewTrig) -> ProjectionRunnerBuilder<Id, Sub, Ckpt, SP, P, EC, NewTrig> {
+        ProjectionRunnerBuilder {
+            id: self.id,
+            subscription: self.subscription,
+            checkpoint: self.checkpoint,
+            state_persistence: self.state_persistence,
+            projector: self.projector,
+            event_codec: self.event_codec,
+            trigger,
+        }
+    }
+}
+
+// ── Schema version setter (only when state store is configured) ─────────
+
+impl<Id, Sub, Ckpt, SS, SC, P, EC, Trig> ProjectionRunnerBuilder<Id, Sub, Ckpt, WithStatePersistence<SS, SC>, P, EC, Trig> {
+    /// Set the schema version for state invalidation.
+    ///
+    /// Default: 1. Increment when the projection state shape changes
+    /// to trigger re-computation from scratch.
+    #[must_use]
+    pub fn state_schema_version(mut self, version: NonZeroU32) -> Self {
+        self.state_persistence.schema_version = version;
+        self
+    }
+}
+
+// ── Terminal: .build() ──────────────────────────────────────────────────
+
+impl<Id, Sub, Ckpt, SP, P, EC, Trig> ProjectionRunnerBuilder<Id, Sub, Ckpt, SP, P, EC, Trig>
+where
+    Sub: Send + Sync,
+    Ckpt: Send + Sync,
+    P: Send + Sync,
+    EC: Send + Sync,
+{
+    /// Build the projection runner.
+    ///
+    /// Only available when all required fields are set. The `Send + Sync`
+    /// bounds exclude `Needs*` markers (which are `!Send`).
+    #[must_use]
+    pub fn build(self) -> ProjectionRunner<Id, Sub, Ckpt, SP, P, EC, Trig> {
+        ProjectionRunner {
+            id: self.id,
+            subscription: self.subscription,
+            checkpoint: self.checkpoint,
+            state_persistence: self.state_persistence,
+            projector: self.projector,
+            event_codec: self.event_codec,
+            trigger: self.trigger,
+        }
+    }
+}
+```
+
+**Step 5: Update module re-exports**
+
+Update `crates/nexus-store/src/projection/runner/mod.rs`:
+
+```rust
+mod builder;
+mod error;
+mod persist;
+mod runner;
+
+pub use builder::ProjectionRunnerBuilder;
+pub use error::{ProjectionError, StatePersistError};
+pub use persist::{NoStatePersistence, StatePersistence, WithStatePersistence};
+pub use runner::ProjectionRunner;
+```
+
+**Step 6: Add crate-level re-exports**
+
+Append to the projection re-exports in `crates/nexus-store/src/lib.rs`:
+
+```rust
+#[cfg(feature = "projection")]
+pub use projection::runner::{ProjectionError, ProjectionRunner};
+```
+
+**Step 7: Run tests to verify they pass**
+
+Run: `cargo test -p nexus-store --features "projection,testing" -- builder_tests`
+Expected: PASS
+
+Run: `cargo test -p nexus-store --features "projection,testing" -- projection_tests`
+Expected: PASS (all existing + new tests)
+
+**Step 8: Commit**
+
+```bash
+git add crates/nexus-store/src/projection/runner/ crates/nexus-store/src/lib.rs crates/nexus-store/tests/projection_tests.rs
+git commit -m "feat(store): add ProjectionRunner struct and typestate builder"
+```
+
+---
+
+### Task 5: Add sequence/protocol tests for the runner
+
+**Files:**
+- Create: `crates/nexus-store/tests/projection_runner_tests.rs`
+
+**Step 1: Write the test file with shared fixtures and sequence tests**
+
+Create `crates/nexus-store/tests/projection_runner_tests.rs`:
+
+```rust
+#![cfg(all(feature = "projection", feature = "testing"))]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::shadow_reuse,
+    clippy::shadow_same,
+    clippy::shadow_unrelated,
+    clippy::as_conversions,
+    reason = "test harness — relaxed lints for test code"
+)]
+
+use std::fmt;
+use std::num::{NonZeroU32, NonZeroU64};
+
+use nexus::{DomainEvent, Message, Version};
+use nexus_store::projection::runner::{ProjectionRunner, StatePersistence, WithStatePersistence};
+use nexus_store::projection::{
+    EveryNEvents as ProjEveryNEvents, InMemoryStateStore, Projector,
+};
+use nexus_store::testing::InMemoryStore;
+use nexus_store::{CheckpointStore, Codec, RawEventStore, pending_envelope};
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Test fixtures
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+struct TestId(String);
+
+impl fmt::Display for TestId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl AsRef<[u8]> for TestId {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_bytes()
+    }
+}
+
+impl nexus::Id for TestId {
+    const BYTE_LEN: usize = 0;
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct CountState {
+    count: u64,
+    total: u64,
+}
+
+#[derive(Debug)]
+enum TestEvent {
+    Added(u64),
+    Removed(u64),
+}
+
+impl Message for TestEvent {}
+impl DomainEvent for TestEvent {
+    fn name(&self) -> &'static str {
+        match self {
+            TestEvent::Added(_) => "Added",
+            TestEvent::Removed(_) => "Removed",
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("projection overflow")]
+struct TestProjectionError;
+
+struct CountingProjector;
+
+impl Projector for CountingProjector {
+    type Event = TestEvent;
+    type State = CountState;
+    type Error = TestProjectionError;
+
+    fn initial(&self) -> CountState {
+        CountState { count: 0, total: 0 }
+    }
+
+    fn apply(&self, state: CountState, event: &TestEvent) -> Result<CountState, TestProjectionError> {
+        match event {
+            TestEvent::Added(n) => Ok(CountState {
+                count: state.count.checked_add(1).ok_or(TestProjectionError)?,
+                total: state.total.checked_add(*n).ok_or(TestProjectionError)?,
+            }),
+            TestEvent::Removed(n) => Ok(CountState {
+                count: state.count.checked_add(1).ok_or(TestProjectionError)?,
+                total: state.total.checked_sub(*n).ok_or(TestProjectionError)?,
+            }),
+        }
+    }
+}
+
+/// Simple event codec for tests.
+struct TestEventCodec;
+
+impl Codec<TestEvent> for TestEventCodec {
+    type Error = std::io::Error;
+
+    fn encode(&self, event: &TestEvent) -> Result<Vec<u8>, Self::Error> {
+        match event {
+            TestEvent::Added(n) => {
+                let mut buf = vec![0u8]; // tag
+                buf.extend_from_slice(&n.to_le_bytes());
+                Ok(buf)
+            }
+            TestEvent::Removed(n) => {
+                let mut buf = vec![1u8]; // tag
+                buf.extend_from_slice(&n.to_le_bytes());
+                Ok(buf)
+            }
+        }
+    }
+
+    fn decode(&self, _name: &str, payload: &[u8]) -> Result<TestEvent, Self::Error> {
+        if payload.len() != 9 {
+            return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "bad len"));
+        }
+        let n = u64::from_le_bytes(payload[1..9].try_into().unwrap());
+        match payload[0] {
+            0 => Ok(TestEvent::Added(n)),
+            1 => Ok(TestEvent::Removed(n)),
+            _ => Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "bad tag")),
+        }
+    }
+}
+
+/// Simple state codec for tests.
+struct TestStateCodec;
+
+impl Codec<CountState> for TestStateCodec {
+    type Error = std::io::Error;
+
+    fn encode(&self, state: &CountState) -> Result<Vec<u8>, Self::Error> {
+        let mut buf = Vec::with_capacity(16);
+        buf.extend_from_slice(&state.count.to_le_bytes());
+        buf.extend_from_slice(&state.total.to_le_bytes());
+        Ok(buf)
+    }
+
+    fn decode(&self, _name: &str, payload: &[u8]) -> Result<CountState, Self::Error> {
+        if payload.len() != 16 {
+            return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "bad len"));
+        }
+        let count = u64::from_le_bytes(payload[..8].try_into().unwrap());
+        let total = u64::from_le_bytes(payload[8..].try_into().unwrap());
+        Ok(CountState { count, total })
+    }
+}
+
+/// Append test events to the in-memory store.
+async fn append_events(store: &InMemoryStore, stream_id: &TestId, events: &[TestEvent]) {
+    let codec = TestEventCodec;
+    let current_len = {
+        let stream = store.read_stream(stream_id, Version::INITIAL).await.unwrap();
+        use nexus_store::EventStreamExt;
+        let mut stream = stream;
+        stream.try_count().await.unwrap()
+    };
+    let base_version = u64::try_from(current_len).unwrap();
+
+    let envelopes: Vec<_> = events
+        .iter()
+        .enumerate()
+        .map(|(i, event)| {
+            let ver = Version::new(base_version + u64::try_from(i).unwrap() + 1).unwrap();
+            let payload = codec.encode(event).unwrap();
+            pending_envelope(ver)
+                .event_type(event.name())
+                .payload(payload)
+                .build(())
+        })
+        .collect();
+
+    let expected = Version::new(base_version).filter(|_| base_version > 0);
+    store.append(stream_id, expected, &envelopes).await.unwrap();
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 1. Sequence/Protocol Tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn runner_processes_events_and_checkpoints() {
+    let store = InMemoryStore::new();
+    let state_store = InMemoryStateStore::new();
+    let stream_id = TestId("stream-1".into());
+
+    // Append 3 events
+    append_events(&store, &stream_id, &[
+        TestEvent::Added(10),
+        TestEvent::Added(20),
+        TestEvent::Added(30),
+    ]).await;
+
+    // Build runner with EveryNEvents(1) — checkpoint every event
+    let runner = ProjectionRunner::builder(stream_id.clone())
+        .subscription(&store)
+        .checkpoint(&store)
+        .projector(CountingProjector)
+        .event_codec(TestEventCodec)
+        .state_store(&state_store, TestStateCodec)
+        .build();
+
+    // Run with immediate shutdown after events are processed
+    // Use a short delay to let the runner process existing events
+    let shutdown = async {
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    };
+
+    runner.run(shutdown).await.unwrap();
+
+    // Verify checkpoint
+    let cp = store.load(&stream_id).await.unwrap();
+    assert_eq!(cp, Some(Version::new(3).unwrap()));
+
+    // Verify state
+    use nexus_store::projection::StateStore;
+    let persisted = state_store
+        .load(&stream_id, NonZeroU32::MIN)
+        .await
+        .unwrap()
+        .unwrap();
+    let state: CountState = TestStateCodec.decode("", persisted.payload()).unwrap();
+    assert_eq!(state, CountState { count: 3, total: 60 });
+}
+
+#[tokio::test]
+async fn runner_resumes_from_checkpoint() {
+    let store = InMemoryStore::new();
+    let state_store = InMemoryStateStore::new();
+    let stream_id = TestId("stream-1".into());
+
+    // Append 3 events, run, shutdown
+    append_events(&store, &stream_id, &[
+        TestEvent::Added(10),
+        TestEvent::Added(20),
+        TestEvent::Added(30),
+    ]).await;
+
+    let runner = ProjectionRunner::builder(stream_id.clone())
+        .subscription(&store)
+        .checkpoint(&store)
+        .projector(CountingProjector)
+        .event_codec(TestEventCodec)
+        .state_store(&state_store, TestStateCodec)
+        .build();
+
+    runner.run(async {
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }).await.unwrap();
+
+    // Append 2 more events
+    append_events(&store, &stream_id, &[
+        TestEvent::Added(40),
+        TestEvent::Removed(5),
+    ]).await;
+
+    // Run again — should resume from checkpoint (version 3)
+    let runner2 = ProjectionRunner::builder(stream_id.clone())
+        .subscription(&store)
+        .checkpoint(&store)
+        .projector(CountingProjector)
+        .event_codec(TestEventCodec)
+        .state_store(&state_store, TestStateCodec)
+        .build();
+
+    runner2.run(async {
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }).await.unwrap();
+
+    // Verify: checkpoint at 5, state = count:5 total:95
+    let cp = store.load(&stream_id).await.unwrap();
+    assert_eq!(cp, Some(Version::new(5).unwrap()));
+
+    use nexus_store::projection::StateStore;
+    let persisted = state_store
+        .load(&stream_id, NonZeroU32::MIN)
+        .await
+        .unwrap()
+        .unwrap();
+    let state: CountState = TestStateCodec.decode("", persisted.payload()).unwrap();
+    assert_eq!(state, CountState { count: 5, total: 95 });
+}
+
+#[tokio::test]
+async fn runner_trigger_controls_checkpoint_frequency() {
+    let store = InMemoryStore::new();
+    let state_store = InMemoryStateStore::new();
+    let stream_id = TestId("stream-1".into());
+
+    // Append 5 events
+    append_events(&store, &stream_id, &[
+        TestEvent::Added(1),
+        TestEvent::Added(2),
+        TestEvent::Added(3),
+        TestEvent::Added(4),
+        TestEvent::Added(5),
+    ]).await;
+
+    // Trigger every 3 events — checkpoint at version 3 only (5 doesn't cross next boundary at 6)
+    let runner = ProjectionRunner::builder(stream_id.clone())
+        .subscription(&store)
+        .checkpoint(&store)
+        .projector(CountingProjector)
+        .event_codec(TestEventCodec)
+        .state_store(&state_store, TestStateCodec)
+        .trigger(ProjEveryNEvents(NonZeroU64::new(3).unwrap()))
+        .build();
+
+    runner.run(async {
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }).await.unwrap();
+
+    // Checkpoint should be at version 5 (flushed on shutdown)
+    let cp = store.load(&stream_id).await.unwrap();
+    assert_eq!(cp, Some(Version::new(5).unwrap()));
+
+    // State should reflect all 5 events (flushed on shutdown)
+    use nexus_store::projection::StateStore;
+    let persisted = state_store
+        .load(&stream_id, NonZeroU32::MIN)
+        .await
+        .unwrap()
+        .unwrap();
+    let state: CountState = TestStateCodec.decode("", persisted.payload()).unwrap();
+    assert_eq!(state, CountState { count: 5, total: 15 });
+}
+
+#[tokio::test]
+async fn runner_works_without_state_persistence() {
+    let store = InMemoryStore::new();
+    let stream_id = TestId("stream-1".into());
+
+    append_events(&store, &stream_id, &[
+        TestEvent::Added(10),
+        TestEvent::Added(20),
+    ]).await;
+
+    // No state_store — only checkpoints
+    let runner = ProjectionRunner::builder(stream_id.clone())
+        .subscription(&store)
+        .checkpoint(&store)
+        .projector(CountingProjector)
+        .event_codec(TestEventCodec)
+        .build();
+
+    runner.run(async {
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }).await.unwrap();
+
+    // Checkpoint should still work
+    let cp = store.load(&stream_id).await.unwrap();
+    assert_eq!(cp, Some(Version::new(2).unwrap()));
+}
+```
+
+**Step 2: Run tests**
+
+Run: `cargo test -p nexus-store --features "projection,testing" -- projection_runner_tests`
+Expected: PASS
+
+**Step 3: Commit**
+
+```bash
+git add crates/nexus-store/tests/projection_runner_tests.rs
+git commit -m "test(store): add sequence/protocol tests for ProjectionRunner"
+```
+
+---
+
+### Task 6: Add lifecycle tests
+
+**Files:**
+- Modify: `crates/nexus-store/tests/projection_runner_tests.rs`
+
+**Step 1: Append lifecycle tests**
+
+```rust
+// ═══════════════════════════════════════════════════════════════════════════
+// 2. Lifecycle Tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn runner_immediate_shutdown_with_no_events() {
+    let store = InMemoryStore::new();
+    let stream_id = TestId("empty-stream".into());
+
+    let runner = ProjectionRunner::builder(stream_id.clone())
+        .subscription(&store)
+        .checkpoint(&store)
+        .projector(CountingProjector)
+        .event_codec(TestEventCodec)
+        .build();
+
+    // Immediate shutdown — should return Ok without errors
+    let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+    tx.send(()).unwrap();
+    let shutdown = async { rx.await.ok(); };
+
+    runner.run(shutdown).await.unwrap();
+
+    // No checkpoint saved (no events processed)
+    let cp = store.load(&stream_id).await.unwrap();
+    assert!(cp.is_none());
+}
+
+#[tokio::test]
+async fn runner_graceful_shutdown_flushes_dirty_state() {
+    let store = InMemoryStore::new();
+    let state_store = InMemoryStateStore::new();
+    let stream_id = TestId("stream-1".into());
+
+    // Append 2 events
+    append_events(&store, &stream_id, &[
+        TestEvent::Added(10),
+        TestEvent::Added(20),
+    ]).await;
+
+    // Trigger every 100 events — so the trigger never fires during these 2 events.
+    // Only the shutdown flush should persist state.
+    let runner = ProjectionRunner::builder(stream_id.clone())
+        .subscription(&store)
+        .checkpoint(&store)
+        .projector(CountingProjector)
+        .event_codec(TestEventCodec)
+        .state_store(&state_store, TestStateCodec)
+        .trigger(ProjEveryNEvents(NonZeroU64::new(100).unwrap()))
+        .build();
+
+    runner.run(async {
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }).await.unwrap();
+
+    // State should be flushed on shutdown even though trigger didn't fire
+    use nexus_store::projection::StateStore;
+    let persisted = state_store
+        .load(&stream_id, NonZeroU32::MIN)
+        .await
+        .unwrap()
+        .unwrap();
+    let state: CountState = TestStateCodec.decode("", persisted.payload()).unwrap();
+    assert_eq!(state, CountState { count: 2, total: 30 });
+
+    // Checkpoint should also be saved
+    let cp = store.load(&stream_id).await.unwrap();
+    assert_eq!(cp, Some(Version::new(2).unwrap()));
+}
+
+#[tokio::test]
+async fn runner_stale_state_falls_back_to_initial() {
+    let store = InMemoryStore::new();
+    let state_store = InMemoryStateStore::new();
+    let stream_id = TestId("stream-1".into());
+
+    // Pre-save state with schema version 1
+    use nexus_store::projection::{PendingState, StateStore};
+    let old_state = PendingState::new(
+        Version::new(5).unwrap(),
+        NonZeroU32::MIN,
+        TestStateCodec.encode(&CountState { count: 99, total: 999 }).unwrap(),
+    );
+    state_store.save(&stream_id, &old_state).await.unwrap();
+
+    // Append 2 events
+    append_events(&store, &stream_id, &[
+        TestEvent::Added(10),
+        TestEvent::Added(20),
+    ]).await;
+
+    // Runner with schema version 2 — stale state should be ignored
+    let runner = ProjectionRunner::builder(stream_id.clone())
+        .subscription(&store)
+        .checkpoint(&store)
+        .projector(CountingProjector)
+        .event_codec(TestEventCodec)
+        .state_store(&state_store, TestStateCodec)
+        .state_schema_version(NonZeroU32::new(2).unwrap())
+        .build();
+
+    runner.run(async {
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }).await.unwrap();
+
+    // State should start from initial(), not from stale v1 state
+    let persisted = state_store
+        .load(&stream_id, NonZeroU32::new(2).unwrap())
+        .await
+        .unwrap()
+        .unwrap();
+    let state: CountState = TestStateCodec.decode("", persisted.payload()).unwrap();
+    assert_eq!(state, CountState { count: 2, total: 30 });
+}
+```
+
+**Step 2: Run tests**
+
+Run: `cargo test -p nexus-store --features "projection,testing" -- projection_runner_tests`
+Expected: PASS
+
+**Step 3: Commit**
+
+```bash
+git add crates/nexus-store/tests/projection_runner_tests.rs
+git commit -m "test(store): add lifecycle tests for ProjectionRunner"
+```
+
+---
+
+### Task 7: Add defensive boundary tests
+
+**Files:**
+- Modify: `crates/nexus-store/tests/projection_runner_tests.rs`
+
+**Step 1: Append defensive tests**
+
+```rust
+// ═══════════════════════════════════════════════════════════════════════════
+// 3. Defensive Boundary Tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+use nexus_store::projection::runner::ProjectionError;
+
+#[tokio::test]
+async fn runner_returns_projector_error_on_apply_failure() {
+    let store = InMemoryStore::new();
+    let stream_id = TestId("stream-1".into());
+
+    // Append an event that will cause underflow
+    append_events(&store, &stream_id, &[
+        TestEvent::Removed(1), // underflow: 0 - 1
+    ]).await;
+
+    let runner = ProjectionRunner::builder(stream_id.clone())
+        .subscription(&store)
+        .checkpoint(&store)
+        .projector(CountingProjector)
+        .event_codec(TestEventCodec)
+        .build();
+
+    let result = runner.run(async {
+        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+    }).await;
+
+    assert!(result.is_err());
+    assert!(matches!(result.unwrap_err(), ProjectionError::Projector(_)));
+}
+
+#[tokio::test]
+async fn runner_returns_event_codec_error_on_bad_payload() {
+    let store = InMemoryStore::new();
+    let stream_id = TestId("stream-1".into());
+
+    // Append a raw event with garbage payload
+    let bad_envelope = pending_envelope(Version::new(1).unwrap())
+        .event_type("Added")
+        .payload(vec![0xFF]) // invalid: too short
+        .build(());
+    store.append(&stream_id, None, &[bad_envelope]).await.unwrap();
+
+    let runner = ProjectionRunner::builder(stream_id.clone())
+        .subscription(&store)
+        .checkpoint(&store)
+        .projector(CountingProjector)
+        .event_codec(TestEventCodec)
+        .build();
+
+    let result = runner.run(async {
+        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+    }).await;
+
+    assert!(result.is_err());
+    assert!(matches!(result.unwrap_err(), ProjectionError::EventCodec(_)));
+}
+```
+
+**Step 2: Run tests**
+
+Run: `cargo test -p nexus-store --features "projection,testing" -- projection_runner_tests`
+Expected: PASS
+
+**Step 3: Commit**
+
+```bash
+git add crates/nexus-store/tests/projection_runner_tests.rs
+git commit -m "test(store): add defensive boundary tests for ProjectionRunner"
+```
+
+---
+
+### Task 8: Add linearizability test
+
+**Files:**
+- Modify: `crates/nexus-store/tests/projection_runner_tests.rs`
+
+**Step 1: Append concurrency test**
+
+```rust
+// ═══════════════════════════════════════════════════════════════════════════
+// 4. Linearizability/Isolation Tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn runner_sees_events_appended_concurrently() {
+    let store = InMemoryStore::new();
+    let state_store = InMemoryStateStore::new();
+    let stream_id = TestId("stream-1".into());
+
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+
+    let runner = ProjectionRunner::builder(stream_id.clone())
+        .subscription(&store)
+        .checkpoint(&store)
+        .projector(CountingProjector)
+        .event_codec(TestEventCodec)
+        .state_store(&state_store, TestStateCodec)
+        .build();
+
+    // Spawn runner in background
+    let store_ref = &store;
+    let stream_id_ref = &stream_id;
+    let runner_handle = tokio::spawn(async move {
+        runner.run(async { shutdown_rx.await.ok(); }).await
+    });
+
+    // Give the runner time to start and subscribe
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    // Append events while runner is live
+    append_events(store_ref, stream_id_ref, &[
+        TestEvent::Added(10),
+        TestEvent::Added(20),
+        TestEvent::Added(30),
+    ]).await;
+
+    // Give runner time to process
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    // Shutdown
+    shutdown_tx.send(()).unwrap();
+    runner_handle.await.unwrap().unwrap();
+
+    // Verify all events were processed
+    let cp = store_ref.load(stream_id_ref).await.unwrap();
+    assert_eq!(cp, Some(Version::new(3).unwrap()));
+
+    use nexus_store::projection::StateStore;
+    let persisted = state_store
+        .load(stream_id_ref, NonZeroU32::MIN)
+        .await
+        .unwrap()
+        .unwrap();
+    let state: CountState = TestStateCodec.decode("", persisted.payload()).unwrap();
+    assert_eq!(state, CountState { count: 3, total: 60 });
+}
+```
+
+**Note:** This test has a lifetime issue — `store_ref` borrows `store` which is moved into the spawn. Fix: use `Arc` or restructure. The test should use `Arc<InMemoryStore>` — but `InMemoryStore` implements `Subscription<()>` and `CheckpointStore` on `&InMemoryStore`, not `Arc<InMemoryStore>`. Restructure the test to avoid this:
+
+The runner takes `&store` (which is `'_` lifetime). `tokio::spawn` requires `'static`. So we need the runner to own the subscription. Since `Subscription` is implemented for `&InMemoryStore`, we need the runner to own a reference... which requires `'static`.
+
+**Alternative approach:** Run the runner on the current task (not spawned), with appending done before starting the runner. The concurrency test becomes: "append while runner is in catch-up phase" — but that's hard to orchestrate.
+
+**Practical approach:** Use a separate tokio task with `Arc` wrappers, OR test with a two-phase approach where events are pre-loaded and the runner catches up.
+
+For now, simplify the concurrency test to verify the runner processes events that arrive after subscription starts:
+
+```rust
+#[tokio::test]
+async fn runner_processes_live_events_after_catchup() {
+    let store = std::sync::Arc::new(InMemoryStore::new());
+    let state_store = InMemoryStateStore::new();
+    let stream_id = TestId("stream-1".into());
+
+    // Pre-append 2 events (catch-up phase)
+    append_events(&store, &stream_id, &[
+        TestEvent::Added(10),
+        TestEvent::Added(20),
+    ]).await;
+
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+
+    // We need the runner to take references that outlive the spawn.
+    // Use a scoped approach: run the runner in a spawned task that
+    // borrows from the test, using unsafe scoping or restructuring.
+    //
+    // Simpler: use the runner on the current task with select.
+    let store_clone = store.clone();
+    let stream_id_clone = stream_id.clone();
+
+    let runner_task = tokio::spawn({
+        let store = store.clone();
+        let stream_id = stream_id.clone();
+        async move {
+            // InMemoryStore doesn't impl Subscription for Arc<InMemoryStore>.
+            // We need to use a reference... but spawn requires 'static.
+            // This is a testing limitation. For now, verify catch-up works.
+            //
+            // TODO: Add Arc<InMemoryStore> impl or restructure test when
+            // supervision layer provides managed runners.
+        }
+    });
+
+    // ... This test needs InMemoryStore to be usable from a spawned task.
+    // For v1, test catch-up + shutdown only (covered by sequence tests above).
+    // True concurrency testing will be possible with the supervision layer
+    // that manages runner lifecycles.
+    shutdown_tx.send(()).ok();
+}
+```
+
+**Revised test:** Since `InMemoryStore` doesn't support `Arc`-wrapped usage for `Subscription`, the linearizability test verifies catch-up behavior with a timed shutdown that gives the runner enough time to process:
+
+```rust
+#[tokio::test]
+async fn runner_catches_up_and_processes_all_existing_events() {
+    let store = InMemoryStore::new();
+    let state_store = InMemoryStateStore::new();
+    let stream_id = TestId("stream-1".into());
+
+    // Append events before runner starts — runner must catch up
+    append_events(&store, &stream_id, &[
+        TestEvent::Added(10),
+        TestEvent::Added(20),
+        TestEvent::Added(30),
+        TestEvent::Added(40),
+        TestEvent::Added(50),
+    ]).await;
+
+    let runner = ProjectionRunner::builder(stream_id.clone())
+        .subscription(&store)
+        .checkpoint(&store)
+        .projector(CountingProjector)
+        .event_codec(TestEventCodec)
+        .state_store(&state_store, TestStateCodec)
+        .build();
+
+    runner.run(async {
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }).await.unwrap();
+
+    // All 5 events processed
+    let cp = store.load(&stream_id).await.unwrap();
+    assert_eq!(cp, Some(Version::new(5).unwrap()));
+
+    use nexus_store::projection::StateStore;
+    let persisted = state_store
+        .load(&stream_id, NonZeroU32::MIN)
+        .await
+        .unwrap()
+        .unwrap();
+    let state: CountState = TestStateCodec.decode("", persisted.payload()).unwrap();
+    assert_eq!(state, CountState { count: 5, total: 150 });
+}
+```
+
+**Step 2: Run tests**
+
+Run: `cargo test -p nexus-store --features "projection,testing" -- projection_runner_tests`
+Expected: PASS
+
+**Step 3: Commit**
+
+```bash
+git add crates/nexus-store/tests/projection_runner_tests.rs
+git commit -m "test(store): add linearizability tests for ProjectionRunner"
+```
+
+---
+
+### Task 9: Run full checks, fix clippy, update hakari
+
+**Files:**
+- Possibly modify: `crates/workspace-hack/Cargo.toml`
+
+**Step 1: Run clippy**
+
+Run: `cargo clippy -p nexus-store --features "projection,testing" -- -D warnings`
+Expected: PASS (fix any warnings)
+
+**Step 2: Run fmt**
+
+Run: `cargo fmt --all -- --check`
+Expected: PASS (fix any formatting)
+
+**Step 3: Generate hakari**
+
+Run: `cargo hakari generate`
+If it changes `crates/workspace-hack/Cargo.toml`, stage it.
+
+**Step 4: Run full test suite**
+
+Run: `cargo test --workspace`
+Expected: PASS — no regressions
+
+**Step 5: Run all feature combinations**
+
+Run: `cargo test -p nexus-store --features "projection"`
+Run: `cargo test -p nexus-store --features "projection,testing"`
+Run: `cargo test -p nexus-store --features "projection,snapshot"`
+Run: `cargo test -p nexus-store --features "projection,snapshot,testing"`
+Expected: All PASS
+
+**Step 6: Commit (if hakari changed)**
+
+```bash
+git add crates/workspace-hack/Cargo.toml
+git commit -m "chore: update workspace-hack after projection runner"
+```
+
+---
+
+### Task 10: Update CLAUDE.md and create PR
+
+**Step 1: Update CLAUDE.md architecture section**
+
+Add the runner to the Store Crate section. Under `projection/`:
+
+```
+- **`runner/`** — Subscription-powered async projection execution.
+  - `runner.rs` — `ProjectionRunner<Id, Sub, Ckpt, SP, P, EC, Trig>`: background event processor. `async fn run(self, shutdown: impl Future<Output = ()>)` consumes self, processes events until shutdown or error. Uses `core::future::poll_fn` for runtime-agnostic select (no tokio in public API).
+  - `builder.rs` — `ProjectionRunnerBuilder`: typestate builder with 4 required slots (subscription, checkpoint, projector, event_codec) and 3 optional (state_store, state_codec via `WithStatePersistence`, trigger). `!Send` markers prevent `.build()` without required fields.
+  - `error.rs` — `ProjectionError<P, EC, SP, Ckpt, Sub>`: one variant per failure domain. `StatePersistError<S, C>`: wraps state store and codec errors.
+  - `persist.rs` — `StatePersistence<S>` trait: polymorphic state load/save. `NoStatePersistence` (Error = Infallible, no-op). `WithStatePersistence<SS, SC>` (real store + codec).
+```
+
+**Step 2: Create PR**
+
+PR title: `feat(store): subscription-powered projection runner (#157)`
+
+Body should reference:
+- Parent issue #124
+- Subtask #157
+- Design doc: `docs/plans/2026-04-27-projection-runner-design.md`
+- That supervision/restart is a separate subtask
+- Key design choices: runtime-agnostic shutdown, `StatePersistence` trait for codec polymorphism, `poll_fn`-based select

--- a/docs/plans/2026-04-27-public-readme-design.md
+++ b/docs/plans/2026-04-27-public-readme-design.md
@@ -1,0 +1,92 @@
+# Public README Design
+
+## Goal
+
+Make the nexus repository public-ready. Update all READMEs to reflect the current API and position Nexus for its target audience: Rust developers who already know event sourcing and DDD.
+
+## Scope
+
+1. Root `README.md` — full rewrite
+2. `crates/nexus/README.md` — update to current API
+3. `crates/nexus-macros/README.md` — fix to show actual macros
+4. Flip repo visibility to public via `gh repo edit --visibility public`
+
+## Positioning
+
+Nexus as a standalone event-sourcing framework. No mention of downstream systems (Agency, Zenoh, AI agents). Lead with code quality — the API speaks for itself.
+
+## Target Audience
+
+Experienced Rust developers who already know ES/DDD/CQRS patterns. No hand-holding on concepts. They want to know why *this* library.
+
+## Root README Structure
+
+### 1. Hook + Badges
+
+One-liner: "Event sourcing for Rust — no `Box<dyn>`, no runtime downcasting, no hidden allocations."
+
+CI and license badges only. No crates.io/docs.rs badges until published.
+
+### 2. Code Example (lead section)
+
+Trimmed bank account example (~35 lines) showing:
+- `#[derive(DomainEvent)]` on a flat enum (no inner structs for brevity)
+- `AggregateState` with `apply(self, &Event) -> Self` (value-semantic signature)
+- `#[nexus::aggregate(state = S, error = E, id = I)]` macro
+- `Handle<Deposit>` impl with `events![]` macro
+
+Code-first approach: experienced devs read the API surface before marketing copy.
+
+### 3. "Why Nexus?" — Three Differentiators
+
+Three paragraphs, each: **bold claim** + mechanism:
+
+1. **Concrete event enums, not trait objects.** Exhaustive `match`, compiler catches missing handlers.
+2. **`no_std` / `no_alloc` kernel.** `ArrayVec` + const generics. Zero heap in the kernel.
+3. **Zero-copy read path.** `BorrowingCodec` + GAT lending iterators.
+
+### 4. Crates Table
+
+Four crates: `nexus`, `nexus-macros`, `nexus-store`, `nexus-fjall`. Relative links to crate directories (not crates.io — not published yet).
+
+### 5. Features List
+
+Compact single-line items for supporting differentiators:
+- Schema evolution (`#[nexus::transforms]`)
+- Aggregate snapshots
+- Optimistic concurrency
+- Allocation-free errors
+- Strict verification (proptest, miri, mutation testing, trybuild)
+
+### 6. Getting Started
+
+`Cargo.toml` snippets for kernel-only and with persistence. Links to the three examples.
+
+### 7. Status
+
+Honest: experimental, unstable API, kernel well-tested, store/fjall under active development.
+
+### 8. License
+
+MIT OR Apache-2.0.
+
+## Crate READMEs
+
+### `nexus/README.md`
+
+Strip to: hook line, link to root README, verification table (kept — it's specific to the kernel and impressive).
+
+### `nexus-macros/README.md`
+
+Fix to show the three actual macros with correct syntax:
+- `#[nexus::aggregate(state = S, error = E, id = I)]` — attribute macro on unit struct
+- `#[derive(DomainEvent)]` — derive on enum
+- `#[nexus::transforms(aggregate = A, error = E)]` — attribute macro on impl block
+
+Kill `Command` and `Query` references (they don't exist).
+
+## What's NOT Changing
+
+- `CONTRIBUTING.md` — already adequate
+- `CLAUDE.md` — internal, not public-facing
+- Examples — already compile and reflect current API


### PR DESCRIPTION
## Summary

- **Projection core traits** (#155): `Projector`, `StateStore`, `ProjectionTrigger` (`EveryNEvents`, `AfterEventTypes`), `PendingState`, `PersistedState`, `InMemoryStateStore` — all feature-gated behind `projection`
- **Projection runner design** (#157): Design doc + implementation plan for the subscription-powered async projection runner

## What's in this PR

### Core traits (subtask 1 — #155)
- `Projector` — pure event fold with fallible `apply` (checked arithmetic)
- `StateStore` — byte-level projection state persistence (with `()` no-op impl)
- `ProjectionTrigger` — `EveryNEvents` (bucket-crossing algorithm) and `AfterEventTypes` (semantic triggers)
- `PendingState` / `PersistedState` — write-path and read-path state containers
- `InMemoryStateStore` — test fixture behind `testing` feature
- Full test coverage in `projection_tests.rs`

### Runner design (subtask 3 — #157)
- `docs/plans/2026-04-27-projection-runner-design.md` — approved design
- `docs/plans/2026-04-27-projection-runner-impl.md` — 10-task TDD implementation plan

### Also includes
- Public-ready README rewrites for all crates

## Key design decisions

- `SnapshotStore` intentionally untouched — coexists with projection module until unification (#159)
- Feature flags: `projection`, `projection-json`
- Runner is runtime-agnostic (`impl Future<Output = ()>` for shutdown, no tokio in public API)
- `StatePersistence<S>` trait solves the `Codec<T> for ()` impossibility via polymorphic dispatch

## Parent issue

#124 — Add projections / read model infrastructure

## Test plan

- [x] `cargo test -p nexus-store --features "projection"` 
- [x] `cargo test -p nexus-store --features "projection,testing"`
- [x] `cargo test -p nexus-store --features "projection,snapshot,testing"`
- [x] Full `nix flake check` passes
- [ ] Runner implementation (separate session, tracked in #157)

🤖 Generated with [Claude Code](https://claude.com/claude-code)