### PR TITLE
refactor(store, macros)!: slim Upcaster trait; macro gap-coverage check; drop UpcastError

### DIFF
--- a/crates/nexus-macros/src/lib.rs
+++ b/crates/nexus-macros/src/lib.rs
@@ -97,6 +97,7 @@ fn parse_domain_event(ast: &DeriveInput) -> Result<proc_macro2::TokenStream> {
 /// # Attributes
 ///
 /// - `aggregate = Type` — the aggregate type these transforms belong to
+/// - `error = Type` — the error type returned by transform functions
 ///
 /// Each method must be annotated with `#[transform(...)]`:
 /// - `event = "EventName"` — the event type this transform handles
@@ -106,14 +107,17 @@ fn parse_domain_event(ast: &DeriveInput) -> Result<proc_macro2::TokenStream> {
 ///
 /// # Compile-time validation
 ///
-/// - No duplicate `(event, from)` pairs
-/// - `to == from + 1` for each transform
 /// - `from >= 1`
+/// - `to == from + 1` for each transform (contiguity per step)
+/// - No duplicate `(event, from)` pairs
+/// - **Chain coverage**: for each event type, every schema version in
+///   `[1, current_version]` is reachable via a contiguous chain — gaps
+///   produce a compile error naming the missing step
 ///
 /// # Example
 ///
 /// ```ignore
-/// #[nexus::transforms(aggregate = Order)]
+/// #[nexus::transforms(aggregate = Order, error = MyError)]
 /// impl OrderTransforms {
 ///     #[transform(event = "OrderCreated", from = 1, to = 2)]
 ///     fn v1_to_v2(payload: &[u8]) -> Result<Vec<u8>, MyError> {
@@ -282,6 +286,47 @@ fn parse_transforms(
         }
     }
 
+    // 6b. Validate chain coverage per event type.
+    //
+    // For each event type, every schema version in [1, current_version]
+    // must be reachable through a contiguous chain. Find the smallest gap
+    // (i.e. the smallest `from` in [1, max_from] for which no transform
+    // exists) and reject with a diagnostic naming the missing step.
+    let mut from_versions_by_event: HashMap<String, HashSet<u64>> = HashMap::new();
+    let mut max_from_by_event: HashMap<String, u64> = HashMap::new();
+    for t in &transforms {
+        from_versions_by_event
+            .entry(t.event_type.clone())
+            .or_default()
+            .insert(t.from_version);
+        let entry = max_from_by_event.entry(t.event_type.clone()).or_insert(0);
+        if t.from_version > *entry {
+            *entry = t.from_version;
+        }
+    }
+    for t in &transforms {
+        let Some(from_set) = from_versions_by_event.get(&t.event_type) else {
+            continue;
+        };
+        let Some(&max_from) = max_from_by_event.get(&t.event_type) else {
+            continue;
+        };
+        for v in 1..max_from {
+            if !from_set.contains(&v) {
+                return Err(Error::new_spanned(
+                    &t.fn_name,
+                    format!(
+                        "transform chain gap for event '{}': missing step from version {} to version {} (chain must cover every version in [1, {}])",
+                        t.event_type,
+                        v,
+                        v + 1,
+                        max_from + 1,
+                    ),
+                ));
+            }
+        }
+    }
+
     // 7. Build the original impl block with #[transform] attrs stripped
     let stripped_methods: Vec<_> = ast
         .items
@@ -296,7 +341,7 @@ fn parse_transforms(
         })
         .collect();
 
