### PR TITLE
refactor(store)!: PendingEnvelope holds value newtypes; builder fallible (PR2 of 3)

### DIFF
--- a/crates/nexus-fjall/benches/fjall_benchmarks.rs
+++ b/crates/nexus-fjall/benches/fjall_benchmarks.rs
@@ -48,6 +48,7 @@ fn make_envelope(version: u64, payload: &[u8]) -> nexus_store::PendingEnvelope {
     pending_envelope(Version::new(version).unwrap())
         .event_type("BenchEvent")
         .payload(payload.to_vec())
+        .expect("valid payload")
         .build()
 }
 

--- a/crates/nexus-fjall/src/store.rs
+++ b/crates/nexus-fjall/src/store.rs
@@ -396,6 +396,7 @@ mod tests {
         pending_envelope(Version::new(version).expect("test version must be > 0"))
             .event_type(event_type)
             .payload(payload.to_vec())
+            .expect("valid payload")
             .build()
     }
 

--- a/crates/nexus-fjall/tests/fjall_conformance.rs
+++ b/crates/nexus-fjall/tests/fjall_conformance.rs
@@ -24,6 +24,7 @@ use nexus_fjall::{FjallError, FjallStore, FjallStream};
 use nexus_store::PendingEnvelope;
 use nexus_store::envelope::{PersistedEnvelope, pending_envelope};
 use nexus_store::store::RawEventStore;
+use nexus_store::value::SchemaVersion;
 use nexus_store_testing::{ConformanceRow, assert_event_stream_conformance};
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
@@ -85,12 +86,15 @@ async fn fjall_event_stream_conforms() {
                     let event_type: &'static str = Box::leak(r.event_type.into_boxed_str());
                     let with_payload = pending_envelope(Version::new(r.version).unwrap())
                         .event_type(event_type)
-                        .payload(r.payload);
+                        .payload(r.payload)
+                        .expect("valid payload");
                     if r.schema_version == 1 {
                         with_payload.build()
                     } else {
                         with_payload
-                            .schema_version(NonZeroU32::new(r.schema_version).unwrap())
+                            .schema_version(SchemaVersion::new(
+                                NonZeroU32::new(r.schema_version).unwrap(),
+                            ))
                             .build()
                     }
                 })

--- a/crates/nexus-fjall/tests/metadata_roundtrip_tests.rs
+++ b/crates/nexus-fjall/tests/metadata_roundtrip_tests.rs
@@ -57,7 +57,9 @@ async fn metadata_roundtrips_across_multiple_events() {
             pending_envelope(Version::new(i).unwrap())
                 .event_type("Test")
                 .payload(Bytes::from(format!("payload-{i}")))
+                .expect("valid payload")
                 .with_metadata(Bytes::from(format!("meta-{i}")))
+                .expect("valid metadata")
         })
         .collect();
 
@@ -98,7 +100,9 @@ async fn metadata_survives_store_reopen() {
         let env = pending_envelope(Version::INITIAL)
             .event_type("X")
             .payload(Bytes::from_static(b"payload"))
-            .with_metadata(Bytes::from_static(b"important-meta"));
+            .expect("valid payload")
+            .with_metadata(Bytes::from_static(b"important-meta"))
+            .expect("valid metadata");
         store
             .append(&StreamName("reopen-stream"), None, &[env])
             .await
@@ -130,6 +134,7 @@ async fn none_metadata_roundtrips_as_none() {
     let pending = pending_envelope(Version::INITIAL)
         .event_type("X")
         .payload(Bytes::from_static(b"payload"))
+        .expect("valid payload")
         .build(); // no metadata
     store.append(&id, None, &[pending]).await.unwrap();
 

--- a/crates/nexus-fjall/tests/property_tests.rs
+++ b/crates/nexus-fjall/tests/property_tests.rs
@@ -55,6 +55,7 @@ use nexus_store::PendingEnvelope;
 use nexus_store::envelope::pending_envelope;
 use nexus_store::error::AppendError;
 use nexus_store::store::RawEventStore;
+use nexus_store::value::SchemaVersion;
 
 use proptest::prelude::*;
 
@@ -109,6 +110,7 @@ fn make_envelope(version: u64, event_type: &'static str, payload: &[u8]) -> Pend
     pending_envelope(Version::new(version).unwrap())
         .event_type(event_type)
         .payload(payload.to_vec())
+        .expect("valid payload")
         .build()
 }
 
@@ -122,7 +124,8 @@ fn make_envelope_with_schema(
     pending_envelope(Version::new(version).unwrap())
         .event_type(event_type)
         .payload(payload.to_vec())
-        .schema_version(sv)
+        .expect("valid payload")
+        .schema_version(SchemaVersion::new(sv))
         .build()
 }
 
@@ -134,6 +137,7 @@ fn build_envelopes(payloads: &[Vec<u8>]) -> Vec<PendingEnvelope> {
             pending_envelope(Version::new(u64::try_from(i).unwrap() + 1).unwrap())
                 .event_type(leak("TestEvent"))
                 .payload(p.clone())
+                .expect("valid payload")
                 .build()
         })
         .collect()
@@ -147,6 +151,7 @@ fn build_envelopes_from(start_version: u64, payloads: &[Vec<u8>]) -> Vec<Pending
             pending_envelope(Version::new(start_version + u64::try_from(i).unwrap()).unwrap())
                 .event_type(leak("TestEvent"))
                 .payload(p.clone())
+                .expect("valid payload")
                 .build()
         })
         .collect()
