### PR TITLE
feat(store): futures::Stream bridge for owning-output lending streams

### DIFF
--- a/.config/hakari.toml
+++ b/.config/hakari.toml
@@ -22,3 +22,14 @@ platforms = [
 
 # Write out exact versions rather than a semver range. (Defaults to false.)
 # exact-versions = true
+
+# Keep optional / feature-gated deps out of the unified workspace-hack dep
+# set so the "feature off → dep absent from dep tree" guarantee holds for
+# every workspace member, not just published consumers. Without this,
+# hakari pulls `futures-core` (used by nexus-store's `futures-bridge`
+# feature) into `workspace-hack`, which propagates into every member that
+# depends on `workspace-hack` regardless of feature selection.
+[final-excludes]
+third-party = [
+  { name = "futures-core" },
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,6 +361,94 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -648,6 +736,8 @@ version = "0.1.0"
 dependencies = [
  "arrayvec",
  "criterion",
+ "futures",
+ "futures-core",
  "nexus",
  "nexus-store",
  "nexus-store-testing",
@@ -1076,6 +1166,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1435,6 +1531,7 @@ version = "0.1.0"
 dependencies = [
  "getrandom",
  "libc",
+ "memchr",
  "num-traits",
  "once_cell",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ members = [
 arrayvec = { version = "0.7.6", default-features = false }
 criterion = { version = "0.8", features = ["html_reports"] }
 fjall = "3"
+futures = "0.3"
+futures-core = { version = "0.3", default-features = false }
 insta = "1.47.2"
 proptest = "1.11.0"
 proptest-state-machine = "0.8.0"

--- a/crates/nexus-store/Cargo.toml
+++ b/crates/nexus-store/Cargo.toml
@@ -18,9 +18,11 @@ snapshot = []
 snapshot-json = ["snapshot", "json"]
 projection = []
 projection-json = ["projection", "json"]
+futures-bridge = ["dep:futures-core"]
 
 [dependencies]
 arrayvec = { workspace = true }
+futures-core = { workspace = true, optional = true }
 nexus = { version = "0.1.0", path = "../nexus" }
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
@@ -30,7 +32,8 @@ workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
 [dev-dependencies]
 criterion = { workspace = true }
-nexus-store = { path = ".", features = ["testing"] }
+futures = { workspace = true }
+nexus-store = { path = ".", features = ["testing", "futures-bridge"] }
 nexus-store-testing = { version = "0.1.0", path = "../nexus-store-testing" }
 proptest = { workspace = true }
 serde = { workspace = true }

--- a/crates/nexus-store/src/lib.rs
+++ b/crates/nexus-store/src/lib.rs
@@ -42,6 +42,8 @@ pub use stream::{
     BorrowedDecodedStream, DecodedStream, DecoderBuilder, Disposition, EventStream, EventStreamExt,
     Progress, Step,
 };
+#[cfg(feature = "futures-bridge")]
+pub use stream::{IntoStream, OwnedEventStream};
 #[cfg(feature = "testing")]
 pub use testing::InMemoryStoreError;
 pub use upcasting::{EventMorsel, Upcaster};

--- a/crates/nexus-store/src/stream/cursor.rs
+++ b/crates/nexus-store/src/stream/cursor.rs
@@ -5,6 +5,8 @@ use std::task::Poll;
 
 use super::combinators::{Map, TryMap, TryScan};
 use super::decoder::{DecoderBuilder, NeedsCodec, NoUpcaster};
+#[cfg(feature = "futures-bridge")]
+use super::owned::{IntoStream, OwnedEventStream};
 use super::progress::{Progress, Step};
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -466,6 +468,47 @@ pub trait EventStreamExt<M = ()>: EventStream<M> {
             f,
             _marker: PhantomData,
         }
+    }
+
+    /// Bridge an owning-output lending stream into a [`futures_core::Stream`].
+    ///
+    /// Available only with the `futures-bridge` feature. Requires
+    /// [`OwnedEventStream<M>`] — implemented for the owning combinators
+    /// ([`Map`], [`TryMap`]) but **not** for raw cursors, whose `Item<'a>`
+    /// borrows from the cursor. To bridge a raw cursor, chain
+    /// `.map(...)` or `.try_map(...)` first so the per-event materialization
+    /// is named at the call site.
+    ///
+    /// The returned stream yields `Result<Self::OwnedItem, Self::Error>` and
+    /// terminates after the underlying cursor returns `Ok(None)` or surfaces
+    /// an error (the error is yielded once; subsequent polls return `None`).
+    ///
+    /// # Cost
+    ///
+    /// Each yielded item box-pins one async block holding the cursor — the
+    /// per-event allocation that makes the futures-stream combinator
+    /// surface available. If you don't need the futures ecosystem, stay
+    /// in lending-stream land (`.try_fold`, `.try_for_each`,
+    /// `.try_collect_map`) and pay no allocation.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use futures::StreamExt;
+    /// use nexus_store::stream::{EventStream, EventStreamExt};
+    ///
+    /// let owned: Vec<(Version, Vec<u8>)> = my_stream
+    ///     .try_map(|env| Ok::<_, MyErr>((env.version(), env.payload().to_vec())))
+    ///     .into_stream()
+    ///     .try_collect()
+    ///     .await?;
+    /// ```
+    #[cfg(feature = "futures-bridge")]
+    fn into_stream(self) -> IntoStream<Self, M>
+    where
+        Self: Sized + OwnedEventStream<M> + Send + 'static,
+    {
+        IntoStream::new(self)
     }
 }
 

--- a/crates/nexus-store/src/stream/mod.rs
+++ b/crates/nexus-store/src/stream/mod.rs
@@ -15,10 +15,15 @@
 //!   wrappers, [`DecodedStream`] (owning codec) and
 //!   [`BorrowedDecodedStream`] (zero-copy codec); also the
 //!   [`BaseEventStream`] sub-trait the decoder bounds on.
+//! - [`owned`] (feature-gated: `futures-bridge`) — the [`OwnedEventStream`]
+//!   sub-trait + [`IntoStream`] bridge that exposes an owning-output
+//!   lending stream as a [`futures_core::Stream`].
 
 mod combinators;
 mod cursor;
 mod decoder;
+#[cfg(feature = "futures-bridge")]
+mod owned;
 mod progress;
 
 pub use combinators::{Map, TryMap, TryScan};
@@ -27,4 +32,6 @@ pub use decoder::{
     BaseEventStream, BorrowedDecodedStream, DecodedStream, DecoderBuilder, NeedsCodec, NoUpcaster,
     WithBorrowingCodec, WithCodec, WithUpcaster,
 };
+#[cfg(feature = "futures-bridge")]
+pub use owned::{IntoStream, OwnedEventStream};
 pub use progress::{Progress, Step};

--- a/crates/nexus-store/src/stream/owned.rs
+++ b/crates/nexus-store/src/stream/owned.rs
@@ -1,0 +1,232 @@
+//! `futures::Stream` bridge for owning-output lending streams.
+//!
+//! `EventStream<M>` is a GAT lending iterator — each `next()` returns an
+//! item that may borrow from the cursor. `futures_core::Stream` has a
+//! fixed (non-GAT) `Item` type, so any bridge between the two must
+//! materialize the item as an owned value per iteration.
+//!
+//! This module exposes two pieces:
+//!
+//! - [`OwnedEventStream`] — a sub-trait of [`EventStream`] that witnesses
+//!   "this stream's [`Item<'a>`](EventStream::Item) does not borrow from
+//!   the cursor" by declaring a concrete [`OwnedItem`](OwnedEventStream::OwnedItem)
+//!   associated type. Implemented for [`Map`] and [`TryMap`] — the
+//!   owning-output combinators — and not for the base cursors (whose
+//!   `Item<'a>` is a borrowing [`PersistedEnvelope`]).
+//! - [`IntoStream`] — the bridge type returned by
+//!   [`EventStreamExt::into_stream`](super::cursor::EventStreamExt::into_stream).
+//!   Implements [`futures_core::Stream`] by box-pinning the per-iteration
+//!   `next()` future. The unfold pattern (move stream into future, return
+//!   it back from the future) keeps the bridge non-self-referential, at
+//!   the explicit cost of one heap allocation per yielded item.
+//!
+//! Bridging a raw cursor therefore requires a visible `.map(...)` /
+//! `.try_map(...)` step that names the owned target type — making the
+//! per-event allocation cost a conscious choice.
+//!
+//! [`EventStream`]: super::cursor::EventStream
+//! [`PersistedEnvelope`]: crate::envelope::PersistedEnvelope
+//! [`Map`]: super::combinators::Map
+//! [`TryMap`]: super::combinators::TryMap
+
+use std::future::Future;
+use std::marker::PhantomData;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use super::combinators::{Map, TryMap};
+use super::cursor::EventStream;
+
+// ═══════════════════════════════════════════════════════════════════════════
+// OwnedEventStream — sub-trait witness for "Item<'a> is an owned value"
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Sub-trait for streams whose [`Item<'a>`](EventStream::Item) does not
+/// borrow from the cursor and can therefore be surfaced through a
+/// non-GAT [`futures_core::Stream`].
+///
+/// Implementations declare a concrete [`OwnedItem`](Self::OwnedItem)
+/// associated type and supply [`into_owned`](Self::into_owned), which
+/// converts a lent item to its owned representation. For the owning
+/// combinators ([`Map`], [`TryMap`]) `into_owned` is the identity — the
+/// closure already produced the owned value.
+///
+/// Hand-implemented (no blanket) by the owning-output combinators only.
+/// Base cursors do **not** implement this trait: their `Item<'a>` is a
+/// borrowing [`PersistedEnvelope`](crate::envelope::PersistedEnvelope),
+/// and forcing a deep-copy here would hide a per-event allocation from
+/// callers. To bridge a raw cursor, chain a `.map(...)` or `.try_map(...)`
+/// first so the materialization is explicit at the call site.
+///
+/// # Why a sub-trait
+///
+/// The natural shape — "`for<'a> Self::Item<'a>: 'static`" plus a way to
+/// name the resulting concrete type — is not expressible on stable Rust:
+/// the GAT's `where Self: 'a` clause propagates into the HRTB and breaks
+/// type equality (`for<'a> Item<'a> = T`). PR1 hit the same wall when
+/// trying to bound the decoder facade on
+/// `for<'a> Item<'a> = PersistedEnvelope<'a, M>` and resolved it with the
+/// `BaseEventStream` sub-trait. This trait is the symmetrical move for
+/// the owning case.
+pub trait OwnedEventStream<M = ()>: EventStream<M> {
+    /// The concrete owned type produced by each yielded item.
+    ///
+    /// Used as the `Item` type of the [`futures_core::Stream`] returned
+    /// by [`EventStreamExt::into_stream`](super::cursor::EventStreamExt::into_stream).
+    type OwnedItem: Send + 'static;
+
+    /// Convert a lent item to its owned representation.
+    ///
+    /// For [`Map`] and [`TryMap`] this is the identity — the closure
+    /// already returned the owned value.
+    fn into_owned(item: Self::Item<'_>) -> Self::OwnedItem
+    where
+        Self: Sized;
+}
+
+// ─── OwnedEventStream for Map ───────────────────────────────────────────────
+
+impl<S, F, T, M> OwnedEventStream<M> for Map<S, F>
+where
+    S: EventStream<M> + Send,
+    F: for<'a> FnMut(S::Item<'a>) -> T + Send,
+    T: Send + 'static,
+{
+    type OwnedItem = T;
+
+    fn into_owned(item: T) -> T {
+        item
+    }
+}
+
+// ─── OwnedEventStream for TryMap ────────────────────────────────────────────
+
+impl<S, F, T, E, M> OwnedEventStream<M> for TryMap<S, F, E>
+where
+    S: EventStream<M> + Send,
+    F: for<'a> FnMut(S::Item<'a>) -> Result<T, E> + Send,
+    T: Send + 'static,
+    E: std::error::Error + Send + Sync + 'static + From<S::Error>,
+{
+    type OwnedItem = T;
+
+    fn into_owned(item: T) -> T {
+        item
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// IntoStream — futures_core::Stream bridge
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// In-flight future yielded by an idle cursor. Owns the cursor outright
+/// so it is non-self-referential and `'static`.
+type Pending<S, T, E> = Pin<Box<dyn Future<Output = (Result<Option<T>, E>, S)> + Send>>;
+
+/// Bridge from an [`OwnedEventStream`] to a [`futures_core::Stream`].
+///
+/// Constructed by
+/// [`EventStreamExt::into_stream`](super::cursor::EventStreamExt::into_stream).
+/// The stream yields `Result<S::OwnedItem, S::Error>` items and terminates
+/// when the underlying cursor returns `Ok(None)` or yields an error
+/// (errors are surfaced once and then the stream terminates).
+///
+/// # Cost
+///
+/// Each `poll_next` that needs to advance the cursor box-pins one async
+/// block (the `next()` future plus the owned cursor it captures). This is
+/// the per-event allocation the plan calls out as explicit and opt-in.
+pub struct IntoStream<S, M>
+where
+    S: OwnedEventStream<M> + Send + 'static,
+{
+    state: BridgeState<S, M>,
+    _marker: PhantomData<fn() -> M>,
+}
+
+enum BridgeState<S, M>
+where
+    S: OwnedEventStream<M> + Send + 'static,
+{
+    /// Cursor is idle; ready to start the next iteration.
+    Idle(S),
+    /// `next()` is in flight; the boxed future owns the cursor.
+    Pending(Pending<S, S::OwnedItem, S::Error>),
+    /// Stream has terminated (either exhausted or surfaced an error).
+    Done,
+}
+
+impl<S, M> IntoStream<S, M>
+where
+    S: OwnedEventStream<M> + Send + 'static,
+{
+    pub(super) fn new(stream: S) -> Self {
+        Self {
+            state: BridgeState::Idle(stream),
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<S, M> futures_core::Stream for IntoStream<S, M>
+where
+    S: OwnedEventStream<M> + Send + Unpin + 'static,
+    M: 'static,
+{
+    type Item = Result<S::OwnedItem, S::Error>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        // `IntoStream` itself is `Unpin` (it contains no self-referential
+        // futures — the boxed future owns its captured `S` outright), so
+        // a regular `get_mut` is safe and matches the `unfold` pattern.
+        let this = self.get_mut();
+        loop {
+            match std::mem::replace(&mut this.state, BridgeState::Done) {
+                BridgeState::Idle(mut stream) => {
+                    // Move the stream into a boxed async block. The future
+                    // owns the stream and returns it back when `next()`
+                    // resolves, so the bridge can re-enter the Idle state
+                    // without any self-referential borrow.
+                    //
+                    // `S::Item<'_>` borrows from `&mut stream`; we extract
+                    // the owned representation via `S::into_owned` inside
+                    // the borrow's scope so the mutable borrow ends before
+                    // we move `stream` into the returned tuple.
+                    let fut: Pending<S, S::OwnedItem, S::Error> = Box::pin(async move {
+                        let owned_result = match stream.next().await {
+                            Ok(Some(item)) => Ok(Some(S::into_owned(item))),
+                            Ok(None) => Ok(None),
+                            Err(err) => Err(err),
+                        };
+                        (owned_result, stream)
+                    });
+                    this.state = BridgeState::Pending(fut);
+                }
+                BridgeState::Pending(mut fut) => match fut.as_mut().poll(cx) {
+                    Poll::Pending => {
+                        this.state = BridgeState::Pending(fut);
+                        return Poll::Pending;
+                    }
+                    Poll::Ready((Ok(Some(item)), stream)) => {
+                        this.state = BridgeState::Idle(stream);
+                        return Poll::Ready(Some(Ok(item)));
+                    }
+                    Poll::Ready((Ok(None), _stream)) => {
+                        // Stream exhausted naturally; the cursor is dropped.
+                        this.state = BridgeState::Done;
+                        return Poll::Ready(None);
+                    }
+                    Poll::Ready((Err(err), _stream)) => {
+                        // Surface the error once and terminate.
+                        this.state = BridgeState::Done;
+                        return Poll::Ready(Some(Err(err)));
+                    }
+                },
+                BridgeState::Done => {
+                    this.state = BridgeState::Done;
+                    return Poll::Ready(None);
+                }
+            }
+        }
+    }
+}

--- a/crates/nexus-store/tests/futures_bridge_tests.rs
+++ b/crates/nexus-store/tests/futures_bridge_tests.rs
@@ -1,0 +1,327 @@
+//! Tests for the `futures::Stream` bridge introduced in PR2 of the
+//! stream refactor.
+//!
+//! Coverage matrix:
+//!
+//! 1. **Sequence/Protocol**: `.try_map(...).into_stream().try_collect()`
+//!    end-to-end — verifies the bridge yields every item in order with
+//!    the owned-value transformation applied by `.try_map`.
+//! 2. **Lifecycle**:
+//!    - empty lending stream → empty futures stream (terminates on first
+//!      poll with `None`).
+//!    - many items → terminates after yielding all items.
+//!    - after exhaustion, subsequent polls keep returning `None`.
+//! 3. **Defensive Boundary**:
+//!    - underlying-stream error propagates through `.try_map` into the
+//!      bridge: the futures stream yields one `Err(...)` item, then
+//!      terminates on the next poll.
+//!    - `.try_map` closure error short-circuits similarly.
+//! 4. **Send/Spawn**: `IntoStream<...>` is `Send` and can be driven from
+//!    a `tokio::spawn` task.
+//!
+//! Plus a static-assertion that `IntoStream` itself is `Send` — the
+//! bridge has to be spawnable for it to be useful.
+
+#![cfg(feature = "futures-bridge")]
+#![allow(clippy::unwrap_used, reason = "tests")]
+#![allow(clippy::missing_panics_doc, reason = "tests")]
+#![allow(clippy::missing_docs_in_private_items, reason = "tests")]
+#![allow(clippy::shadow_unrelated, reason = "tests")]
+#![allow(clippy::shadow_reuse, reason = "tests")]
+#![allow(clippy::as_conversions, reason = "tests")]
+#![allow(clippy::arithmetic_side_effects, reason = "tests")]
+#![allow(clippy::indexing_slicing, reason = "tests")]
+#![allow(clippy::cast_possible_truncation, reason = "tests")]
+#![allow(clippy::str_to_string, reason = "tests")]
+
+use std::convert::Infallible;
+use std::fmt;
+
+use futures::StreamExt;
+use futures::TryStreamExt;
+use nexus::Version;
+use nexus_store::PersistedEnvelope;
+use nexus_store::store::GlobalSeq;
+use nexus_store::stream::{BaseEventStream, EventStream, EventStreamExt, IntoStream};
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Test fixtures
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Minimal lending stream over `(version, event_type, payload)` rows.
+/// Identical shape to the `VecStream` in `combinator_tests.rs`.
+struct VecStream {
+    rows: Vec<(u64, String, Vec<u8>)>,
+    pos: usize,
+}
+
+impl VecStream {
+    fn new(rows: Vec<(u64, String, Vec<u8>)>) -> Self {
+        Self { rows, pos: 0 }
+    }
+}
+
+impl BaseEventStream for VecStream {
+    fn to_envelope<'a>(item: PersistedEnvelope<'a>) -> PersistedEnvelope<'a>
+    where
+        Self: 'a,
+    {
+        item
+    }
+}
+
+impl EventStream for VecStream {
+    type Item<'a> = PersistedEnvelope<'a>;
+    type Error = Infallible;
+
+    async fn next(&mut self) -> Result<Option<PersistedEnvelope<'_>>, Self::Error> {
+        if self.pos >= self.rows.len() {
+            return Ok(None);
+        }
+        let row = &self.rows[self.pos];
+        self.pos += 1;
+        Ok(Some(PersistedEnvelope::new_unchecked(
+            Version::new(row.0).unwrap(),
+            GlobalSeq::INITIAL,
+            &row.1,
+            1,
+            &row.2,
+            (),
+        )))
+    }
+}
+
+fn rows(n: u64) -> Vec<(u64, String, Vec<u8>)> {
+    (1..=n)
+        .map(|v| (v, "E".to_string(), vec![v as u8]))
+        .collect()
+}
+
+/// Lending stream that fails on the `fail_at`-th `next()` call (1-indexed).
+/// Used to verify error propagation through the bridge.
+struct FailingStream {
+    seen: u64,
+    fail_at: u64,
+}
+
+impl FailingStream {
+    const fn new(fail_at: u64) -> Self {
+        Self { seen: 0, fail_at }
+    }
+}
+
+#[derive(Debug)]
+struct BoomError;
+
+impl fmt::Display for BoomError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("boom")
+    }
+}
+
+impl std::error::Error for BoomError {}
+
+impl BaseEventStream for FailingStream {
+    fn to_envelope<'a>(item: PersistedEnvelope<'a>) -> PersistedEnvelope<'a>
+    where
+        Self: 'a,
+    {
+        item
+    }
+}
+
+impl EventStream for FailingStream {
+    type Item<'a> = PersistedEnvelope<'a>;
+    type Error = BoomError;
+
+    async fn next(&mut self) -> Result<Option<PersistedEnvelope<'_>>, Self::Error> {
+        self.seen += 1;
+        if self.seen == self.fail_at {
+            return Err(BoomError);
+        }
+        // Synthesise a placeholder envelope when not failing.
+        Ok(Some(PersistedEnvelope::new_unchecked(
+            Version::new(self.seen).unwrap(),
+            GlobalSeq::INITIAL,
+            "E",
+            1,
+            &[0u8; 1],
+            (),
+        )))
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Static — IntoStream is Send (must be spawnable)
+// ═══════════════════════════════════════════════════════════════════════════
+
+// Anchored on a concrete `.try_map(...)` shape so the assertion is
+// meaningful even for the non-trivial bound stack.
+fn _assert_into_stream_send() {
+    fn is_send<T: Send>() {}
+    is_send::<
+        IntoStream<
+            nexus_store::stream::TryMap<
+                VecStream,
+                fn(PersistedEnvelope<'_>) -> Result<u64, Infallible>,
+                Infallible,
+            >,
+            (),
+        >,
+    >();
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 1. Sequence/Protocol — end-to-end try_map -> into_stream -> try_collect
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn try_map_then_into_stream_then_try_collect_yields_all_items_in_order() {
+    let stream = VecStream::new(rows(4))
+        .try_map(|env| Ok::<_, Infallible>((env.version(), env.payload().to_vec())))
+        .into_stream();
+
+    let collected: Vec<(Version, Vec<u8>)> = stream.try_collect().await.unwrap();
+    assert_eq!(collected.len(), 4);
+    assert_eq!(
+        collected,
+        vec![
+            (Version::new(1).unwrap(), vec![1]),
+            (Version::new(2).unwrap(), vec![2]),
+            (Version::new(3).unwrap(), vec![3]),
+            (Version::new(4).unwrap(), vec![4]),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn map_then_into_stream_yields_owned_closure_outputs() {
+    // `.map` (infallible) produces an owned `u64`. The bridge surfaces
+    // each value wrapped in `Ok(...)` — there's no per-item error path
+    // for the closure, only for the underlying stream.
+    let stream = VecStream::new(rows(3))
+        .map(|env| env.version().as_u64())
+        .into_stream();
+    let collected: Vec<Result<u64, Infallible>> = stream.collect().await;
+    let values: Vec<u64> = collected.into_iter().map(Result::unwrap).collect();
+    assert_eq!(values, vec![1, 2, 3]);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 2. Lifecycle
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn empty_lending_stream_yields_empty_futures_stream() {
+    let stream = VecStream::new(Vec::new())
+        .try_map(|env| Ok::<_, Infallible>(env.version()))
+        .into_stream();
+    let collected: Vec<Version> = stream.try_collect().await.unwrap();
+    assert!(collected.is_empty());
+}
+
+#[tokio::test]
+async fn bridge_is_fused_after_exhaustion() {
+    // After the underlying stream returns Ok(None), subsequent polls
+    // must keep returning None forever — the futures-stream contract.
+    let stream = VecStream::new(rows(2))
+        .try_map(|env| Ok::<_, Infallible>(env.version()))
+        .into_stream();
+    let mut pinned = Box::pin(stream);
+
+    // First two `next()`s yield the items.
+    assert_eq!(
+        pinned.next().await.unwrap().unwrap(),
+        Version::new(1).unwrap()
+    );
+    assert_eq!(
+        pinned.next().await.unwrap().unwrap(),
+        Version::new(2).unwrap()
+    );
+
+    // Then None ... and stays None.
+    assert!(pinned.next().await.is_none());
+    assert!(pinned.next().await.is_none());
+    assert!(pinned.next().await.is_none());
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 3. Defensive Boundary — error propagation
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn underlying_stream_error_propagates_through_bridge_then_terminates() {
+    // FailingStream errors on its 3rd next() call. The bridge yields
+    // 2 Ok items, 1 Err item, then terminates with None.
+    let stream = FailingStream::new(3)
+        .try_map(|env| Ok::<_, BoomError>(env.version().as_u64()))
+        .into_stream();
+    let mut pinned = Box::pin(stream);
+
+    assert_eq!(pinned.next().await.unwrap().unwrap(), 1);
+    assert_eq!(pinned.next().await.unwrap().unwrap(), 2);
+
+    let err_item = pinned.next().await.unwrap();
+    assert!(err_item.is_err(), "expected Err, got {err_item:?}");
+    assert_eq!(err_item.unwrap_err().to_string(), "boom");
+
+    assert!(pinned.next().await.is_none());
+    assert!(pinned.next().await.is_none());
+}
+
+#[derive(Debug)]
+struct CloseError;
+
+impl fmt::Display for CloseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("close")
+    }
+}
+
+impl std::error::Error for CloseError {}
+
+impl From<Infallible> for CloseError {
+    fn from(_: Infallible) -> Self {
+        Self
+    }
+}
+
+#[tokio::test]
+async fn try_map_closure_error_surfaces_through_bridge_then_terminates() {
+    // The closure rejects payload byte == 2; the bridge yields one Ok,
+    // one Err, then terminates.
+    let stream = VecStream::new(rows(4))
+        .try_map(|env| {
+            if env.payload()[0] == 2 {
+                Err(CloseError)
+            } else {
+                Ok(env.version().as_u64())
+            }
+        })
+        .into_stream();
+    let mut pinned = Box::pin(stream);
+
+    assert_eq!(pinned.next().await.unwrap().unwrap(), 1);
+
+    let err_item = pinned.next().await.unwrap();
+    assert!(err_item.is_err());
+    assert_eq!(err_item.unwrap_err().to_string(), "close");
+
+    assert!(pinned.next().await.is_none());
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 4. Spawn — bridge is driveable from a tokio task
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn bridge_is_driveable_from_tokio_spawn() {
+    let handle = tokio::spawn(async {
+        let stream = VecStream::new(rows(5))
+            .try_map(|env| Ok::<_, Infallible>(env.version().as_u64()))
+            .into_stream();
+        stream.try_collect::<Vec<u64>>().await
+    });
+    let collected = handle.await.unwrap().unwrap();
+    assert_eq!(collected, vec![1, 2, 3, 4, 5]);
+}

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -12,6 +12,7 @@ publish = false
 
 ### BEGIN HAKARI SECTION
 [dependencies]
+memchr = { version = "2" }
 num-traits = { version = "0.2" }
 once_cell = { version = "1" }
 serde = { version = "1", features = ["alloc", "derive", "rc"] }
@@ -20,6 +21,7 @@ trybuild = { version = "1", default-features = false, features = ["diff"] }
 zerocopy = { version = "0.8", default-features = false, features = ["derive", "simd"] }
 
 [build-dependencies]
+memchr = { version = "2" }
 num-traits = { version = "0.2" }
 once_cell = { version = "1" }
 proc-macro2 = { version = "1", features = ["span-locations"] }


### PR DESCRIPTION
## Summary

PR2 of the dual-track stream refactor (plan: `cheerful-yawning-hopper`). Adds a feature-gated bridge from the GAT lending `EventStream` into `futures_core::Stream` so consumers can opt in to the futures ecosystem when they want owning output.

- New `futures-bridge` feature gates an optional `futures-core` dep.
- New `OwnedEventStream<M>` sub-trait witnesses "Item<'a> is an owned value" via a concrete `OwnedItem` associated type. Mirrors PR1's `BaseEventStream` pattern, which sidesteps the HRTB-on-GAT type equality issue on stable Rust. Implemented for `Map` and `TryMap` only — **not** for raw cursors (their `Item<'a>` borrows from the cursor). To bridge a raw cursor, chain `.map(...)` / `.try_map(...)` first so the per-event materialization is named at the call site.
- New `IntoStream<S, M>` implements `futures_core::Stream` via a hand-rolled state machine (Idle / Pending / Done) that box-pins each `next()` future. The unfold pattern moves the cursor into the future and returns it back — sidestepping self-referential lifetimes. The box-pin is the per-event allocation the plan calls out as explicit and opt-in.
- `EventStreamExt::into_stream()` is the entry point (also feature-gated).
- Hakari: `futures-core` excluded from `workspace-hack` unification (`.config/hakari.toml`) so the "feature off → dep absent from dep tree" guarantee holds workspace-wide, not just for published consumers.

`Filter` (deferred from PR1 per its deviation log) is untouched; remains a follow-up.

## Open design point resolved

The plan listed three options for the "OwnedItem marker shape" — separate trait, `'static` bound, or `Clone + Send + 'static`. Picked the trait route (`OwnedEventStream`) for symmetry with PR1's `BaseEventStream`. The `'static` bound is insufficient on its own because `futures::Stream::Item` is a single concrete type and we still need a named associated type to plug into it; HRTB type equality (`for<'a> Item<'a> = T`) is blocked by the GAT's `where Self: 'a` clause leaking `Self: 'static` into the HRTB. Full reasoning in the deviation log.

## Test plan

- [x] `nix flake check` passes (all 8 checks).
- [x] `cargo test -p nexus-store --features futures-bridge --test futures_bridge_tests` — 7 tests pass:
  - Sequence/Protocol: `try_map → into_stream → try_collect` yields all items in order
  - Sequence/Protocol: `map → into_stream` yields owned closure outputs wrapped in `Ok(...)`
  - Lifecycle: empty lending stream → empty futures stream
  - Lifecycle: bridge is fused after exhaustion (`None` keeps returning `None`)
  - Defensive Boundary: underlying-stream error propagates once then bridge terminates
  - Defensive Boundary: `try_map` closure error short-circuits identically
  - Send/spawn: bridge is driveable from `tokio::spawn`
- [x] Static assertion: `IntoStream<TryMap<VecStream, ..>, ()>: Send`.
- [x] `cargo tree -p nexus-store --no-default-features --edges normal` shows zero futures crates (hakari exclude in place).
- [x] `cargo tree -p nexus-store --features futures-bridge` confirms `futures-core` IS present when the feature is on.

## Files

- `Cargo.toml` — workspace deps: `futures = "0.3"` (dev-dep), `futures-core = "0.3"` (default-features = false).
- `.config/hakari.toml` — `[final-excludes]` block excluding `futures-core` from workspace-hack unification.
- `crates/nexus-store/Cargo.toml` — `futures-bridge` feature → `dep:futures-core`; `futures` workspace dev-dep; dev-dep enables `futures-bridge`.
- `crates/nexus-store/src/stream/owned.rs` (new) — `OwnedEventStream` sub-trait + `IntoStream` bridge.
- `crates/nexus-store/src/stream/mod.rs` — feature-gated re-export.
- `crates/nexus-store/src/stream/cursor.rs` — feature-gated `EventStreamExt::into_stream()` method.
- `crates/nexus-store/src/lib.rs` — feature-gated re-export.
- `crates/nexus-store/tests/futures_bridge_tests.rs` (new) — 7 tests covering the 4-category matrix.
- `crates/workspace-hack/Cargo.toml` — hakari output (regenerated).

## Plan / deviation log

- Plan: `/Users/joel/.claude/plans/cheerful-yawning-hopper.md`
- Deviation log: `/Users/joel/.claude/plans/cheerful-yawning-hopper-deviations.md` — four new entries for PR2 (OwnedEventStream choice, futures-core-only impl, hakari exclude, module naming).

🤖 Generated with [Claude Code](https://claude.com/claude-code)