### PR TITLE
refactor(store)!: combinator-chain replay_from via map_err; Arc-own facade; expose Store::raw (PR5a)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -204,7 +204,15 @@
       "WebFetch(domain:lib.rs)",
       "WebFetch(domain:axoniq.io)",
       "WebFetch(domain:tokio.rs)",
-      "WebFetch(domain:redbadger.github.io)"
+      "WebFetch(domain:redbadger.github.io)",
+      "Bash(sed -i '' -e 's|use nexus_store::store::{CheckpointStore, EventStream, RawEventStore, Subscription};|use nexus_store::store::{CheckpointStore, RawEventStore, Subscription};\\\\nuse nexus_store::stream::EventStream;|' crates/nexus-store/tests/subscription_tests.rs crates/nexus-fjall/tests/subscription_tests.rs)",
+      "Bash(sed -i '' -e 's|use nexus_store::store::{EventStream, RawEventStore};|use nexus_store::store::RawEventStore;\\\\nuse nexus_store::stream::EventStream;|' crates/nexus-fjall/src/subscription_stream.rs)",
+      "Bash(sed -i '' -e 's|use nexus_store::store::{EventStream, EventStreamExt};|use nexus_store::stream::{EventStream, EventStreamExt};|' crates/nexus-store/src/stream.rs)",
+      "Bash(TRYBUILD=overwrite nix develop -c cargo test -p nexus-store --test compile_fail_tests)",
+      "Bash(sed -n '/\\\\[features\\\\]/,/^\\\\[/p' crates/nexus-fjall/Cargo.toml)",
+      "Bash(sed -n '/\\\\[features\\\\]/,/^\\\\[/p' crates/nexus-store/Cargo.toml)",
+      "Bash(tee /tmp/nexus-flake-check.log)",
+      "Bash(tee -a /tmp/nexus-flake-check.log)"
     ]
   },
   "hooks": {

--- a/crates/nexus-store/src/lib.rs
+++ b/crates/nexus-store/src/lib.rs
@@ -38,7 +38,10 @@ pub use state::{
     SnapshotStore,
 };
 pub use store::{GlobalSeq, RawEventStore, Store, Subscription};
-pub use stream::{BaseEventStream, Disposition, EventStream, EventStreamExt, Progress, Step};
+pub use stream::{
+    BaseEventStream, Disposition, EventStream, EventStreamExt, Map, MapErr, Progress, Step, TryMap,
+    TryScan,
+};
 #[cfg(feature = "futures-bridge")]
 pub use stream::{IntoStream, OwnedEventStream};
 #[cfg(feature = "testing")]

--- a/crates/nexus-store/src/repository.rs
+++ b/crates/nexus-store/src/repository.rs
@@ -1,5 +1,6 @@
 use std::future::Future;
 use std::num::NonZeroU32;
+use std::sync::Arc;
 
 use nexus::{Aggregate, AggregateRoot, DomainEvent, EventOf, Version};
 
@@ -7,7 +8,7 @@ use crate::codec::{BorrowingDecode, Decode, Encode};
 use crate::envelope::pending_envelope;
 use crate::error::{AppendError, StoreError};
 use crate::store::{RawEventStore, Store};
-use crate::stream::{BaseEventStream, EventStream};
+use crate::stream::{BaseEventStream, EventStreamExt};
 use crate::upcasting::{EventMorsel, Upcaster};
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -142,19 +143,28 @@ pub(super) fn version_to_nz32(version: Version) -> Option<NonZeroU32> {
 /// // With transforms:
 /// let orders = store.repository().codec(OrderCodec).upcaster(OrderTransforms).build();
 /// ```
+/// Owns the codec and upcaster as `Arc<C>` / `Arc<U>` so async load paths
+/// can clone the handles into combinator closures and capture them by
+/// value. Per Rust 2024's stricter capture rules (RFC 3498, rustc issue
+/// 133529), a closure that borrows from `&self` and is then handed to a
+/// `try_fold`-style combinator whose returned future is `+ Send` cannot
+/// satisfy the bound — the future-Send check effectively requires the
+/// borrow to be `'static`. Owning the components via `Arc` and cloning
+/// per call sidesteps the borrow entirely. Cost: one heap allocation at
+/// facade construction, one pointer bump per `load`.
 pub struct EventStore<S, C, U = ()> {
     store: Store<S>,
-    codec: C,
-    upcaster: U,
+    codec: Arc<C>,
+    upcaster: Arc<U>,
 }
 
 impl<S, C, U> EventStore<S, C, U> {
     /// Create an event store bound to a shared store, codec, and upcaster.
-    pub(crate) const fn new(store: Store<S>, codec: C, upcaster: U) -> Self {
+    pub(crate) fn new(store: Store<S>, codec: C, upcaster: U) -> Self {
         Self {
             store,
-            codec,
-            upcaster,
+            codec: Arc::new(codec),
+            upcaster: Arc::new(upcaster),
         }
     }
 }
@@ -162,11 +172,11 @@ impl<S, C, U> EventStore<S, C, U> {
 impl<A, S, C, U> ReplayFrom<A> for EventStore<S, C, U>
 where
     A: Aggregate,
-    S: RawEventStore,
-    C: Encode<EventOf<A>> + Decode<EventOf<A>>,
-    U: Upcaster,
+    S: RawEventStore + 'static,
+    C: Encode<EventOf<A>> + Decode<EventOf<A>> + 'static,
+    U: Upcaster + 'static,
     EventOf<A>: DomainEvent,
-    for<'a> S::Stream<'a>: Send,
+    for<'a> S::Stream<'a>: Send + 'static,
 {
     type Error = StoreError<
         S::Error,
@@ -177,45 +187,65 @@ where
 
     async fn replay_from(
         &self,
-        mut root: AggregateRoot<A>,
+        root: AggregateRoot<A>,
         from: Version,
     ) -> Result<AggregateRoot<A>, Self::Error> {
-        let mut stream = self
-            .store
+        // Clone everything into function-local owned values. The
+        // combinator closure captures the locals (Arc clones), with no
+        // borrow of `&self`. See the doc comment on `EventStore` for the
+        // full Rust 2024 capture-rules rationale. The `'static` bounds
+        // on S/C/U here discharge the "due to a current limitation of
+        // the type system" `'static` implied by `try_fold`'s HRTB-on-GAT
+        // closure bound (rustc note on the error path).
+        //
+        // `map_err` converts the adapter error eagerly into the sink type
+        // so the `try_fold` closure can use plain `?` propagation
+        // throughout. Without it, the closure-error `From` bound and
+        // `StoreError`'s `#[from] Kernel(KernelError)` impl overlap on
+        // `S::Error = KernelError` and coherence rejects the chain.
+        // See the PR3 deviation entry in the stream-refactor plan.
+        let store = self.store.clone();
+        let codec = Arc::<C>::clone(&self.codec);
+        let upcaster = Arc::<U>::clone(&self.upcaster);
+
+        let raw_stream = store
             .raw()
             .read_stream(root.id(), from)
             .await
             .map_err(StoreError::Adapter)?;
 
-        while let Some(item) = stream.next().await.map_err(StoreError::Adapter)? {
-            let env = <S::Stream<'_> as BaseEventStream<()>>::to_envelope(item);
-            let version = env.version();
-            let morsel = EventMorsel::borrowed(
-                env.event_type(),
-                env.schema_version_as_version(),
-                env.payload(),
-            );
-            let transformed = self.upcaster.upcast(morsel).map_err(StoreError::Upcast)?;
-            let event = <C as Decode<EventOf<A>>>::decode(
-                &self.codec,
-                transformed.event_type(),
-                transformed.payload(),
-            )
-            .map_err(StoreError::Decode)?;
-            root.replay(version, &event)?;
-        }
-        Ok(root)
+        raw_stream
+            .map_err(StoreError::Adapter)
+            .try_fold(root, move |mut r, item| {
+                let env = <S::Stream<'_> as BaseEventStream<()>>::to_envelope(item);
+                let version = env.version();
+                let morsel = EventMorsel::borrowed(
+                    env.event_type(),
+                    env.schema_version_as_version(),
+                    env.payload(),
+                );
+                let transformed = upcaster.upcast(morsel).map_err(StoreError::Upcast)?;
+                let event = <C as Decode<EventOf<A>>>::decode(
+                    &codec,
+                    transformed.event_type(),
+                    transformed.payload(),
+                )
+                .map_err(StoreError::Decode)?;
+                r.replay(version, &event)?;
+                Ok(r)
+            })
+            .await
     }
 }
 
 impl<A, S, C, U> Repository<A> for EventStore<S, C, U>
 where
     A: Aggregate,
-    S: RawEventStore,
-    C: Encode<EventOf<A>> + Decode<EventOf<A>>,
-    U: Upcaster,
+    S: RawEventStore + 'static,
+    C: Encode<EventOf<A>> + Decode<EventOf<A>> + 'static,
+    U: Upcaster + 'static,
     EventOf<A>: DomainEvent,
-    for<'a> S::Stream<'a>: Send,
+    for<'a> S::Stream<'a>: Send + 'static,
 {
     type Error = StoreError<
         S::Error,
@@ -329,19 +359,21 @@ where
 /// // With transforms:
 /// let orders = store.repository().codec(OrderCodec).upcaster(OrderTransforms).build_zero_copy();
 /// ```
+/// See [`EventStore`]'s doc comment for the rationale behind `Arc`-owning
+/// the codec and upcaster.
 pub struct ZeroCopyEventStore<S, C, U = ()> {
     store: Store<S>,
-    codec: C,
-    upcaster: U,
+    codec: Arc<C>,
+    upcaster: Arc<U>,
 }
 
 impl<S, C, U> ZeroCopyEventStore<S, C, U> {
     /// Create a zero-copy event store bound to a shared store, codec, and upcaster.
-    pub(crate) const fn new(store: Store<S>, codec: C, upcaster: U) -> Self {
+    pub(crate) fn new(store: Store<S>, codec: C, upcaster: U) -> Self {
         Self {
             store,
-            codec,
-            upcaster,
+            codec: Arc::new(codec),
+            upcaster: Arc::new(upcaster),
         }
     }
 }
@@ -349,11 +381,11 @@ impl<S, C, U> ZeroCopyEventStore<S, C, U> {
 impl<A, S, C, U> ReplayFrom<A> for ZeroCopyEventStore<S, C, U>
 where
     A: Aggregate,
-    S: RawEventStore,
-    C: Encode<EventOf<A>> + BorrowingDecode<EventOf<A>>,
-    U: Upcaster,
+    S: RawEventStore + 'static,
+    C: Encode<EventOf<A>> + BorrowingDecode<EventOf<A>> + 'static,
+    U: Upcaster + 'static,
     EventOf<A>: DomainEvent,
-    for<'a> S::Stream<'a>: Send,
+    for<'a> S::Stream<'a>: Send + 'static,
 {
     type Error = StoreError<
         S::Error,
@@ -364,45 +396,58 @@ where
 
     async fn replay_from(
         &self,
-        mut root: AggregateRoot<A>,
+        root: AggregateRoot<A>,
         from: Version,
     ) -> Result<AggregateRoot<A>, Self::Error> {
-        let mut stream = self
-            .store
+        // Same Arc-owned-captures pattern as `EventStore::replay_from`; see
+        // that comment for the Rust 2024 capture-rules rationale.
+        // `BorrowingDecode` returns `&'_ EventOf<A>` borrowing from the
+        // transformed morsel's payload; the borrow is consumed inside the
+        // closure body (`r.replay(v, event)` takes `&E`) before the next
+        // iteration invalidates it, so the lending discipline is honored
+        // entirely inside the `try_fold` closure.
+        let store = self.store.clone();
+        let codec = Arc::<C>::clone(&self.codec);
+        let upcaster = Arc::<U>::clone(&self.upcaster);
+
+        let raw_stream = store
             .raw()
             .read_stream(root.id(), from)
             .await
             .map_err(StoreError::Adapter)?;
 
-        while let Some(item) = stream.next().await.map_err(StoreError::Adapter)? {
-            let env = <S::Stream<'_> as BaseEventStream<()>>::to_envelope(item);
-            let version = env.version();
-            let morsel = EventMorsel::borrowed(
-                env.event_type(),
-                env.schema_version_as_version(),
-                env.payload(),
-            );
-            let transformed = self.upcaster.upcast(morsel).map_err(StoreError::Upcast)?;
-            let event: &EventOf<A> = <C as BorrowingDecode<EventOf<A>>>::decode(
-                &self.codec,
-                transformed.event_type(),
-                transformed.payload(),
-            )
-            .map_err(StoreError::Decode)?;
-            root.replay(version, event)?;
-        }
-        Ok(root)
+        raw_stream
+            .map_err(StoreError::Adapter)
+            .try_fold(root, move |mut r, item| {
+                let env = <S::Stream<'_> as BaseEventStream<()>>::to_envelope(item);
+                let version = env.version();
+                let morsel = EventMorsel::borrowed(
+                    env.event_type(),
+                    env.schema_version_as_version(),
+                    env.payload(),
+                );
+                let transformed = upcaster.upcast(morsel).map_err(StoreError::Upcast)?;
+                let event: &EventOf<A> = <C as BorrowingDecode<EventOf<A>>>::decode(
+                    &codec,
+                    transformed.event_type(),
+                    transformed.payload(),
+                )
+                .map_err(StoreError::Decode)?;
+                r.replay(version, event)?;
+                Ok(r)
+            })
+            .await
     }
 }
 
 impl<A, S, C, U> Repository<A> for ZeroCopyEventStore<S, C, U>
 where
     A: Aggregate,
-    S: RawEventStore,
-    C: Encode<EventOf<A>> + BorrowingDecode<EventOf<A>>,
-    U: Upcaster,
+    S: RawEventStore + 'static,
+    C: Encode<EventOf<A>> + BorrowingDecode<EventOf<A>> + 'static,
+    U: Upcaster + 'static,
     EventOf<A>: DomainEvent,
-    for<'a> S::Stream<'a>: Send,
+    for<'a> S::Stream<'a>: Send + 'static,
 {
     type Error = StoreError<
         S::Error,

--- a/crates/nexus-store/src/store.rs
+++ b/crates/nexus-store/src/store.rs
@@ -44,8 +44,44 @@ impl<S> Store<S> {
         }
     }
 
-    /// Access the underlying raw store.
-    pub(crate) fn raw(&self) -> &S {
+    /// Borrow the underlying raw store.
+    ///
+    /// The escape hatch for users who need the substrate directly — when
+    /// the [`Repository`](crate::Repository) facade's `load` / `save` isn't
+    /// flexible enough (e.g. you want to filter, peek, branch, or chain
+    /// custom combinators during load). Hand the borrowed `&S` to
+    /// [`RawEventStore::read_stream`] / [`RawEventStore::append`] and
+    /// compose your own chain via [`EventStreamExt`](crate::EventStreamExt).
+    ///
+    /// Users who just want "load this aggregate" should stay on the facade.
+    ///
+    /// # Example
+    ///
+    /// Substrate-path read: convert the adapter error eagerly via
+    /// [`map_err`](crate::EventStreamExt::map_err) and drive a custom fold.
+    ///
+    /// ```ignore
+    /// use nexus_store::{EventStreamExt, RawEventStore, Store};
+    ///
+    /// async fn count_events<S: RawEventStore>(
+    ///     store: &Store<S>,
+    ///     id: &impl nexus::Id,
+    ///     from: nexus::Version,
+    /// ) -> Result<usize, MyError> {
+    ///     store.raw()
+    ///         .read_stream(id, from).await
+    ///         .map_err(MyError::Adapter)?
+    ///         .map_err(MyError::Adapter)
+    ///         .try_count()
+    ///         .await
+    /// }
+    /// ```
+    ///
+    /// [`RawEventStore`]: crate::RawEventStore
+    /// [`RawEventStore::read_stream`]: crate::RawEventStore::read_stream
+    /// [`RawEventStore::append`]: crate::RawEventStore::append
+    #[must_use]
+    pub fn raw(&self) -> &S {
         &self.inner
     }
 }

--- a/crates/nexus-store/src/stream/combinators.rs
+++ b/crates/nexus-store/src/stream/combinators.rs
@@ -111,6 +111,54 @@ where
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
+// MapErr<S, F, E2> — per-item error-type transform
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Wraps `S` and converts each `S::Error` to `E2` via `F`, leaving the
+/// [`Item`](EventStream::Item) projection untouched.
+///
+/// Built by [`EventStreamExt::map_err`](super::EventStreamExt::map_err).
+///
+/// # Why this exists
+///
+/// `EventStreamExt::try_map`, `try_fold`, and friends require the closure's
+/// error type to satisfy `E: From<Self::Error>`. When the desired sink error
+/// type (e.g. [`StoreError`](crate::StoreError)) already has a `From` impl
+/// for an unrelated error type that happens to coincide with `Self::Error`
+/// under monomorphization, the coherence checker rejects the natural
+/// `impl<A, ...> From<A> for StoreError<A, ...>` for `Adapter` (it would
+/// overlap with the existing `#[from] Kernel(KernelError)` once
+/// `A = KernelError`). `map_err` sidesteps this by converting the stream's
+/// error to the sink type *before* the closure-error bound enters the
+/// picture — the downstream combinator then sees `Self::Error = E2`, and
+/// `E: From<E2>` is the trivial reflexive impl.
+///
+/// See the PR3 deviation entry in the stream-refactor plan for the full
+/// coherence-wall story.
+pub struct MapErr<S, F, E2> {
+    pub(crate) inner: S,
+    pub(crate) f: F,
+    pub(crate) _err: PhantomData<fn() -> E2>,
+}
+
+impl<S, F, E2, M> EventStream<M> for MapErr<S, F, E2>
+where
+    S: EventStream<M> + Send,
+    F: FnMut(S::Error) -> E2 + Send,
+    E2: std::error::Error + Send + Sync + 'static,
+{
+    type Item<'a>
+        = S::Item<'a>
+    where
+        Self: 'a;
+    type Error = E2;
+
+    async fn next(&mut self) -> Result<Option<Self::Item<'_>>, Self::Error> {
+        self.inner.next().await.map_err(&mut self.f)
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
 // (Filter intentionally not implemented in this iteration — see the
 // deviation log: stable Rust's borrow checker can't accept a natural
 // loop-based Filter impl over a lending GAT stream, and the Box::pin

--- a/crates/nexus-store/src/stream/cursor.rs
+++ b/crates/nexus-store/src/stream/cursor.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 use std::pin::pin;
 use std::task::Poll;
 
-use super::combinators::{Map, TryMap, TryScan};
+use super::combinators::{Map, MapErr, TryMap, TryScan};
 #[cfg(feature = "futures-bridge")]
 use super::owned::{IntoStream, OwnedEventStream};
 use super::progress::{Progress, Step};
@@ -446,6 +446,43 @@ pub trait EventStreamExt<M = ()>: EventStream<M> {
         E: From<Self::Error>,
     {
         TryMap {
+            inner: self,
+            f,
+            _err: PhantomData,
+        }
+    }
+
+    /// Convert the stream's error type via a closure.
+    ///
+    /// Builds a [`MapErr`] that re-types each `Self::Error` as `E2` and
+    /// leaves the [`Item`](EventStream::Item) projection untouched. The
+    /// returned stream's `Error` becomes `E2`, so a subsequent
+    /// [`try_map`](Self::try_map) / [`try_fold`](Self::try_fold) can use a
+    /// closure whose error is `E2` without needing `E2: From<Self::Error>`
+    /// at the call site — the conversion already happened here.
+    ///
+    /// # Why this combinator exists
+    ///
+    /// When the sink error type carries `#[from]` impls that overlap with
+    /// the stream's error type under monomorphization, the natural
+    /// `try_map(decode).try_fold(replay)` chain fails to type-check (the
+    /// `E: From<Self::Error>` bound on `try_map` plus the sink's own
+    /// `#[from]` impl would produce two overlapping `From` impls for the
+    /// same concrete type, which coherence rejects).
+    /// [`StoreError`](crate::StoreError) hits exactly this wall: it derives
+    /// `#[from] Kernel(KernelError)` for `try_fold(replay)`, while
+    /// `try_map(decode)` wants `From<S::Error>` for `Adapter` — and the two
+    /// overlap when `S::Error == KernelError`. Inserting `.map_err(StoreError::Adapter)`
+    /// before `.try_map(...)` converts the stream's error eagerly, so the
+    /// downstream combinator's `E: From<Self::Error>` bound is the
+    /// trivial reflexive one.
+    fn map_err<E2, F>(self, f: F) -> MapErr<Self, F, E2>
+    where
+        Self: Sized,
+        F: FnMut(Self::Error) -> E2,
+        E2: std::error::Error + Send + Sync + 'static,
+    {
+        MapErr {
             inner: self,
             f,
             _err: PhantomData,

--- a/crates/nexus-store/src/stream/mod.rs
+++ b/crates/nexus-store/src/stream/mod.rs
@@ -22,7 +22,7 @@ mod cursor;
 mod owned;
 mod progress;
 
-pub use combinators::{Map, TryMap, TryScan};
+pub use combinators::{Map, MapErr, TryMap, TryScan};
 pub use cursor::{BaseEventStream, Disposition, EventStream, EventStreamExt};
 #[cfg(feature = "futures-bridge")]
 pub use owned::{IntoStream, OwnedEventStream};

--- a/crates/nexus-store/src/stream/owned.rs
+++ b/crates/nexus-store/src/stream/owned.rs
@@ -34,7 +34,7 @@ use std::marker::PhantomData;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use super::combinators::{Map, TryMap};
+use super::combinators::{Map, MapErr, TryMap};
 use super::cursor::EventStream;
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -112,6 +112,36 @@ where
 
     fn into_owned(item: T) -> T {
         item
+    }
+}
+
+// ─── OwnedEventStream for MapErr ────────────────────────────────────────────
+
+// MapErr passes the inner stream's item through unchanged; the impl follows
+// whatever `S` is bound to, mirroring the CARRY-FORWARD note from the
+// PR2 deviation entry on `OwnedEventStream` ("if its output is owning, the
+// impl follows the inner").
+//
+// Why `'static` on both `S` and `F`: unlike `Map`/`TryMap`, whose
+// `type Item<'a> = T` is a fresh owned type that ignores the GAT lifetime,
+// `MapErr<S, F, E2>::Item<'a> = S::Item<'a>` propagates the GAT's
+// `where Self: 'a` clause back through `Self`. For the trait method
+// `into_owned(item: Self::Item<'_>)` to type-check for any `'_`, every
+// type parameter inside `Self` must outlive arbitrary lifetimes —
+// `'static` is the standard discharge. This matches actual usage: the
+// only consumer of `OwnedEventStream` is
+// [`IntoStream`](super::owned::IntoStream), which already requires the
+// stream to be `'static + Send + Unpin`.
+impl<S, F, E2, M> OwnedEventStream<M> for MapErr<S, F, E2>
+where
+    S: OwnedEventStream<M> + Send + 'static,
+    F: FnMut(S::Error) -> E2 + Send + 'static,
+    E2: std::error::Error + Send + Sync + 'static,
+{
+    type OwnedItem = S::OwnedItem;
+
+    fn into_owned(item: Self::Item<'_>) -> Self::OwnedItem {
+        S::into_owned(item)
     }
 }
 

--- a/crates/nexus-store/tests/combinator_tests.rs
+++ b/crates/nexus-store/tests/combinator_tests.rs
@@ -296,6 +296,154 @@ async fn try_scan_state_accumulates_across_iterations() {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
+// 5. map_err — error-type conversion combinator
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Fixture stream that fails on the Nth next() call. Used to exercise the
+/// error path of `map_err` without needing a real adapter.
+struct FailingStream {
+    rows: Vec<(u64, String, Vec<u8>)>,
+    fail_at: usize,
+    pos: usize,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("upstream failed at index {0}")]
+struct UpstreamError(usize);
+
+impl BaseEventStream for FailingStream {
+    fn to_envelope<'a>(item: PersistedEnvelope<'a>) -> PersistedEnvelope<'a>
+    where
+        Self: 'a,
+    {
+        item
+    }
+}
+
+impl EventStream for FailingStream {
+    type Item<'a> = PersistedEnvelope<'a>;
+    type Error = UpstreamError;
+
+    async fn next(&mut self) -> Result<Option<PersistedEnvelope<'_>>, Self::Error> {
+        if self.pos == self.fail_at {
+            return Err(UpstreamError(self.pos));
+        }
+        if self.pos >= self.rows.len() {
+            return Ok(None);
+        }
+        let row = &self.rows[self.pos];
+        self.pos += 1;
+        Ok(Some(PersistedEnvelope::new_unchecked(
+            Version::new(row.0).unwrap(),
+            GlobalSeq::INITIAL,
+            &row.1,
+            1,
+            &row.2,
+            (),
+        )))
+    }
+}
+
+/// Downstream sink error — represents the kind of error the user wants
+/// after `map_err` converts the stream's raw error.
+#[derive(Debug, thiserror::Error)]
+enum SinkError {
+    #[error("wrapped upstream: {0}")]
+    Wrapped(#[source] UpstreamError),
+}
+
+#[tokio::test]
+async fn map_err_passes_items_through_unchanged() {
+    // map_err leaves the Item projection alone — only the error type
+    // changes. `fail_at: usize::MAX` ensures the stream completes naturally.
+    let mut stream = FailingStream {
+        rows: rows(3),
+        fail_at: usize::MAX,
+        pos: 0,
+    }
+    .map_err(SinkError::Wrapped);
+    let collected: Result<Vec<u64>, SinkError> = stream
+        .try_fold(Vec::new(), |mut acc, env| {
+            acc.push(env.version().as_u64());
+            Ok(acc)
+        })
+        .await;
+    assert_eq!(collected.unwrap(), vec![1, 2, 3]);
+}
+
+#[tokio::test]
+async fn map_err_over_empty_stream_yields_nothing() {
+    let mut stream = FailingStream {
+        rows: vec![],
+        fail_at: usize::MAX,
+        pos: 0,
+    }
+    .map_err(SinkError::Wrapped);
+    let n: Result<usize, SinkError> = stream.try_count().await;
+    assert_eq!(n.unwrap(), 0);
+}
+
+#[tokio::test]
+async fn map_err_converts_upstream_error_to_sink_type() {
+    // Stream errors flow through the converter; the sink sees the wrapped form.
+    let mut stream = FailingStream {
+        rows: rows(5),
+        fail_at: 2,
+        pos: 0,
+    }
+    .map_err(SinkError::Wrapped);
+
+    let result: Result<Vec<u64>, SinkError> = stream
+        .try_fold(Vec::new(), |mut acc, env| {
+            acc.push(env.version().as_u64());
+            Ok(acc)
+        })
+        .await;
+
+    assert!(matches!(result, Err(SinkError::Wrapped(UpstreamError(2)))));
+}
+
+#[tokio::test]
+async fn map_err_identity_converter_preserves_error_payload() {
+    // Identity converter — error round-trips through map_err with no
+    // information loss. This is the smoke test for the closure
+    // wiring itself.
+    let mut stream = FailingStream {
+        rows: rows(3),
+        fail_at: 0,
+        pos: 0,
+    }
+    .map_err(|e: UpstreamError| e);
+
+    let result: Result<usize, UpstreamError> = stream.try_count().await;
+    assert!(matches!(result, Err(UpstreamError(0))));
+}
+
+#[tokio::test]
+async fn map_err_then_try_map_unblocks_coherence_wall() {
+    // This is the structural pattern PR3 wanted but couldn't write:
+    // .map_err(convert) .try_map(decode) — the converter eats the
+    // adapter error before try_map's `E: From<Self::Error>` bound asks
+    // for one. With map_err, Self::Error is already the sink type,
+    // and `E: From<E>` is the reflexive impl.
+    let mut stream = FailingStream {
+        rows: rows(4),
+        fail_at: usize::MAX,
+        pos: 0,
+    }
+    .map_err(SinkError::Wrapped)
+    .try_map(|env| Ok::<_, SinkError>(env.version().as_u64()));
+
+    let collected: Result<Vec<u64>, SinkError> = stream
+        .try_fold(Vec::new(), |mut acc, v| {
+            acc.push(v);
+            Ok(acc)
+        })
+        .await;
+    assert_eq!(collected.unwrap(), vec![1, 2, 3, 4]);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
 // Cross-consistency: count == collected.len() through each combinator
 // ═══════════════════════════════════════════════════════════════════════════
 


### PR DESCRIPTION
## Summary

PR5a of the stream refactor (`cheerful-yawning-hopper`) — the **substrate** half of the originally-planned PR5. The facade-cleanup half (delete `Upcaster` trait, drop `U` generic, rebuild `#[nexus::transforms]` macro, shrink `StoreError`) splits into **PR5b**, kept separate to keep each narrative reviewable.

### What's in this PR

- **`EventStreamExt::map_err<E2, F>` + `MapErr<S, F, E2>` combinator** — the structural fix PR3 named in its deviation log. Converts `Self::Error` eagerly so the downstream `try_map`/`try_fold` closure-error bound becomes the trivial reflexive `From`, sidestepping the `StoreError` `#[from] Kernel(KernelError)` coherence wall. Five new tests cover identity, passthrough, empty, mid-stream error propagation, and the coherence-wall unblock.
- **Combinator-chain `replay_from`** — `raw_stream + map_err + try_fold` replaces PR3's manual while-let loop in both `EventStore` and `ZeroCopyEventStore`.
- **`Arc`-own codec + upcaster on both facade structs** — Rust 2024's stricter capture rules combined with `try_fold`'s HRTB-on-GAT closure bound require closure captures to be owned (rustc#133529, RFC 3498). Mirrors the existing `Store<S> = Arc<S>` pattern. Cost: one heap alloc at facade construction + one pointer bump per `load`.
- **`'static` bounds on Repository impls** — `S: 'static`, `C: 'static`, `U: 'static`, `for<'a> S::Stream<'a>: Send + 'static`. Concrete production types (`FjallStore`, `JsonCodec`, macro-generated upcasters) already satisfy these.
- **`Store::raw()` promoted to `pub`** — the substrate escape hatch users need when `load()` isn't flexible enough; includes a doctest showing the `raw_stream + map_err` pattern.

### Why split

The Arc-wrap was an **unanticipated structural change** driven by Rust 2024's stricter lifetime checking on `+ Send` futures returned from trait methods. The `'1: 'static` requirement on borrowed-from-`&self` captures was discovered mid-PR. With that work in, stacking the `Upcaster` trait deletion + macro rebuild on top would balloon the diff and conflate two narratives.

### Deferred to PR5b

- Delete `Upcaster` trait + `impl Upcaster for ()`
- Drop `U` generic from `EventStore<S, C, U>` → `EventStore<S, C>`
- Rebuild `#[nexus::transforms]` macro to emit struct + inherent methods (no trait impl)
- Add `load_with(id, upcast_fn)` for the with-upcaster ergonomics
- Drop `UpErr` parameter from `StoreError`
- Migrate hand-rolled upcaster test fixtures

See `cheerful-yawning-hopper-deviations.md` "PR 5" / "PR 5a" entries for the full rationale.

## Breaking changes

- `Repository<A>` / `ReplayFrom<A>` impls on `EventStore<S, C, U>` and `ZeroCopyEventStore<S, C, U>` now require `S/C/U: 'static` and `for<'a> S::Stream<'a>: Send + 'static`. Concrete production types satisfy these — invisible at typical call sites.
- `EventStore::new` / `ZeroCopyEventStore::new` lose `const` (they `Arc::new` internally). Both were `pub(crate)`; user-facing impact is via the builder, which is unchanged.

## Test plan

- [x] `cargo test --workspace --all-features` — 300+ tests pass
- [x] `cargo clippy --workspace --all-features --lib --exclude nexus-framework -- --deny warnings` — clean
- [x] `cargo fmt --all`
- [x] `nix flake check` — all 8 checks green (toml-fmt, fmt, doc, hakari, audit, nextest, clippy, deny)
- [x] 18 combinator tests pass (5 new `map_err` + 13 existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)