@@ -1161,7 +1166,8 @@ async fn attack_schema_version_zero_clamped_by_builder() {
     let env = pending_envelope(Version::INITIAL)
         .event_type("BadSchema")
         .payload(b"data".to_vec())
-        .schema_version(NonZeroU32::MIN) // Minimum valid schema version
+        .expect("valid payload")
+        .schema_version(SchemaVersion::INITIAL) // Minimum valid schema version
         .build();
 
     // schema_version should be 1

--- a/crates/nexus-fjall/tests/resilience_tests.rs
+++ b/crates/nexus-fjall/tests/resilience_tests.rs
@@ -95,6 +95,7 @@ fn make_envelope(version: u64, event_type: &'static str, payload: &[u8]) -> Pend
     pending_envelope(Version::new(version).unwrap())
         .event_type(event_type)
         .payload(payload.to_vec())
+        .expect("valid payload")
         .build()
 }
 
@@ -341,6 +342,7 @@ proptest! {
                                 pending_envelope(Version::new(ver).unwrap())
                                     .event_type(leak(&format!("Tick_{stream}_{}", existing + i)))
                                     .payload(payload.clone())
+                                    .expect("valid payload")
                                     .build(),
                             );
                         }
@@ -599,6 +601,7 @@ async fn attack_concurrent_append_storm_50_tasks() {
             let env = pending_envelope(Version::INITIAL)
                 .event_type(leak(&format!("Created_{i}")))
                 .payload(i.to_le_bytes().to_vec())
+                .expect("valid payload")
                 .build();
             store_clone.append(&sid_val, None, &[env]).await
         });
@@ -650,6 +653,7 @@ async fn attack_concurrent_append_same_stream_conflict() {
             let env = pending_envelope(Version::INITIAL)
                 .event_type(leak(&format!("Contested_{i}")))
                 .payload(i.to_le_bytes().to_vec())
+                .expect("valid payload")
                 .build();
             store_clone.append(&sid_val, None, &[env]).await
         });

--- a/crates/nexus-fjall/tests/snapshot_tests.rs
+++ b/crates/nexus-fjall/tests/snapshot_tests.rs
@@ -59,6 +59,7 @@ async fn setup_stream(store: &FjallStore, id: &TestId, event_count: u64) {
             pending_envelope(Version::new(i).unwrap())
                 .event_type("TestEvent")
                 .payload(format!("payload-{i}").into_bytes())
+                .expect("valid payload")
                 .build(),
         );
     }

--- a/crates/nexus-fjall/tests/state_machine_tests.rs
+++ b/crates/nexus-fjall/tests/state_machine_tests.rs
@@ -228,6 +228,7 @@ fn make_envelope(version: u64, event_type: &'static str, payload: &[u8]) -> Pend
     pending_envelope(Version::new(version).unwrap())
         .event_type(event_type)
         .payload(payload.to_vec())
+        .expect("valid payload")
         .build()
 }
 

--- a/crates/nexus-fjall/tests/subscription_tests.rs
+++ b/crates/nexus-fjall/tests/subscription_tests.rs
@@ -50,6 +50,7 @@ fn make_envelope(version: u64, event_type: &'static str, payload: &[u8]) -> Pend
     pending_envelope(Version::new(version).expect("test version must be > 0"))
         .event_type(event_type)
         .payload(payload.to_vec())
+        .expect("valid payload")
         .build()
 }
 