-    // 8. Generate match arms for apply()
+    // 8. Generate match arms for upcast()
     let match_arms: Vec<_> = transforms
         .iter()
         .map(|t| {
@@ -308,16 +353,7 @@ fn parse_transforms(
 
             quote! {
                 (#event_type, v) if v == ::nexus::Version::new(#from_version).expect("nonzero") => {
-                    let payload = Self::#fn_name(morsel.payload())
-                        .map_err(|e| ::nexus_store::UpcastError::TransformFailed {
-                            event_type: {
-                                let mut buf = ::nexus_store::ArrayString::<64>::new();
-                                let _ = ::std::fmt::Write::write_str(&mut buf, #event_type);
-                                buf
-                            },
-                            schema_version: ::nexus::Version::new(#from_version).expect("nonzero"),
-                            source: e,
-                        })?;
+                    let payload = Self::#fn_name(morsel.payload())?;
                     ::nexus_store::upcasting::EventMorsel::new(
                         #output_event_type,
                         ::nexus::Version::new(#to_version).expect("nonzero"),
@@ -366,12 +402,12 @@ fn parse_transforms(
         impl ::nexus_store::Upcaster for #struct_ident {
             type Error = #error_type;
 
-            fn apply<'a>(
+            fn upcast<'a>(
                 &self,
                 mut morsel: ::nexus_store::upcasting::EventMorsel<'a>,
             ) -> ::core::result::Result<
                 ::nexus_store::upcasting::EventMorsel<'a>,
-                ::nexus_store::UpcastError<Self::Error>,
+                Self::Error,
             > {
                 loop {
                     morsel = match (morsel.event_type(), morsel.schema_version()) {

--- a/crates/nexus-macros/tests/macro_compile_fail/transforms_gap.rs
+++ b/crates/nexus-macros/tests/macro_compile_fail/transforms_gap.rs
@@ -1,0 +1,31 @@
+use nexus_macros::transforms;
+
+struct Order;
+
+#[derive(Debug)]
+struct MyError;
+impl std::fmt::Display for MyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "error")
+    }
+}
+impl std::error::Error for MyError {}
+
+// Declares transforms 1→2 and 4→5 with no 2→3 or 3→4 step. The macro must
+// reject this because version 3's `from` step is missing — the chain has a
+// gap and rehydrating a v3 event would silently leave it at v3 while
+// current_version is 5.
+#[transforms(aggregate = Order, error = MyError)]
+impl OrderTransforms {
+    #[transform(event = "OrderCreated", from = 1, to = 2)]
+    fn v1_to_v2(payload: &[u8]) -> Result<Vec<u8>, MyError> {
+        Ok(payload.to_vec())
+    }
+
+    #[transform(event = "OrderCreated", from = 4, to = 5)]
+    fn v4_to_v5(payload: &[u8]) -> Result<Vec<u8>, MyError> {
+        Ok(payload.to_vec())
+    }
+}
+
+fn main() {}

--- a/crates/nexus-macros/tests/macro_compile_fail/transforms_gap.stderr
+++ b/crates/nexus-macros/tests/macro_compile_fail/transforms_gap.stderr
@@ -1,0 +1,5 @@
+error: transform chain gap for event 'OrderCreated': missing step from version 2 to version 3 (chain must cover every version in [1, 5])
+  --> tests/macro_compile_fail/transforms_gap.rs:21:8
+   |
+21 |     fn v1_to_v2(payload: &[u8]) -> Result<Vec<u8>, MyError> {
+   |        ^^^^^^^^

--- a/crates/nexus-macros/tests/transforms_derive.rs
+++ b/crates/nexus-macros/tests/transforms_derive.rs
@@ -42,7 +42,7 @@ impl TestTransforms {
 #[test]
 fn transforms_multi_step_upcast() {
     let morsel = EventMorsel::borrowed("OrderCreated", Version::INITIAL, b"data");
-    let result = TestTransforms.apply(morsel).unwrap();
+    let result = TestTransforms.upcast(morsel).unwrap();
     assert_eq!(result.schema_version(), Version::new(3).unwrap());
     assert_eq!(result.payload(), b"data,v2,v3");
     assert_eq!(result.event_type(), "OrderCreated");
@@ -51,7 +51,7 @@ fn transforms_multi_step_upcast() {
 #[test]
 fn transforms_rename() {
     let morsel = EventMorsel::borrowed("OrderCancelled", Version::INITIAL, b"data");
-    let result = TestTransforms.apply(morsel).unwrap();
+    let result = TestTransforms.upcast(morsel).unwrap();
     assert_eq!(result.event_type(), "OrderVoided");
     assert_eq!(result.schema_version(), Version::new(2).unwrap());
 }
@@ -59,14 +59,14 @@ fn transforms_rename() {
 #[test]
 fn transforms_passthrough_current_version() {
     let morsel = EventMorsel::borrowed("OrderCreated", Version::new(3).unwrap(), b"data");
-    let result = TestTransforms.apply(morsel).unwrap();
+    let result = TestTransforms.upcast(morsel).unwrap();
     assert!(result.is_borrowed(), "current version should pass through");
 }
 
 #[test]
 fn transforms_unknown_event_passthrough() {
     let morsel = EventMorsel::borrowed("Unknown", Version::INITIAL, b"data");
-    let result = TestTransforms.apply(morsel).unwrap();
+    let result = TestTransforms.upcast(morsel).unwrap();
     assert!(result.is_borrowed());
 }
 

--- a/crates/nexus-store/benches/store_bench.rs
+++ b/crates/nexus-store/benches/store_bench.rs
@@ -177,11 +177,10 @@ struct NoopV1ToV6;
 impl Upcaster for NoopV1ToV6 {
     type Error = Infallible;
 
-    fn apply<'a>(
+    fn upcast<'a>(
         &self,
         mut morsel: nexus_store::upcasting::EventMorsel<'a>,
-    ) -> Result<nexus_store::upcasting::EventMorsel<'a>, nexus_store::UpcastError<Self::Error>>
-    {
+    ) -> Result<nexus_store::upcasting::EventMorsel<'a>, Self::Error> {
         loop {
             morsel = match (morsel.event_type(), morsel.schema_version()) {
                 ("UserCreated", v) if v == Version::new(1).unwrap() => {
@@ -348,7 +347,7 @@ fn bench_upcaster(c: &mut Criterion) {
                 Version::new(1).unwrap(),
                 black_box(&payload),
             );
-            let result = upcaster.apply(morsel).unwrap();
+            let result = upcaster.upcast(morsel).unwrap();
             black_box(result)
         });
     });

--- a/crates/nexus-store/src/error.rs
+++ b/crates/nexus-store/src/error.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 /// Errors from the event store layer.
 ///
 /// Generic over adapter (`A`), encode (`EncErr`), decode (`DecErr`), and
-/// upcaster transform (`U`) error types — zero allocation, no `Box<dyn Error>`.
+/// upcaster transform (`UpErr`) error types — zero allocation, no `Box<dyn Error>`.
 ///
 /// `EncErr` and `DecErr` are independent so write-only and read-only codecs
 /// can each set the unused side to `Infallible`. For the common case where
@@ -13,7 +13,7 @@ use thiserror::Error;
 /// the same `Error` associated type on both `Encode` and `Decode` impls and
 /// `EncErr == DecErr` falls out without a where-clause.
 #[derive(Debug, Error)]
-pub enum StoreError<A, EncErr, DecErr, U> {
+pub enum StoreError<A, EncErr, DecErr, UpErr> {
     /// Optimistic concurrency conflict.
     #[error(
         "concurrency conflict on stream '{stream_id}': expected version {expected:?}, actual {actual:?}"
@@ -41,8 +41,13 @@ pub enum StoreError<A, EncErr, DecErr, U> {
     Decode(#[source] DecErr),
 
     /// Upcaster transform failure.
+    ///
+    /// Carries the upcaster's raw error type (the `Self::Error` associated type
+    /// from the [`Upcaster`](crate::Upcaster) implementation). No wrapper is
+    /// applied; if the user wants diagnostic context (event type, schema
+    /// version), they should encode it in their own error type.
     #[error("upcast error: {0}")]
-    Upcast(#[source] UpcastError<U>),
+    Upcast(#[source] UpErr),
 
     /// Kernel error during replay (e.g. version mismatch, rehydration limit).
     #[error("kernel error: {0}")]
@@ -51,18 +56,6 @@ pub enum StoreError<A, EncErr, DecErr, U> {
     /// Version overflow: cannot advance past `u64::MAX`.
     #[error("version overflow: cannot advance past u64::MAX")]
     VersionOverflow,
-}
-
-impl<A, EncErr, DecErr, U> From<DecodeStreamError<A, DecErr, U>>
-    for StoreError<A, EncErr, DecErr, U>
-{
-    fn from(err: DecodeStreamError<A, DecErr, U>) -> Self {
-        match err {
-            DecodeStreamError::Stream(e) => Self::Adapter(e),
-            DecodeStreamError::Decode(e) => Self::Decode(e),
-            DecodeStreamError::Upcast(e) => Self::Upcast(e),
-        }
-    }
 }
 
 /// Structured error from [`RawEventStore::append`](crate::RawEventStore::append).
@@ -91,70 +84,3 @@ pub enum AppendError<E> {
 #[derive(Debug, Error)]
 #[error("invalid schema version: 0 (schema versions start at 1)")]
 pub struct InvalidSchemaVersion;
-
-/// Convenience error type for [`DecodedStream`](crate::stream::DecodedStream)
-/// and [`BorrowedDecodedStream`](crate::stream::BorrowedDecodedStream) fold operations.
-///
-/// Each variant carries the underlying error from one stage of the read
-/// pipeline. Generic over the three error sources so callers may use it
-/// directly or define their own enum with `From` impls for the same three
-/// errors.
-#[derive(Debug, Error)]
-pub enum DecodeStreamError<S, DecErr, U> {
-    /// Underlying stream failure.
-    #[error("stream error: {0}")]
-    Stream(#[source] S),
-
-    /// Decode failure.
-    #[error("decode error: {0}")]
-    Decode(#[source] DecErr),
-
-    /// Upcaster transform failure.
-    #[error("upcaster error: {0}")]
-    Upcast(#[source] UpcastError<U>),
-}
-
-/// Errors from upcaster validation and transform execution.
-///
-/// Generic over the transform error type `U` — each `Upcaster`
-/// implementation specifies its own error type via `Upcaster::Error`.
-#[derive(Debug, Error)]
-pub enum UpcastError<U> {
-    /// Upcaster returned the same or lower schema version.
-    #[error(
-        "upcaster did not advance schema version for '{event_type}': input {input_version}, output {output_version}"
-    )]
-    VersionNotAdvanced {
-        event_type: ArrayString<64>,
-        input_version: Version,
-        output_version: Version,
-    },
-
-    /// Upcaster returned an empty event type.
-    #[error(
-        "upcaster returned empty event_type (input: '{input_event_type}', schema version {schema_version})"
-    )]
-    EmptyEventType {
-        input_event_type: ArrayString<64>,
-        schema_version: Version,
-    },
-
-    /// Upcaster chain exceeded the iteration limit.
-    #[error(
-        "upcaster chain exceeded {limit} iterations for '{event_type}' (stuck at schema version {schema_version})"
-    )]
-    ChainLimitExceeded {
-        event_type: ArrayString<64>,
-        schema_version: Version,
-        limit: u64,
-    },
-
-    /// A schema transform failed to process the payload.
-    #[error("transform failed for '{event_type}' at schema version {schema_version}: {source}")]
-    TransformFailed {
-        event_type: ArrayString<64>,
-        schema_version: Version,
-        #[source]
-        source: U,
-    },
-}

--- a/crates/nexus-store/src/lib.rs
+++ b/crates/nexus-store/src/lib.rs
@@ -24,7 +24,7 @@ pub use codec::serde::json::{Json, JsonCodec};
 pub use codec::serde::{SerdeCodec, SerdeFormat};
 pub use codec::{BorrowingDecode, Decode, Encode};
 pub use envelope::{PendingEnvelope, PersistedEnvelope, pending_envelope};
-pub use error::{AppendError, DecodeStreamError, InvalidSchemaVersion, StoreError, UpcastError};
+pub use error::{AppendError, InvalidSchemaVersion, StoreError};
 pub use nexus::Version;
 #[cfg(feature = "projection")]
 pub use projection::Projector;

--- a/crates/nexus-store/src/repository.rs
+++ b/crates/nexus-store/src/repository.rs
@@ -195,7 +195,7 @@ where
                 env.schema_version_as_version(),
                 env.payload(),
             );
-            let transformed = self.upcaster.apply(morsel).map_err(StoreError::Upcast)?;
+            let transformed = self.upcaster.upcast(morsel).map_err(StoreError::Upcast)?;
             let event = <C as Decode<EventOf<A>>>::decode(
                 &self.codec,
                 transformed.event_type(),
@@ -382,7 +382,7 @@ where
                 env.schema_version_as_version(),
                 env.payload(),
             );
-            let transformed = self.upcaster.apply(morsel).map_err(StoreError::Upcast)?;
+            let transformed = self.upcaster.upcast(morsel).map_err(StoreError::Upcast)?;
             let event: &EventOf<A> = <C as BorrowingDecode<EventOf<A>>>::decode(
                 &self.codec,
                 transformed.event_type(),

--- a/crates/nexus-store/src/upcasting.rs
+++ b/crates/nexus-store/src/upcasting.rs
@@ -2,8 +2,6 @@ use std::borrow::Cow;
 
 use nexus::Version;
 
-use crate::error::UpcastError;
-
 // ═══════════════════════════════════════════════════════════════════════════
 // EventMorsel — data unit flowing through the transform pipeline
 // ═══════════════════════════════════════════════════════════════════════════
@@ -97,9 +95,25 @@ impl<'a> EventMorsel<'a> {
 
 /// Upcast old events to the current schema version.
 ///
-/// `EventStore` calls `apply()` on the read path and `current_version()`
-/// on the write path. The proc macro `#[nexus::transforms]` generates
-/// implementations; `()` is the no-op passthrough.
+/// `EventStore` calls [`upcast`](Upcaster::upcast) on the read path and
+/// [`current_version`](Upcaster::current_version) on the write path. The proc
+/// macro `#[nexus::transforms]` generates implementations; `()` is the no-op
+/// passthrough.
+///
+/// # Compile-time guarantees (macro-generated impls)
+///
+/// The `#[nexus::transforms]` macro verifies, at compile time:
+/// - `from >= 1` on every transform.
+/// - `to == from + 1` on every transform (contiguity per step).
+/// - No duplicate `(event_type, from)` pairs.
+/// - **Chain coverage**: for each event type, every schema version in
+///   `[1, current_version]` is reachable via the declared chain (no gaps).
+///
+/// These guarantees make a number of runtime errors unrepresentable for
+/// macro-generated upcasters: the chain always terminates, every step
+/// advances the schema version, and event types are non-empty literals.
+/// Hand-rolled `Upcaster` implementations should preserve these properties
+/// themselves; the trait does not check them at runtime.
 pub trait Upcaster: Send + Sync {
     /// The error type produced by transform functions.
     ///
@@ -111,12 +125,12 @@ pub trait Upcaster: Send + Sync {
     ///
     /// # Errors
     ///
-    /// Returns [`UpcastError`] if a transform function fails or validation detects
-    /// an invariant violation (version not advanced, empty event type, chain limit).
-    fn apply<'a>(
-        &self,
-        morsel: EventMorsel<'a>,
-    ) -> Result<EventMorsel<'a>, UpcastError<Self::Error>>;
+    /// Returns the implementation's `Self::Error` when a user-provided
+    /// transform function fails. Macro-generated implementations propagate
+    /// the transform's error verbatim; the wrapper context (event type,
+    /// schema version) is the user's responsibility to encode in their own
+    /// error type if needed.
+    fn upcast<'a>(&self, morsel: EventMorsel<'a>) -> Result<EventMorsel<'a>, Self::Error>;
 
     /// Current schema version for an event type (stamped on new events).
     /// Returns `None` if the event type has no transforms.
@@ -128,10 +142,7 @@ impl Upcaster for () {
     type Error = std::convert::Infallible;
 
     #[inline]
-    fn apply<'a>(
-        &self,
-        morsel: EventMorsel<'a>,
-    ) -> Result<EventMorsel<'a>, UpcastError<Self::Error>> {
+    fn upcast<'a>(&self, morsel: EventMorsel<'a>) -> Result<EventMorsel<'a>, Self::Error> {
         Ok(morsel)
     }
 

--- a/crates/nexus-store/tests/adversarial_property_tests.rs
+++ b/crates/nexus-store/tests/adversarial_property_tests.rs
@@ -69,7 +69,7 @@ use nexus_store::Store;
 use nexus_store::Upcaster;
 use nexus_store::codec::{Decode, Encode};
 use nexus_store::envelope::{PendingEnvelope, PersistedEnvelope};
-use nexus_store::error::{StoreError, UpcastError};
+use nexus_store::error::StoreError;
 use nexus_store::pending_envelope;
 use nexus_store::store::{GlobalSeq, RawEventStore};
 use nexus_store::stream::EventStream;
@@ -843,10 +843,7 @@ fn attack_upcaster_correct_final_state() {
     impl Upcaster for ThreeStepUpcaster {
         type Error = Infallible;
 
-        fn apply<'a>(
-            &self,
-            mut morsel: EventMorsel<'a>,
-        ) -> Result<EventMorsel<'a>, UpcastError<Self::Error>> {
+        fn upcast<'a>(&self, mut morsel: EventMorsel<'a>) -> Result<EventMorsel<'a>, Self::Error> {
             loop {
                 match (morsel.event_type(), morsel.schema_version()) {
                     ("E", v) if v == Version::INITIAL => {
@@ -874,7 +871,7 @@ fn attack_upcaster_correct_final_state() {
 
     let payload = vec![42u8; 100];
     let morsel = EventMorsel::borrowed("E", Version::INITIAL, &payload);
-    let result = ThreeStepUpcaster.apply(morsel).unwrap();
+    let result = ThreeStepUpcaster.upcast(morsel).unwrap();
 
     assert_eq!(result.event_type(), "E");
     assert_eq!(result.schema_version(), Version::new(4).unwrap());
@@ -1086,10 +1083,7 @@ async fn attack_event_store_transforms_applied_on_load() {
     impl Upcaster for HappenedV1ToV2 {
         type Error = Infallible;
 
-        fn apply<'a>(
-            &self,
-            morsel: EventMorsel<'a>,
-        ) -> Result<EventMorsel<'a>, UpcastError<Self::Error>> {
+        fn upcast<'a>(&self, morsel: EventMorsel<'a>) -> Result<EventMorsel<'a>, Self::Error> {
             match (morsel.event_type(), morsel.schema_version()) {
                 ("Happened", v) if v == Version::INITIAL => Ok(EventMorsel::new(
                     "Happened",
@@ -1643,7 +1637,7 @@ proptest! {
         let upcaster = ();
         let ver = Version::new(schema_version).unwrap();
         let morsel = EventMorsel::borrowed(&event_type, ver, &payload);
-        let result = upcaster.apply(morsel).unwrap();
+        let result = upcaster.upcast(morsel).unwrap();
 
         prop_assert_eq!(result.event_type(), event_type.as_str(), "event_type changed with no-op upcaster");
         prop_assert_eq!(result.schema_version(), ver, "version changed with no-op upcaster");
@@ -1704,47 +1698,11 @@ proptest! {
     }
 }
 
-// ============================================================================
-// ATTACK 36: UpcastError Display formatting
-// ============================================================================
-
-proptest! {
-    #![proptest_config(ProptestConfig::with_cases(64))]
-
-    #[test]
-    fn attack_upcast_error_display_includes_context(
-        event_type in "[A-Z][a-z]{0,20}",
-        schema_version in 1..1000u64,
-    ) {
-        let ver = Version::new(schema_version).unwrap();
-
-        let et_label = label(&event_type);
-
-        let err1 = UpcastError::<Infallible>::VersionNotAdvanced {
-            event_type: et_label,
-            input_version: ver,
-            output_version: ver,
-        };
-        let msg1 = err1.to_string();
-        prop_assert!(msg1.contains(&event_type), "event_type missing from error: {}", msg1);
-
-        let err2 = UpcastError::<Infallible>::EmptyEventType {
-            input_event_type: et_label,
-            schema_version: ver,
-        };
-        let msg2 = err2.to_string();
-        prop_assert!(msg2.contains(&event_type), "event_type missing from error: {}", msg2);
-
-        let err3 = UpcastError::<Infallible>::ChainLimitExceeded {
-            event_type: et_label,
-            schema_version: ver,
-            limit: 100,
-        };
-        let msg3 = err3.to_string();
-        prop_assert!(msg3.contains(&event_type), "event_type missing from error: {}", msg3);
-        prop_assert!(msg3.contains("100"), "limit missing from error: {}", msg3);
-    }
-}
+// ATTACK 36 deleted in PR4: UpcastError type was removed when the Upcaster
+// trait shape was slimmed. The runtime invariants that produced those error
+// variants (chain coverage, contiguity, no duplicates) are now validated at
+// compile time by the #[transforms] macro, so no enum variants remain to
+// format-test.
 
 // ============================================================================
 // ATTACK 37: Concurrent writers racing on the same stream
@@ -1806,7 +1764,7 @@ proptest! {
         impl Upcaster for RenamingUpcaster {
             type Error = Infallible;
 
-            fn apply<'a>(&self, mut morsel: EventMorsel<'a>) -> Result<EventMorsel<'a>, UpcastError<Self::Error>> {
+            fn upcast<'a>(&self, mut morsel: EventMorsel<'a>) -> Result<EventMorsel<'a>, Self::Error> {
                 loop {
                     match (morsel.event_type(), morsel.schema_version()) {
                         ("OldEvent", v) if v == Version::INITIAL => {
@@ -1834,7 +1792,7 @@ proptest! {
         }
 
         let morsel = EventMorsel::borrowed("OldEvent", Version::INITIAL, &payload);
-        let result = RenamingUpcaster.apply(morsel).unwrap();
+        let result = RenamingUpcaster.upcast(morsel).unwrap();
 
         prop_assert_eq!(result.event_type(), "NewEvent", "type rename chain failed");
         prop_assert_eq!(result.schema_version(), Version::new(3).unwrap());
@@ -1858,7 +1816,7 @@ proptest! {
         impl Upcaster for PrefixUpcaster {
             type Error = Infallible;
 
-            fn apply<'a>(&self, mut morsel: EventMorsel<'a>) -> Result<EventMorsel<'a>, UpcastError<Self::Error>> {
+            fn upcast<'a>(&self, mut morsel: EventMorsel<'a>) -> Result<EventMorsel<'a>, Self::Error> {
                 loop {
                     match (morsel.event_type(), morsel.schema_version()) {
                         ("E", v) if v == Version::INITIAL => {
@@ -1881,7 +1839,7 @@ proptest! {
         }
 
         let morsel = EventMorsel::borrowed("E", Version::INITIAL, &payload);
-        let result = PrefixUpcaster.apply(morsel).unwrap();
+        let result = PrefixUpcaster.upcast(morsel).unwrap();
 
         prop_assert_eq!(result.schema_version(), Version::new(2).unwrap());
         prop_assert_eq!(result.payload().len(), payload.len() + 2);

--- a/crates/nexus-store/tests/error_tests.rs
+++ b/crates/nexus-store/tests/error_tests.rs
@@ -1,15 +1,14 @@
-//! Unit tests for `StoreError` and `UpcastError` Display output and `source()` chain.
+//! Unit tests for `StoreError` Display output and `source()` chain.
 
 #![allow(clippy::unwrap_used, reason = "tests")]
 
 use arrayvec::ArrayString;
 use nexus::{KernelError, Version};
-use nexus_store::{StoreError, UpcastError};
+use nexus_store::StoreError;
 
 /// Concrete `StoreError` for tests: adapter = `std::io::Error`, codec = `std::io::Error`,
-/// upcaster = `std::convert::Infallible`.
-type TestStoreError =
-    StoreError<std::io::Error, std::io::Error, std::io::Error, std::convert::Infallible>;
+/// upcaster = `std::io::Error`.
+type TestStoreError = StoreError<std::io::Error, std::io::Error, std::io::Error, std::io::Error>;
 
 fn label(s: &str) -> ArrayString<64> {
     ArrayString::try_from(s).unwrap()
@@ -122,16 +121,15 @@ fn kernel_error_has_source_chain() {
 }
 
 #[test]
-fn transform_failed_error_displays_context() {
-    let err = UpcastError::<std::io::Error>::TransformFailed {
-        event_type: label("OrderCreated"),
-        schema_version: Version::INITIAL,
-        source: std::io::Error::new(std::io::ErrorKind::InvalidData, "bad json"),
-    };
-    let msg = err.to_string();
-    assert!(msg.contains("OrderCreated"), "should contain event type");
-    assert!(msg.contains("bad json"), "should contain source message");
-
+fn upcast_display_contains_inner_message() {
+    let inner = std::io::Error::new(std::io::ErrorKind::InvalidData, "bad transform");
+    let err: TestStoreError = StoreError::Upcast(inner);
+    let msg = format!("{err}");
+    assert!(msg.contains("upcast"), "should mention upcast");
+    assert!(
+        msg.contains("bad transform"),
+        "should contain inner message"
+    );
     let source = std::error::Error::source(&err);
-    assert!(source.is_some(), "TransformFailed should have a source");
+    assert!(source.is_some(), "Upcast variant should have a source");
 }

--- a/crates/nexus-store/tests/event_store_tests.rs
+++ b/crates/nexus-store/tests/event_store_tests.rs
@@ -9,7 +9,6 @@ use std::fmt;
 use nexus::*;
 use nexus_store::Repository;
 use nexus_store::Store;
-use nexus_store::UpcastError;
 use nexus_store::Upcaster;
 use nexus_store::testing::InMemoryStore;
 use nexus_store::upcasting::EventMorsel;
@@ -195,10 +194,7 @@ struct V1ToV2Upcaster;
 impl Upcaster for V1ToV2Upcaster {
     type Error = Infallible;
 
-    fn apply<'a>(
-        &self,
-        morsel: EventMorsel<'a>,
-    ) -> Result<EventMorsel<'a>, UpcastError<Self::Error>> {
+    fn upcast<'a>(&self, morsel: EventMorsel<'a>) -> Result<EventMorsel<'a>, Self::Error> {
         match (morsel.event_type(), morsel.schema_version()) {
             ("Created", v) if v == Version::INITIAL => {
                 // Passthrough — payload format unchanged, just bump version.

--- a/crates/nexus-store/tests/property_tests.rs
+++ b/crates/nexus-store/tests/property_tests.rs
@@ -263,7 +263,7 @@ proptest! {
         impl Upcaster for V1ToV3Upcaster {
             type Error = Infallible;
 
-            fn apply<'a>(&self, mut morsel: nexus_store::upcasting::EventMorsel<'a>) -> Result<nexus_store::upcasting::EventMorsel<'a>, nexus_store::UpcastError<Self::Error>> {
+            fn upcast<'a>(&self, mut morsel: nexus_store::upcasting::EventMorsel<'a>) -> Result<nexus_store::upcasting::EventMorsel<'a>, Self::Error> {
                 loop {
                     morsel = match (morsel.event_type(), morsel.schema_version()) {
                         ("E", v) if v == Version::INITIAL => nexus_store::upcasting::EventMorsel::new("E", Version::new(2).unwrap(), morsel.payload().to_vec()),
@@ -282,7 +282,7 @@ proptest! {
         }
 
         let morsel = nexus_store::EventMorsel::borrowed("E", Version::INITIAL, &payload);
-        let result = V1ToV3Upcaster.apply(morsel).unwrap();
+        let result = V1ToV3Upcaster.upcast(morsel).unwrap();
 
         prop_assert_eq!(result.schema_version(), Version::new(3).unwrap(), "final version should be 3");
         prop_assert_eq!(

--- a/crates/nexus-store/tests/repository_qa_tests.rs
+++ b/crates/nexus-store/tests/repository_qa_tests.rs
@@ -43,12 +43,12 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use nexus::*;
 use nexus_store::Repository;
 use nexus_store::Store;
+use nexus_store::Upcaster;
 use nexus_store::codec::{BorrowingDecode, Decode, Encode};
 use nexus_store::error::StoreError;
 use nexus_store::store::RawEventStore;
 use nexus_store::testing::InMemoryStore;
 use nexus_store::upcasting::EventMorsel;
-use nexus_store::{UpcastError, Upcaster};
 use proptest::prelude::*;
 
 // StreamId has been removed from the API — use typed Id values directly
@@ -386,10 +386,7 @@ struct IncrementedV1ToV2;
 impl Upcaster for IncrementedV1ToV2 {
     type Error = Infallible;
 
-    fn apply<'a>(
-        &self,
-        morsel: EventMorsel<'a>,
-    ) -> Result<EventMorsel<'a>, UpcastError<Self::Error>> {
+    fn upcast<'a>(&self, morsel: EventMorsel<'a>) -> Result<EventMorsel<'a>, Self::Error> {
         match (morsel.event_type(), morsel.schema_version()) {
             ("Incremented", v) if v == Version::INITIAL => Ok(EventMorsel::new(
                 "Incremented",
@@ -414,10 +411,7 @@ struct IncrementedV1ToV3;
 impl Upcaster for IncrementedV1ToV3 {
     type Error = Infallible;
 
-    fn apply<'a>(
-        &self,
-        mut morsel: EventMorsel<'a>,
-    ) -> Result<EventMorsel<'a>, UpcastError<Self::Error>> {
+    fn upcast<'a>(&self, mut morsel: EventMorsel<'a>) -> Result<EventMorsel<'a>, Self::Error> {
         loop {
             morsel = match (morsel.event_type(), morsel.schema_version()) {
                 ("Incremented", v) if v == Version::INITIAL => EventMorsel::new(
@@ -450,10 +444,7 @@ struct DeltaDoublingUpcaster;
 impl Upcaster for DeltaDoublingUpcaster {
     type Error = Infallible;
 
-    fn apply<'a>(
-        &self,
-        morsel: EventMorsel<'a>,
-    ) -> Result<EventMorsel<'a>, UpcastError<Self::Error>> {
+    fn upcast<'a>(&self, morsel: EventMorsel<'a>) -> Result<EventMorsel<'a>, Self::Error> {
         match (morsel.event_type(), morsel.schema_version()) {
             ("Delta", v) if v == Version::INITIAL => {
                 let delta = i32::from_le_bytes(morsel.payload()[0..4].try_into().unwrap());

--- a/crates/nexus-store/tests/stream_tests.rs
+++ b/crates/nexus-store/tests/stream_tests.rs
@@ -77,11 +77,9 @@ use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use arrayvec::ArrayString;
 use nexus::Version;
 use nexus_store::codec::{BorrowingDecode, Decode, Encode};
 use nexus_store::envelope::PersistedEnvelope;
-use nexus_store::error::UpcastError;
 use nexus_store::store::GlobalSeq;
 use nexus_store::stream::{
     BaseEventStream, Disposition, EventStream, EventStreamExt, Progress, Step,
@@ -414,10 +412,7 @@ struct PrependError;
 impl Upcaster for PrependOne {
     type Error = PrependError;
 
-    fn apply<'a>(
-        &self,
-        morsel: EventMorsel<'a>,
-    ) -> Result<EventMorsel<'a>, UpcastError<Self::Error>> {
+    fn upcast<'a>(&self, morsel: EventMorsel<'a>) -> Result<EventMorsel<'a>, Self::Error> {
         let mut new_payload = Vec::with_capacity(morsel.payload().len() + 1);
         new_payload.push(1);
         new_payload.extend_from_slice(morsel.payload());
@@ -433,7 +428,7 @@ impl Upcaster for PrependOne {
     }
 }
 
-/// Upcaster that always returns `TransformFailed`.
+/// Upcaster that always returns an error.
 struct FailingUpcaster;
 
 #[derive(Debug, Error)]
@@ -443,15 +438,8 @@ struct UpcastBoom;
 impl Upcaster for FailingUpcaster {
     type Error = UpcastBoom;
 
-    fn apply<'a>(
-        &self,
-        morsel: EventMorsel<'a>,
-    ) -> Result<EventMorsel<'a>, UpcastError<Self::Error>> {
-        Err(UpcastError::TransformFailed {
-            event_type: ArrayString::<64>::from(morsel.event_type()).unwrap_or_default(),
-            schema_version: morsel.schema_version(),
-            source: UpcastBoom,
-        })
+    fn upcast<'a>(&self, _morsel: EventMorsel<'a>) -> Result<EventMorsel<'a>, Self::Error> {
+        Err(UpcastBoom)
     }
 
     fn current_version(&self, _event_type: &str) -> Option<Version> {
@@ -479,10 +467,7 @@ impl RecordingUpcaster {
 impl Upcaster for RecordingUpcaster {
     type Error = Infallible;
 
-    fn apply<'a>(
-        &self,
-        morsel: EventMorsel<'a>,
-    ) -> Result<EventMorsel<'a>, UpcastError<Self::Error>> {
+    fn upcast<'a>(&self, morsel: EventMorsel<'a>) -> Result<EventMorsel<'a>, Self::Error> {
         self.seen.lock().expect("test mutex").push((
             morsel.event_type().to_owned(),
             morsel.schema_version().as_u64(),
@@ -1082,7 +1067,7 @@ async fn inline_decode_owning_with_upcaster_runs_upcast_before_codec() {
                 env.payload(),
             );
             let transformed = upcaster
-                .apply(morsel)
+                .upcast(morsel)
                 .map_err(|e| PipelineErr::Upcast(e.to_string()))?;
             let _e: u64 = codec
                 .decode(transformed.event_type(), transformed.payload())
@@ -1124,7 +1109,7 @@ async fn inline_decode_borrowing_with_upcaster_runs_upcast_before_codec() {
                 env.payload(),
             );
             let transformed = upcaster
-                .apply(morsel)
+                .upcast(morsel)
                 .map_err(|e| PipelineErr::Upcast(e.to_string()))?;
             let bytes: &[u8] = codec
                 .decode(transformed.event_type(), transformed.payload())
@@ -1202,7 +1187,7 @@ async fn inline_decode_owning_upcaster_runs_before_codec() {
                 env.payload(),
             );
             let transformed = upcaster
-                .apply(morsel)
+                .upcast(morsel)
                 .map_err(|e| PipelineErr::Upcast(e.to_string()))?;
             let e: u64 = codec
                 .decode(transformed.event_type(), transformed.payload())
@@ -1297,7 +1282,7 @@ async fn inline_decode_owning_upcaster_error_propagates() {
                 env.payload(),
             );
             let transformed = upcaster
-                .apply(morsel)
+                .upcast(morsel)
                 .map_err(|e| PipelineErr::Upcast(e.to_string()))?;
             let _e: u64 = codec
                 .decode(transformed.event_type(), transformed.payload())
@@ -1342,7 +1327,7 @@ async fn inline_decode_schema_version_visible_to_upcaster() {
                 env.payload(),
             );
             let transformed = upcaster
-                .apply(morsel)
+                .upcast(morsel)
                 .map_err(|e| PipelineErr::Upcast(e.to_string()))?;
             let _e: u64 = codec
                 .decode(transformed.event_type(), transformed.payload())
@@ -1368,7 +1353,7 @@ async fn inline_decode_owning_noop_upcaster_passthrough() {
                 env.schema_version_as_version(),
                 env.payload(),
             );
-            let transformed = <() as Upcaster>::apply(&noop, morsel)
+            let transformed = <() as Upcaster>::upcast(&noop, morsel)
                 .map_err(|e| PipelineErr::Upcast(e.to_string()))?;
             let e: u64 = codec
                 .decode(transformed.event_type(), transformed.payload())
@@ -1509,7 +1494,7 @@ async fn inline_decode_borrowing_upcaster_error_propagates() {
                 env.payload(),
             );
             let transformed = upcaster
-                .apply(morsel)
+                .upcast(morsel)
                 .map_err(|e| PipelineErr::Upcast(e.to_string()))?;
             let _bytes: &[u8] = codec
                 .decode(transformed.event_type(), transformed.payload())
@@ -1549,7 +1534,7 @@ async fn inline_decode_borrowing_noop_upcaster_passthrough() {
                 env.schema_version_as_version(),
                 env.payload(),
             );
-            let transformed = <() as Upcaster>::apply(&noop, morsel)
+            let transformed = <() as Upcaster>::upcast(&noop, morsel)
                 .map_err(|e| PipelineErr::Upcast(e.to_string()))?;
             let bytes: &[u8] = codec
                 .decode(transformed.event_type(), transformed.payload())

--- a/crates/nexus-store/tests/upcaster_trait_tests.rs
+++ b/crates/nexus-store/tests/upcaster_trait_tests.rs
@@ -8,7 +8,7 @@ use nexus_store::upcasting::EventMorsel;
 fn unit_upcaster_is_passthrough() {
     let upcaster = ();
     let morsel = EventMorsel::borrowed("OrderCreated", Version::INITIAL, b"payload");
-    let result = upcaster.apply(morsel).unwrap();
+    let result = upcaster.upcast(morsel).unwrap();
     assert_eq!(result.event_type(), "OrderCreated");
     assert_eq!(result.schema_version(), Version::INITIAL);
     assert_eq!(result.payload(), b"payload");

--- a/examples/store-inmemory/src/main.rs
+++ b/examples/store-inmemory/src/main.rs
@@ -152,10 +152,7 @@ struct RenameUpcaster;
 impl Upcaster for RenameUpcaster {
     type Error = std::convert::Infallible;
 
-    fn apply<'a>(
-        &self,
-        morsel: EventMorsel<'a>,
-    ) -> Result<EventMorsel<'a>, nexus_store::UpcastError<Self::Error>> {
+    fn upcast<'a>(&self, morsel: EventMorsel<'a>) -> Result<EventMorsel<'a>, Self::Error> {
         if morsel.event_type() != "TaskCreated" || morsel.schema_version().as_u64() >= 2 {
             return Ok(morsel);
         }
@@ -330,7 +327,7 @@ async fn main() {
     for (event_type, schema_version, payload, version) in &read_events {
         let schema_ver = Version::new(u64::from(*schema_version)).expect("schema version > 0");
         let morsel = EventMorsel::borrowed(event_type, schema_ver, payload);
-        let upcasted = upcaster.apply(morsel).expect("upcast should succeed");
+        let upcasted = upcaster.upcast(morsel).expect("upcast should succeed");
 
         if upcasted.event_type() != event_type {
             println!(


### PR DESCRIPTION
## Summary

Final PR (4 of 4) in the dual-track stream refactor. Slims the `Upcaster` trait to one method (`upcast`) returning the user's raw error directly, deletes `UpcastError` and `DecodeStreamError`, and teaches the `#[transforms]` macro to validate chain coverage at compile time.

- `Upcaster::apply(...) -> Result<EventMorsel<'a>, UpcastError<E>>` → `Upcaster::upcast(...) -> Result<EventMorsel<'a>, E>`. Method renamed, error wrapper dropped.
- `#[transforms]` macro now checks: for each event type, every schema version in `[1, current_version]` is reachable via a contiguous chain. A gap (e.g. declaring `1→2` and `4→5` with `current=5`) produces a compile error naming the missing step.
- `UpcastError` deleted — its variants (`VersionNotAdvanced`, `EmptyEventType`, `ChainLimitExceeded`, `TransformFailed`) are either unrepresentable for macro-generated upcasters or collapsed into the user's raw error.
- `DecodeStreamError` deleted (no production consumers after PR3).
- `StoreError::Upcast(UpErr)` now carries the user's raw error type directly; the `U` generic on `StoreError<A, EncErr, DecErr, UpErr>` is retained but cleaner.

## Deviations from plan

The plan asked to drop the `U` generic from `EventStore<S, C, U>` and remove the `Upcaster` trait entirely. Both proved mechanically impossible in stable Rust without trading static dispatch for runtime polymorphism. The `U` generic and the trait name are retained; the trait shape is slimmed dramatically. Full reasoning in `/Users/joel/.claude/plans/cheerful-yawning-hopper-deviations.md` (the PR4 entries).

## Test plan

- [x] `nix flake check` — all 6 checks pass (clippy, doc, fmt, deny, nextest, hakari) + 2 cached (toml-fmt, audit)
- [x] `cargo nextest run --workspace` — 660 tests pass
- [x] New compile-fail test `transforms_gap.rs` fires with diagnostic naming the missing chain step
- [x] All hand-rolled `Upcaster` impls across the workspace migrated to the slim shape
- [x] `examples/store-inmemory` builds and demonstrates the new shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)