--- a/crates/nexus-framework/tests/projection_tests.rs
+++ b/crates/nexus-framework/tests/projection_tests.rs
@@ -162,7 +162,7 @@ fn snapshot_store() -> InMemorySnapshotStore<CountState, Version> {
 async fn append_events(store: &InMemoryStore, stream_id: &TestId, events: &[TestEvent]) {
     let codec = TestEventCodec;
     let current_len = {
-        let mut stream = store
+        let stream = store
             .read_stream(stream_id, Version::INITIAL)
             .await
             .unwrap();
@@ -179,6 +179,7 @@ async fn append_events(store: &InMemoryStore, stream_id: &TestId, events: &[Test
             pending_envelope(ver)
                 .event_type(event.name())
                 .payload(payload)
+                .expect("valid payload")
                 .build()
         })
         .collect();
@@ -900,6 +901,7 @@ async fn runner_returns_event_codec_error_on_bad_payload() {
     let bad_envelope = pending_envelope(Version::new(1).unwrap())
         .event_type("Added")
         .payload(vec![0xFF]) // invalid: too short
+        .expect("valid payload")
         .build();
     store
         .append(&stream_id, None, &[bad_envelope])

--- a/crates/nexus-store/benches/store_bench.rs
+++ b/crates/nexus-store/benches/store_bench.rs
@@ -248,6 +248,7 @@ fn make_envelopes(n: usize) -> Vec<PendingEnvelope> {
             pending_envelope(Version::new(version).unwrap())
                 .event_type("BenchEvent")
                 .payload(vec![1, 2, 3, 4])
+                .expect("valid payload")
                 .build()
         })
         .collect()
@@ -264,6 +265,7 @@ fn bench_builder_throughput(c: &mut Criterion) {
                 pending_envelope(black_box(Version::INITIAL))
                     .event_type("UserCreated")
                     .payload(vec![1, 2, 3, 4])
+                    .expect("valid payload")
                     .build(),
             )
         });

--- a/crates/nexus-store/src/envelope.rs
+++ b/crates/nexus-store/src/envelope.rs
@@ -40,6 +40,9 @@ pub enum EnvelopeError {
         #[source]
         source: std::str::Utf8Error,
     },
+
+    #[error(transparent)]
+    Value(#[from] crate::value::ValueError),
 }
 
 // =============================================================================

--- a/crates/nexus-store/src/envelope.rs
+++ b/crates/nexus-store/src/envelope.rs
@@ -479,6 +479,7 @@ const fn check_range(range: &Range<u32>, len: usize) -> Result<(), EnvelopeError
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::value::MAX_EVENT_TYPE_LEN;
     use bytes::Bytes;
     use nexus::Version;
 
@@ -509,18 +510,26 @@ mod tests {
     }
 
     #[test]
-    fn pending_envelope_holds_typed_event_type() {
+    fn pending_envelope_typed_accessors_roundtrip() {
         let env = pending_envelope(Version::INITIAL)
             .event_type("UserCreated")
-            .payload(Bytes::from_static(b"p"))
+            .payload(Bytes::from_static(b"payload-bytes"))
             .expect("valid payload")
-            .build();
-        assert_eq!(env.event_type(), "UserCreated");
+            .with_metadata(Bytes::from_static(b"meta-bytes"))
+            .expect("valid metadata");
+
+        assert_eq!(env.event_type_value().as_str(), "UserCreated");
+        assert_eq!(env.payload_value().as_slice(), b"payload-bytes");
+        assert_eq!(
+            env.metadata_value().map(|m| m.as_slice().to_vec()),
+            Some(b"meta-bytes".to_vec())
+        );
+        assert_eq!(env.schema_version_value().get(), 1);
     }
 
     #[test]
     fn pending_envelope_rejects_oversize_event_type() {
-        let oversized = "x".repeat(crate::value::MAX_EVENT_TYPE_LEN + 1);
+        let oversized = "x".repeat(MAX_EVENT_TYPE_LEN + 1);
         let err = pending_envelope(Version::INITIAL)
             .event_type_bytes(Bytes::from(oversized))
             .expect_err("oversized must be rejected");

--- a/crates/nexus-store/src/envelope.rs
+++ b/crates/nexus-store/src/envelope.rs
@@ -1,4 +1,3 @@
-use std::num::NonZeroU32;
 use std::ops::Range;
 
 use bytes::Bytes;
@@ -6,6 +5,7 @@ use nexus::Version;
 use thiserror::Error;
 
 use crate::store::GlobalSeq;
+use crate::value::{EventType, Metadata, Payload, SchemaVersion};
 
 /// Cast `u32` index to `usize` for slice indexing.
 ///
@@ -51,17 +51,17 @@ pub enum EnvelopeError {
 
 /// Event envelope for the write path.
 ///
-/// `payload` and `metadata` are `bytes::Bytes` — Arc-shared, cheap to clone,
-/// no lifetime. Safe to hold across awaits or in long-lived containers.
+/// Fields hold validated value newtypes — `EventType`, `Payload`, `Metadata`,
+/// `SchemaVersion` — so downstream wire encoding can skip re-validation.
 ///
 /// Construction is via the typestate builder rooted at [`pending_envelope`].
 #[derive(Debug, Clone)]
 pub struct PendingEnvelope {
     version: Version,
-    event_type: &'static str,
-    schema_version: u32,
-    payload: Bytes,
-    metadata: Option<Bytes>,
+    event_type: EventType,
+    schema_version: SchemaVersion,
+    payload: Payload,
+    metadata: Option<Metadata>,
 }
 
 impl PendingEnvelope {
@@ -70,35 +70,61 @@ impl PendingEnvelope {
         self.version
     }
 
+    /// Borrowed event type as `&str`.
     #[must_use]
-    pub const fn event_type(&self) -> &'static str {
-        self.event_type
+    pub fn event_type(&self) -> &str {
+        self.event_type.as_str()
+    }
+
+    /// Owned event type — one Arc share.
+    #[must_use]
+    pub fn event_type_value(&self) -> EventType {
+        self.event_type.clone()
     }
 
     #[must_use]
     pub fn payload(&self) -> &[u8] {
-        &self.payload
+        self.payload.as_slice()
     }
 
-    /// Owned view — one atomic refcount inc, zero allocation.
+    /// Owned payload — one Arc share.
     #[must_use]
     pub fn payload_bytes(&self) -> Bytes {
+        self.payload.clone().into_bytes()
+    }
+
+    /// Owned payload value newtype — one Arc share.
+    #[must_use]
+    pub fn payload_value(&self) -> Payload {
         self.payload.clone()
     }
 
     #[must_use]
     pub fn metadata(&self) -> Option<&[u8]> {
-        self.metadata.as_deref()
+        self.metadata.as_ref().map(Metadata::as_slice)
     }
 
-    /// Owned view — one atomic refcount inc per `Some`, zero allocation.
+    /// Owned metadata — one Arc share per `Some`.
     #[must_use]
     pub fn metadata_bytes(&self) -> Option<Bytes> {
+        self.metadata.as_ref().map(|m| m.clone().into_bytes())
+    }
+
+    /// Owned metadata value newtype — one Arc share per `Some`.
+    #[must_use]
+    pub fn metadata_value(&self) -> Option<Metadata> {
         self.metadata.clone()
     }
 
+    /// The raw u32 view (always > 0, by the `SchemaVersion` invariant).
     #[must_use]
     pub const fn schema_version(&self) -> u32 {
+        self.schema_version.get()
+    }
+
+    /// The typed schema version.
+    #[must_use]
+    pub const fn schema_version_value(&self) -> SchemaVersion {
         self.schema_version
     }
 }
@@ -108,60 +134,80 @@ impl PendingEnvelope {
 // =============================================================================
 
 /// Step 1: has `version`, needs `event_type`.
+#[derive(Debug)]
 pub struct WithVersion {
     version: Version,
 }
 
 /// Step 2: has `version` + `event_type`, needs payload.
+#[derive(Debug)]
 pub struct WithEventType {
     version: Version,
-    event_type: &'static str,
+    event_type: EventType,
 }
 
 /// Step 3: has all core fields; optional `schema_version` override; finalize via `build`/`with_metadata`.
+#[derive(Debug)]
 pub struct WithPayload {
     version: Version,
-    event_type: &'static str,
-    payload: Bytes,
-    schema_version: u32,
+    event_type: EventType,
+    payload: Payload,
+    schema_version: SchemaVersion,
 }
 
 impl WithVersion {
+    /// Set the event type from a `&'static str` literal. Infallible.
     #[must_use]
-    pub const fn event_type(self, event_type: &'static str) -> WithEventType {
+    pub fn event_type(self, event_type: &'static str) -> WithEventType {
         WithEventType {
             version: self.version,
-            event_type,
+            event_type: EventType::from_static_str(event_type),
         }
+    }
+
+    /// Set the event type from arbitrary bytes; validates UTF-8 and size cap.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EnvelopeError::Value`] if the bytes are invalid UTF-8 or
+    /// exceed [`MAX_EVENT_TYPE_LEN`](crate::value::MAX_EVENT_TYPE_LEN).
+    pub fn event_type_bytes(self, bytes: Bytes) -> Result<WithEventType, EnvelopeError> {
+        let event_type = EventType::from_bytes(bytes)?;
+        Ok(WithEventType {
+            version: self.version,
+            event_type,
+        })
     }
 }
 
 impl WithEventType {
-    /// Accepts anything that converts into `Bytes` — `Bytes`, `Vec<u8>`
-    /// (reuses the Vec's allocation), `&'static [u8]`, `String`.
-    #[must_use]
-    pub fn payload(self, payload: impl Into<Bytes>) -> WithPayload {
-        WithPayload {
+    /// Set the payload from any `Into<Bytes>` source. Fallible: validates
+    /// the size cap.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EnvelopeError::Value`] if the payload exceeds
+    /// [`MAX_PAYLOAD_LEN`](crate::value::MAX_PAYLOAD_LEN).
+    pub fn payload(self, payload: impl Into<Bytes>) -> Result<WithPayload, EnvelopeError> {
+        let validated = Payload::from_bytes(payload.into())?;
+        Ok(WithPayload {
             version: self.version,
             event_type: self.event_type,
-            payload: payload.into(),
-            schema_version: 1,
-        }
+            payload: validated,
+            schema_version: SchemaVersion::INITIAL,
+        })
     }
 }
 
 impl WithPayload {
-    /// Override the schema version (default: 1).
-    ///
-    /// Uses `NonZeroU32` so `schema_version == 0` is a compile-time error,
-    /// matching the invariant enforced by `PersistedEnvelope::try_new`.
+    /// Override the schema version (default: [`SchemaVersion::INITIAL`]).
     #[must_use]
-    pub const fn schema_version(mut self, schema_version: NonZeroU32) -> Self {
-        self.schema_version = schema_version.get();
+    pub const fn schema_version(mut self, schema_version: SchemaVersion) -> Self {
+        self.schema_version = schema_version;
         self
     }
 
-    /// Build with no metadata.
+    /// Build with no metadata. Infallible.
     #[must_use]
     pub fn build(self) -> PendingEnvelope {
         PendingEnvelope {
@@ -173,16 +219,24 @@ impl WithPayload {
         }
     }
 
-    /// Build with metadata. Accepts any `Into<Bytes>`.
-    #[must_use]
-    pub fn with_metadata(self, metadata: impl Into<Bytes>) -> PendingEnvelope {
-        PendingEnvelope {
+    /// Build with metadata; fallible (validates non-empty + size cap).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EnvelopeError::Value`] if the metadata is empty or
+    /// exceeds [`MAX_METADATA_LEN`](crate::value::MAX_METADATA_LEN).
+    pub fn with_metadata(
+        self,
+        metadata: impl Into<Bytes>,
+    ) -> Result<PendingEnvelope, EnvelopeError> {
+        let validated = Metadata::from_bytes(metadata.into())?;
+        Ok(PendingEnvelope {
             version: self.version,
             event_type: self.event_type,
             schema_version: self.schema_version,
             payload: self.payload,
-            metadata: Some(metadata.into()),
-        }
+            metadata: Some(validated),
+        })
     }
 }
 
@@ -433,7 +487,9 @@ mod tests {
         let env = pending_envelope(Version::INITIAL)
             .event_type("UserCreated")
             .payload(Bytes::from_static(b"payload-bytes"))
-            .with_metadata(Bytes::from_static(b"meta-bytes"));
+            .expect("valid payload")
+            .with_metadata(Bytes::from_static(b"meta-bytes"))
+            .expect("valid metadata");
 
         assert_eq!(env.event_type(), "UserCreated");
         assert_eq!(env.payload(), b"payload-bytes");
@@ -445,10 +501,30 @@ mod tests {
     fn pending_envelope_builds_without_metadata() {
         let env = pending_envelope(Version::INITIAL)
             .event_type("X")
-            .payload(Bytes::from_static(b""))
+            .payload(Bytes::from_static(b"p"))
+            .expect("valid payload")
             .build();
 
         assert_eq!(env.metadata(), None);
+    }
+
+    #[test]
+    fn pending_envelope_holds_typed_event_type() {
+        let env = pending_envelope(Version::INITIAL)
+            .event_type("UserCreated")
+            .payload(Bytes::from_static(b"p"))
+            .expect("valid payload")
+            .build();
+        assert_eq!(env.event_type(), "UserCreated");
+    }
+
+    #[test]
+    fn pending_envelope_rejects_oversize_event_type() {
+        let oversized = "x".repeat(crate::value::MAX_EVENT_TYPE_LEN + 1);
+        let err = pending_envelope(Version::INITIAL)
+            .event_type_bytes(Bytes::from(oversized))
+            .expect_err("oversized must be rejected");
+        assert!(matches!(err, EnvelopeError::Value(_)));
     }
 
     #[test]

--- a/crates/nexus-store/src/error.rs
+++ b/crates/nexus-store/src/error.rs
@@ -67,6 +67,15 @@ pub enum StoreError<A, EncErr, DecErr> {
     /// a `payload` longer than `u32::MAX` bytes.
     #[error("wire-format error: {0}")]
     Wire(#[source] crate::wire::WireError),
+
+    /// Envelope construction rejected user-supplied bytes
+    /// (size cap exceeded, UTF-8 invalid, or zero schema version).
+    ///
+    /// Raised on the save path when an encoded payload, metadata, or
+    /// event-type name violates the value-newtype invariants enforced by
+    /// the [`PendingEnvelope`](crate::PendingEnvelope) builder.
+    #[error("envelope error: {0}")]
+    Envelope(#[from] crate::envelope::EnvelopeError),
 }
 
 /// Errors from the with-upcaster load path.

--- a/crates/nexus-store/src/error.rs
+++ b/crates/nexus-store/src/error.rs
@@ -69,11 +69,13 @@ pub enum StoreError<A, EncErr, DecErr> {
     Wire(#[source] crate::wire::WireError),
 
     /// Envelope construction rejected user-supplied bytes
-    /// (size cap exceeded, UTF-8 invalid, or zero schema version).
+    /// (payload exceeded its size cap, or another value-newtype invariant).
     ///
-    /// Raised on the save path when an encoded payload, metadata, or
-    /// event-type name violates the value-newtype invariants enforced by
-    /// the [`PendingEnvelope`](crate::PendingEnvelope) builder.
+    /// Raised on the save path when an encoded payload violates the
+    /// invariants enforced by the [`PendingEnvelope`](crate::PendingEnvelope)
+    /// builder. The schema-version-zero case is not reachable from the
+    /// typed-repository save path because `SchemaVersion` is constructed
+    /// from `NonZeroU32`.
     #[error("envelope error: {0}")]
     Envelope(#[from] crate::envelope::EnvelopeError),
 }

--- a/crates/nexus-store/src/repository.rs
+++ b/crates/nexus-store/src/repository.rs
@@ -20,6 +20,7 @@ use crate::envelope::{PersistedEnvelope, pending_envelope};
 use crate::error::{AppendError, LoadWithError, StoreError};
 use crate::store::{RawEventStore, Store};
 use crate::upcasting::EventMorsel;
+use crate::value::SchemaVersion;
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Repository<A> — high-level aggregate facade (load + save)
@@ -433,8 +434,8 @@ where
 
         let envelope = pending_envelope(next_version)
             .event_type(event_name)
-            .payload(payload)
-            .schema_version(schema_nz32)
+            .payload(payload)?
+            .schema_version(SchemaVersion::new(schema_nz32))
             .build();
 
         envelopes.push(envelope);
@@ -725,8 +726,8 @@ where
 
         let envelope = pending_envelope(next_version)
             .event_type(event_name)
-            .payload(payload)
-            .schema_version(schema_nz32)
+            .payload(payload)?
+            .schema_version(SchemaVersion::new(schema_nz32))
             .build();
 
         envelopes.push(envelope);

--- a/crates/nexus-store/tests/adversarial_property_tests.rs
+++ b/crates/nexus-store/tests/adversarial_property_tests.rs
@@ -270,6 +270,7 @@ fn build_envelopes(payloads: &[Vec<u8>]) -> Vec<PendingEnvelope> {
             pending_envelope(Version::new(u64::try_from(i).unwrap() + 1).unwrap())
                 .event_type(leak("TestEvent"))
                 .payload(p.clone())
+                .expect("valid payload")
                 .build()
         })
         .collect()
@@ -283,6 +284,7 @@ fn build_envelopes_from(start_version: u64, payloads: &[Vec<u8>]) -> Vec<Pending
             pending_envelope(Version::new(start_version + u64::try_from(i).unwrap()).unwrap())
                 .event_type(leak("TestEvent"))
                 .payload(p.clone())
+                .expect("valid payload")
                 .build()
         })
         .collect()
@@ -436,6 +438,7 @@ proptest! {
         let env = pending_envelope(ver)
             .event_type(leak("AnyType"))
             .payload(payload.clone())
+            .expect("valid payload")
             .build();
 
         prop_assert_eq!(env.version().as_u64(), version);
@@ -603,6 +606,7 @@ proptest! {
                 pending_envelope(Version::new(v).unwrap())
                     .event_type(leak("E"))
                     .payload(vec![v as u8])
+                    .expect("valid payload")
                     .build()
             }).collect();
 
@@ -633,6 +637,7 @@ proptest! {
                 pending_envelope(Version::INITIAL)
                     .event_type(leak("E"))
                     .payload(vec![1])
+                    .expect("valid payload")
                     .build()
             }).collect();
 
@@ -669,6 +674,7 @@ proptest! {
                 pending_envelope(Version::new(v).unwrap())
                     .event_type(leak("E"))
                     .payload(vec![v as u8])
+                    .expect("valid payload")
                     .build()
             }).collect();
 
@@ -1109,6 +1115,7 @@ async fn attack_event_store_transforms_applied_on_load() {
         pending_envelope(Version::INITIAL)
             .event_type(leak("Happened"))
             .payload(payload)
+            .expect("valid payload")
             .build(),
     ];
     raw_store
@@ -1294,6 +1301,7 @@ proptest! {
             let envelope = pending_envelope(Version::INITIAL)
                 .event_type(leak("E"))
                 .payload(vec![1, 2, 3])
+                .expect("valid payload")
                 .build();
 
             // Append should not panic (may succeed or fail with error)
@@ -1724,6 +1732,7 @@ async fn attack_concurrent_writers_exactly_one_wins() {
             let envelope = pending_envelope(Version::INITIAL)
                 .event_type(Box::leak(format!("Writer{writer_id}").into_boxed_str()))
                 .payload(vec![writer_id as u8])
+                .expect("valid payload")
                 .build();
 
             store.append(&sn("race-stream"), None, &[envelope]).await

--- a/crates/nexus-store/tests/adversarial_tests.rs
+++ b/crates/nexus-store/tests/adversarial_tests.rs
@@ -63,6 +63,7 @@ fn max_version_envelope() {
     let envelope = pending_envelope(Version::new(u64::MAX).unwrap())
         .event_type("Event")
         .payload(vec![])
+        .expect("valid payload")
         .build();
 
     assert_eq!(envelope.version().as_u64(), u64::MAX);
@@ -86,6 +87,7 @@ fn empty_payload() {
     let envelope = pending_envelope(Version::INITIAL)
         .event_type("EmptyEvent")
         .payload(vec![])
+        .expect("valid payload")
         .build();
 
     assert!(envelope.payload().is_empty());
@@ -103,6 +105,7 @@ fn large_payload() {
     let envelope = pending_envelope(Version::INITIAL)
         .event_type("LargeEvent")
         .payload(payload)
+        .expect("valid payload")
         .build();
 
     assert_eq!(envelope.payload().len(), size);

--- a/crates/nexus-store/tests/bug_hunt_tests.rs
+++ b/crates/nexus-store/tests/bug_hunt_tests.rs
@@ -264,14 +264,17 @@ async fn append_rejects_backwards_versions() {
         pending_envelope(Version::new(3).unwrap())
             .event_type("E")
             .payload(vec![3])
+            .expect("valid payload")
             .build(),
         pending_envelope(Version::new(2).unwrap())
             .event_type("E")
             .payload(vec![2])
+            .expect("valid payload")
             .build(),
         pending_envelope(Version::new(1).unwrap())
             .event_type("E")
             .payload(vec![1])
+            .expect("valid payload")
             .build(),
     ];
 
@@ -311,6 +314,7 @@ proptest! {
         let envelope = pending_envelope(Version::INITIAL)
             .event_type("E")
             .payload(payload.clone())
+            .expect("valid payload")
             .build();
         prop_assert_eq!(envelope.payload(), payload.as_slice());
     }
@@ -330,6 +334,7 @@ proptest! {
                     pending_envelope(Version::new(v).unwrap())
                         .event_type("E")
                         .payload(vec![v as u8])
+                        .expect("valid payload")
                         .build()
                 })
                 .collect();
@@ -461,7 +466,9 @@ fn bug_probe_metadata_bytes_stored_correctly() {
     let envelope = pending_envelope(Version::INITIAL)
         .event_type("E")
         .payload(vec![])
-        .with_metadata(meta.clone());
+        .expect("valid payload")
+        .with_metadata(meta.clone())
+        .expect("valid metadata");
 
     assert_eq!(envelope.version(), Version::INITIAL);
     assert_eq!(envelope.metadata(), Some(meta.as_slice()));

--- a/crates/nexus-store/tests/envelope_tests.rs
+++ b/crates/nexus-store/tests/envelope_tests.rs
@@ -36,6 +36,7 @@ fn pending_envelope_accessors() {
     let envelope = pending_envelope(Version::new(1).unwrap())
         .event_type("UserCreated")
         .payload(vec![1, 2, 3])
+        .expect("valid payload")
         .build();
 
     assert_eq!(envelope.version(), Version::new(1).unwrap());
@@ -50,7 +51,9 @@ fn pending_envelope_with_metadata() {
     let envelope = pending_envelope(Version::new(1).unwrap())
         .event_type("OrderPlaced")
         .payload(vec![4, 5, 6])
-        .with_metadata(meta.clone());
+        .expect("valid payload")
+        .with_metadata(meta.clone())
+        .expect("valid metadata");
 
     assert_eq!(envelope.metadata(), Some(meta.as_slice()));
 }
@@ -107,6 +110,7 @@ fn pending_envelope_debug_output() {
     let envelope = pending_envelope(Version::new(7).unwrap())
         .event_type("UserCreated")
         .payload(vec![1, 2, 3])
+        .expect("valid payload")
         .build();
     let debug = format!("{envelope:?}");
     assert!(
@@ -130,6 +134,7 @@ fn build_without_metadata_has_no_metadata() {
     let env = pending_envelope(Version::new(5).unwrap())
         .event_type("Evt")
         .payload(vec![9, 8, 7])
+        .expect("valid payload")
         .build();
 
     assert!(env.metadata().is_none());

--- a/crates/nexus-store/tests/inmemory_conformance.rs
+++ b/crates/nexus-store/tests/inmemory_conformance.rs
@@ -15,6 +15,7 @@ use nexus::Id;
 use nexus_store::envelope::pending_envelope;
 use nexus_store::store::RawEventStore;
 use nexus_store::testing::InMemoryStore;
+use nexus_store::value::SchemaVersion;
 use nexus_store::{PendingEnvelope, Version};
 use nexus_store_testing::{ConformanceRow, assert_event_stream_conformance};
 
@@ -53,12 +54,15 @@ async fn inmemory_event_stream_conforms() {
                     let event_type: &'static str = Box::leak(r.event_type.into_boxed_str());
                     let with_payload = pending_envelope(Version::new(r.version).unwrap())
                         .event_type(event_type)
-                        .payload(r.payload);
+                        .payload(r.payload)
+                        .expect("valid payload");
                     if r.schema_version == 1 {
                         with_payload.build()
                     } else {
                         with_payload
-                            .schema_version(NonZeroU32::new(r.schema_version).unwrap())
+                            .schema_version(SchemaVersion::new(
+                                NonZeroU32::new(r.schema_version).unwrap(),
+                            ))
                             .build()
                     }
                 })

--- a/crates/nexus-store/tests/inmemory_store_tests.rs
+++ b/crates/nexus-store/tests/inmemory_store_tests.rs
@@ -29,6 +29,7 @@ async fn append_and_read_back() {
     let envelope = pending_envelope(Version::INITIAL)
         .event_type("TestEvent")
         .payload(b"hello".to_vec())
+        .expect("valid payload")
         .build();
     store
         .append(&TestId("stream-1"), None, &[envelope])
@@ -55,14 +56,17 @@ async fn read_from_version_filters_correctly() {
         pending_envelope(Version::new(1).unwrap())
             .event_type("E1")
             .payload(b"one".to_vec())
+            .expect("valid payload")
             .build(),
         pending_envelope(Version::new(2).unwrap())
             .event_type("E2")
             .payload(b"two".to_vec())
+            .expect("valid payload")
             .build(),
         pending_envelope(Version::new(3).unwrap())
             .event_type("E3")
             .payload(b"three".to_vec())
+            .expect("valid payload")
             .build(),
     ];
     store.append(&TestId("s1"), None, &envelopes).await.unwrap();
@@ -96,10 +100,12 @@ async fn append_assigns_monotonic_global_seq_across_batches_and_streams() {
         pending_envelope(Version::new(1).unwrap())
             .event_type("A1")
             .payload(b"a1".to_vec())
+            .expect("valid payload")
             .build(),
         pending_envelope(Version::new(2).unwrap())
             .event_type("A2")
             .payload(b"a2".to_vec())
+            .expect("valid payload")
             .build(),
     ];
     store.append(&TestId("a"), None, &batch_a).await.unwrap();
@@ -110,6 +116,7 @@ async fn append_assigns_monotonic_global_seq_across_batches_and_streams() {
         pending_envelope(Version::new(1).unwrap())
             .event_type("B1")
             .payload(b"b1".to_vec())
+            .expect("valid payload")
             .build(),
     ];
     store.append(&TestId("b"), None, &batch_b).await.unwrap();

--- a/crates/nexus-store/tests/integration_tests.rs
+++ b/crates/nexus-store/tests/integration_tests.rs
@@ -49,6 +49,7 @@ fn make_envelopes(start: u64, count: u64) -> Vec<nexus_store::envelope::PendingE
             pending_envelope(Version::new(v).unwrap())
                 .event_type("Event")
                 .payload(v.to_le_bytes().to_vec())
+                .expect("valid payload")
                 .build()
         })
         .collect()

--- a/crates/nexus-store/tests/property_tests.rs
+++ b/crates/nexus-store/tests/property_tests.rs
@@ -80,6 +80,7 @@ fn build_envelopes(payloads: &[Vec<u8>]) -> Vec<PendingEnvelope> {
             pending_envelope(Version::new(version_num).unwrap())
                 .event_type(leak_event_type("TestEvent"))
                 .payload(p.clone())
+                .expect("valid payload")
                 .build()
         })
         .collect()

--- a/crates/nexus-store/tests/repository_qa_tests.rs
+++ b/crates/nexus-store/tests/repository_qa_tests.rs
@@ -847,6 +847,7 @@ async fn d4_zero_copy_event_store_with_payload_mutating_upcaster() {
     let legacy = pending_envelope(Version::INITIAL)
         .event_type("Delta")
         .payload(5_i32.to_le_bytes().to_vec())
+        .expect("valid payload")
         .build(); // schema_version defaults to 1
     raw_store
         .append(&CounterId("counter-1".into()), None, &[legacy])
@@ -883,6 +884,7 @@ async fn d4_upcaster_must_not_double_apply_to_new_events() {
     let legacy = pending_envelope(Version::INITIAL)
         .event_type("Delta")
         .payload(5_i32.to_le_bytes().to_vec())
+        .expect("valid payload")
         .build(); // schema_version defaults to 1
     raw_store
         .append(&CounterId("counter-1".into()), None, &[legacy])
@@ -1451,10 +1453,12 @@ async fn d11_schema_version_always_one() {
         pending_envelope(Version::INITIAL)
             .event_type("Incremented")
             .payload(b"inc".to_vec())
+            .expect("valid payload")
             .build(),
         pending_envelope(Version::new(2).unwrap())
             .event_type("Set")
             .payload(b"set:42".to_vec())
+            .expect("valid payload")
             .build(),
     ];
     store

--- a/crates/nexus-store/tests/security_tests.rs
+++ b/crates/nexus-store/tests/security_tests.rs
@@ -69,6 +69,7 @@ fn c2_builder_accepts_empty_event_type() {
     let envelope = pending_envelope(Version::INITIAL)
         .event_type("")
         .payload(vec![1])
+        .expect("valid payload")
         .build();
     assert_eq!(envelope.event_type(), "");
 }
@@ -115,14 +116,17 @@ async fn h5_append_with_non_sequential_versions() {
         pending_envelope(Version::new(3).unwrap())
             .event_type("E")
             .payload(vec![])
+            .expect("valid payload")
             .build(),
         pending_envelope(Version::new(1).unwrap())
             .event_type("E")
             .payload(vec![])
+            .expect("valid payload")
             .build(),
         pending_envelope(Version::new(5).unwrap())
             .event_type("E")
             .payload(vec![])
+            .expect("valid payload")
             .build(),
     ];
 
@@ -148,10 +152,12 @@ async fn h5_append_with_duplicate_versions() {
         pending_envelope(Version::INITIAL)
             .event_type("E")
             .payload(vec![])
+            .expect("valid payload")
             .build(),
         pending_envelope(Version::INITIAL)
             .event_type("E")
             .payload(vec![])
+            .expect("valid payload")
             .build(), // dup!
     ];
 
@@ -186,10 +192,12 @@ fn m2_pending_envelope_no_partial_eq() {
     let e1 = pending_envelope(Version::INITIAL)
         .event_type("E")
         .payload(vec![1])
+        .expect("valid payload")
         .build();
     let e2 = pending_envelope(Version::INITIAL)
         .event_type("E")
         .payload(vec![1])
+        .expect("valid payload")
         .build();
     // Can't do assert_eq!(e1, e2) — no PartialEq
     // So we compare field by field
@@ -227,12 +235,14 @@ async fn streams_are_isolated() {
         pending_envelope(Version::INITIAL)
             .event_type("EventA")
             .payload(vec![1])
+            .expect("valid payload")
             .build(),
     ];
     let e2 = vec![
         pending_envelope(Version::INITIAL)
             .event_type("EventB")
             .payload(vec![2])
+            .expect("valid payload")
             .build(),
     ];
 
@@ -280,5 +290,6 @@ fn store_error_variants_are_known() {
         StoreError::Kernel(_) => {}
         StoreError::VersionOverflow => {} // If you add a variant, add it here
         StoreError::Wire(_) => {}
+        StoreError::Envelope(_) => {}
     }
 }

--- a/crates/nexus-store/tests/subscription_tests.rs
+++ b/crates/nexus-store/tests/subscription_tests.rs
@@ -1,5 +1,6 @@
 #![cfg(feature = "testing")]
 #![allow(clippy::unwrap_used, reason = "tests")]
+#![allow(clippy::expect_used, reason = "tests")]
 #![allow(clippy::panic, reason = "tests")]
 
 use std::sync::Arc;
@@ -40,6 +41,7 @@ fn make_envelope(version: u64, event_type: &'static str) -> nexus_store::Pending
     pending_envelope(Version::new(version).unwrap())
         .event_type(event_type)
         .payload(format!("payload-{version}").into_bytes())
+        .expect("valid payload")
         .build()
 }
 

--- a/crates/nexus-store/tests/wire_alignment_tests.rs
+++ b/crates/nexus-store/tests/wire_alignment_tests.rs
@@ -77,6 +77,7 @@ fn build_envelope(version: u64, event_type: &'static str, payload_len: usize) ->
     pending_envelope(Version::new(version).expect("version > 0"))
         .event_type(event_type)
         .payload(payload)
+        .expect("valid payload")
         .build()
 }
 

--- a/examples/store-and-kernel/src/main.rs
+++ b/examples/store-and-kernel/src/main.rs
@@ -226,6 +226,7 @@ fn encode_decided(
             pending_envelope(ver)
                 .event_type(event.name())
                 .payload(payload)
+                .expect("valid payload")
                 .build()
         })
         .collect()

--- a/examples/store-inmemory/src/main.rs
+++ b/examples/store-inmemory/src/main.rs
@@ -226,6 +226,7 @@ async fn main() {
         let envelope = pending_envelope(Version::new(version_num).expect("version > 0"))
             .event_type(event_type)
             .payload(payload.clone())
+            .expect("valid payload")
             .build();
         println!(
             "  Envelope: version={}, type={}",
@@ -270,6 +271,7 @@ async fn main() {
         let legacy_envelope = pending_envelope(Version::new(4).expect("version > 0"))
             .event_type("TaskCreated")
             .payload(old_json.into_bytes())
+            .expect("valid payload")
             .build();
 
         store
@@ -353,6 +355,7 @@ async fn main() {
     let envelope = pending_envelope(Version::INITIAL)
         .event_type("TodoCreated")
         .payload(payload)
+        .expect("valid payload")
         .build();
     typed_store
         .raw()


### PR DESCRIPTION
## Summary

PR2 of the value-newtype refactor (depends on #187, the PR1 module introduction).

- `PendingEnvelope` now holds `EventType`, `Payload`, `Option<Metadata>`, `SchemaVersion` — the typed value newtypes from PR1.
- Builder methods that accept user bytes (`.payload`, `.with_metadata`, `.event_type_bytes`) return `Result<_, EnvelopeError>`. `WithVersion::event_type(&'static str)` stays infallible (string literals use `EventType::from_static_str` per CLAUDE.md §3 same-invariants-both-paths).
- `EnvelopeError` gains a `Value(#[from] ValueError)` variant. `StoreError` gains an `Envelope(#[from] EnvelopeError)` variant so the typed-repository save path propagates value-validation failures via `?`.
- `PendingEnvelope` gains four owned-value accessors: `event_type_value`, `payload_value`, `metadata_value`, `schema_version_value` — all one-Arc-share via `Bytes::clone`.
- All internal, test, example, and downstream-crate (`nexus-fjall`, `nexus-framework`) call sites updated.

## Why one commit for Tasks 2.2–2.6

The plan split the work into 6 commits. The pre-commit hook runs `nix flake check` (which runs `cargo nextest` across the workspace), so any commit that breaks `PendingEnvelope`'s API must update every caller in the same commit to survive the hook. The `--no-verify` escape is banned by project rules. The result: one big mechanical commit (28 files, +229/-56) rather than six unbuildable intermediates. A small follow-up commit addresses spec-/code-quality-review feedback.

## Breaking changes

- `WithEventType::payload` returns `Result<WithPayload, EnvelopeError>` (was `WithPayload`).
- `WithPayload::with_metadata` returns `Result<PendingEnvelope, EnvelopeError>` (was `PendingEnvelope`).
- `WithPayload::schema_version` now takes `SchemaVersion` (was `NonZeroU32`).
- New `WithVersion::event_type_bytes(Bytes) -> Result<WithEventType, EnvelopeError>` for the fallible bytes path.
- New `StoreError::Envelope(#[from] EnvelopeError)` variant.
- The three typestate intermediates (`WithVersion`, `WithEventType`, `WithPayload`) now derive `Debug` — required by the new `expect_err` test on the bytes path; harmless for downstream users.

## Drive-by

- Removed a pre-existing `let mut stream` in `nexus-framework/tests/projection_tests.rs` where `stream` was never reassigned. The flake's `--lib`-only clippy gate had been hiding this; the `--all-targets` clippy run on this branch would otherwise fail.

## Test plan

- [x] Two new `envelope.rs` unit tests: `pending_envelope_typed_accessors_roundtrip` (exercises all 4 owned-value accessors) and `pending_envelope_rejects_oversize_event_type` (asserts `EnvelopeError::Value(_)` on `event_type_bytes` with `MAX_EVENT_TYPE_LEN + 1` bytes).
- [x] All existing envelope-mod, integration, adversarial, property, conformance, and security tests updated and passing.
- [x] Examples (`store-inmemory`, `store-and-kernel`) build and run to completion.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `nix flake check` passes all 8 derivations (clippy, fmt, toml-fmt, audit, deny, nextest, doc, hakari).

🤖 Generated with [Claude Code](https://claude.com/claude-code)