### PR TITLE
refactor(store, fjall)!: shrink wire.rs to pure framing; SchemaVersion + PersistedEnvelope value accessors (PR3 of 3)

### DIFF
--- a/crates/nexus-fjall/src/encoding.rs
+++ b/crates/nexus-fjall/src/encoding.rs
@@ -23,37 +23,25 @@ pub enum DecodeError {
 /// Errors from encoding values into byte layouts.
 #[derive(Debug, Error)]
 pub enum EncodeError {
-    #[error("event type too long: {len} bytes (max {})", u16::MAX)]
-    EventTypeTooLong { len: usize },
-
     #[error("stream ID too long: {len} bytes (max {})", u16::MAX)]
     IdTooLong { len: usize },
-
-    #[error("metadata too long: {len} bytes (max {})", u32::MAX - 1)]
-    MetadataTooLong { len: usize },
-
-    #[error("payload too long: {len} bytes (max {})", u32::MAX)]
-    PayloadTooLong { len: usize },
 
     #[error("frame length overflow")]
     FrameLengthOverflow,
 
-    #[error("schema_version must be > 0 (got 0)")]
-    InvalidSchemaVersion,
+    /// Value newtype rejected an input (oversize `event_type` / payload /
+    /// metadata, invalid UTF-8 in `event_type`, empty metadata, or zero
+    /// `schema_version`). The size-cap and `schema_version` invariants
+    /// live on [`nexus_store::value`] now; this variant surfaces every
+    /// rejection at the encoding-layer boundary.
+    #[error(transparent)]
+    Value(#[from] nexus_store::value::ValueError),
 }
 
 impl From<wire::WireError> for EncodeError {
     fn from(e: wire::WireError) -> Self {
         match e {
-            wire::WireError::EventTypeTooLong { actual, .. } => {
-                Self::EventTypeTooLong { len: actual }
-            }
-            wire::WireError::MetadataTooLong { actual, .. } => {
-                Self::MetadataTooLong { len: actual }
-            }
-            wire::WireError::PayloadTooLong { actual, .. } => Self::PayloadTooLong { len: actual },
             wire::WireError::FrameLengthOverflow { .. } => Self::FrameLengthOverflow,
-            wire::WireError::InvalidSchemaVersion => Self::InvalidSchemaVersion,
         }
     }
 }
@@ -180,11 +168,13 @@ pub fn decode_stream_version(value: &[u8]) -> Result<u64, DecodeError> {
 /// to `decode_event_value`. `metadata_range` is `None` when the encoded
 /// `meta_len` is the [`META_LEN_ABSENT`] sentinel. The payload offset
 /// honors the 16-byte alignment invariant from
-/// [`nexus_store::wire`][wire].
+/// [`nexus_store::wire`][wire]. `schema_version` is the typed
+/// [`nexus_store::value::SchemaVersion`] — corrupt on-disk zeros are
+/// surfaced as `DecodeError::Wire(wire::DecodeError::CorruptSchemaVersion)`.
 #[derive(Debug)]
 pub struct DecodedEvent {
     pub global_seq: u64,
-    pub schema_version: u32,
+    pub schema_version: nexus_store::value::SchemaVersion,
     pub event_type_range: std::ops::Range<u32>,
     pub payload_range: std::ops::Range<u32>,
     pub metadata_range: Option<std::ops::Range<u32>>,
@@ -212,7 +202,15 @@ pub fn encode_event_value(
     metadata: Option<&[u8]>,
     payload: &[u8],
 ) -> Result<(), EncodeError> {
-    let frame = wire::encode_frame(global_seq, schema_version, event_type, metadata, payload)?;
+    let sv = nexus_store::value::SchemaVersion::from_u32(schema_version)?;
+    let et = nexus_store::value::EventType::from_bytes(bytes::Bytes::copy_from_slice(
+        event_type.as_bytes(),
+    ))?;
+    let pl = nexus_store::value::Payload::from_bytes(bytes::Bytes::copy_from_slice(payload))?;
+    let md = metadata
+        .map(|m| nexus_store::value::Metadata::from_bytes(bytes::Bytes::copy_from_slice(m)))
+        .transpose()?;
+    let frame = wire::encode_frame(global_seq, sv, &et, &pl, md.as_ref())?;
     buf.clear();
     buf.extend_from_slice(&frame.value);
     Ok(())
@@ -404,7 +402,7 @@ mod tests {
         let decoded = decode_event_value(&bytes_buf).unwrap();
 
         assert_eq!(decoded.global_seq, global_seq);
-        assert_eq!(decoded.schema_version, schema_version);
+        assert_eq!(decoded.schema_version.get(), schema_version);
         assert!(decoded.metadata_range.is_none());
         let et = &bytes_buf
             [decoded.event_type_range.start as usize..decoded.event_type_range.end as usize];
@@ -421,7 +419,7 @@ mod tests {
         let bytes_buf = bytes::Bytes::copy_from_slice(&buf);
         let decoded = decode_event_value(&bytes_buf).unwrap();
         assert_eq!(decoded.global_seq, 7);
-        assert_eq!(decoded.schema_version, 1);
+        assert_eq!(decoded.schema_version.get(), 1);
         let et = &bytes_buf
             [decoded.event_type_range.start as usize..decoded.event_type_range.end as usize];
         assert_eq!(et, b"Empty");
@@ -458,7 +456,7 @@ mod tests {
         let decoded = decode_event_value(&bytes_buf).unwrap();
 
         assert_eq!(decoded.global_seq, global_seq);
-        assert_eq!(decoded.schema_version, schema_version);
+        assert_eq!(decoded.schema_version.get(), schema_version);
         assert_eq!(
             &bytes_buf
                 [decoded.event_type_range.start as usize..decoded.event_type_range.end as usize],
@@ -484,7 +482,7 @@ mod tests {
         let decoded = decode_event_value(&bytes_buf).unwrap();
 
         assert_eq!(decoded.global_seq, 7);
-        assert_eq!(decoded.schema_version, 1);
+        assert_eq!(decoded.schema_version.get(), 1);
         assert!(decoded.metadata_range.is_none());
         assert_eq!(decoded.payload_range.end, decoded.payload_range.start);
     }

--- a/crates/nexus-fjall/src/encoding.rs
+++ b/crates/nexus-fjall/src/encoding.rs
@@ -26,8 +26,13 @@ pub enum EncodeError {
     #[error("stream ID too long: {len} bytes (max {})", u16::MAX)]
     IdTooLong { len: usize },
 
-    #[error("frame length overflow")]
-    FrameLengthOverflow,
+    /// Wire-format build failure (e.g. `FrameLengthOverflow`). Wraps
+    /// [`wire::WireError`] verbatim via `#[from]` so the source error's
+    /// structured fields (header / padding / payload sizes) survive
+    /// through the encoding-layer boundary instead of being collapsed
+    /// to a bare variant.
+    #[error(transparent)]
+    Wire(#[from] wire::WireError),
 
     /// Value newtype rejected an input (oversize `event_type` / payload /
     /// metadata, invalid UTF-8 in `event_type`, empty metadata, or zero
@@ -36,14 +41,6 @@ pub enum EncodeError {
     /// rejection at the encoding-layer boundary.
     #[error(transparent)]
     Value(#[from] nexus_store::value::ValueError),
-}
-
-impl From<wire::WireError> for EncodeError {
-    fn from(e: wire::WireError) -> Self {
-        match e {
-            wire::WireError::FrameLengthOverflow { .. } => Self::FrameLengthOverflow,
-        }
-    }
 }
 
 /// Size of the event key header: `[u16 BE id_len]`.

--- a/crates/nexus-fjall/src/store.rs
+++ b/crates/nexus-fjall/src/store.rs
@@ -173,10 +173,10 @@ impl RawEventStore for FjallStore {
             })?;
             let frame = wire::encode_frame(
                 global_seq,
-                env.schema_version(),
-                env.event_type(),
-                env.metadata(),
-                env.payload(),
+                env.schema_version_value(),
+                &env.event_type_value(),
+                &env.payload_value(),
+                env.metadata_value().as_ref(),
             )
             .map_err(|e| {
                 AppendError::Store(FjallError::InvalidInput {

--- a/crates/nexus-fjall/tests/property_tests.rs
+++ b/crates/nexus-fjall/tests/property_tests.rs
@@ -97,7 +97,7 @@ fn decode_ev_slices(buf: &[u8]) -> (u64, u32, String, Vec<u8>) {
             .unwrap()
             .to_owned();
     let pl = b[d.payload_range.start as usize..d.payload_range.end as usize].to_vec();
-    (d.global_seq, d.schema_version, et, pl)
+    (d.global_seq, d.schema_version.get(), et, pl)
 }
 
 fn temp_store() -> (FjallStore, tempfile::TempDir) {

--- a/crates/nexus-fjall/tests/resilience_tests.rs
+++ b/crates/nexus-fjall/tests/resilience_tests.rs
@@ -43,7 +43,6 @@ use futures::StreamExt;
 use nexus::Version;
 use nexus_fjall::FjallStore;
 use nexus_fjall::encoding::{EncodeError, decode_event_value, encode_event_value};
-use nexus_store::GlobalSeq;
 use nexus_store::PendingEnvelope;
 use nexus_store::envelope::pending_envelope;
 use nexus_store::error::AppendError;
@@ -84,7 +83,7 @@ fn decode_ev_slices(buf: &[u8]) -> (u64, u32, String, Vec<u8>) {
             .unwrap()
             .to_owned();
     let pl = b[d.payload_range.start as usize..d.payload_range.end as usize].to_vec();
-    (d.global_seq, d.schema_version, et, pl)
+    (d.global_seq, d.schema_version.get(), et, pl)
 }
 
 fn leak(s: &str) -> &'static str {
@@ -765,8 +764,8 @@ fn attack_encoding_schema_version_boundaries() {
     let mut buf = Vec::new();
     let result = encode_event_value(&mut buf, 1, 0, "Test", None, b"data");
     match result {
-        Err(EncodeError::InvalidSchemaVersion) => {}
-        other => panic!("expected InvalidSchemaVersion at encoding layer, got {other:?}"),
+        Err(EncodeError::Value(nexus_store::value::ValueError::SchemaVersionZero)) => {}
+        other => panic!("expected Value(SchemaVersionZero) at encoding layer, got {other:?}"),
     }
 
     // schema_version = 1 is the minimum valid value and must round-trip.
@@ -1106,21 +1105,17 @@ async fn attack_reopen_10_times_with_appends() {
 /// of defense against corrupt persisted data.
 #[test]
 fn attack_schema_version_zero_rejected_by_type_system() {
-    // NonZeroU32::new(0) returns None — 0 is structurally unrepresentable
+    // Defense in depth: every layer rejects schema_version=0 by construction.
+    // - NonZeroU32::new(0) returns None.
+    // - SchemaVersion::from_u32(0) returns SchemaVersionZero.
+    // - PersistedEnvelope::try_new takes SchemaVersion, so 0 is unrepresentable
+    //   at the type level (no test case can pass it).
+    // - wire::decode_frame rejects on-disk schema_version=0 (corrupt-data path),
+    //   pinned in nexus_store::wire::tests::decode_frame_rejects_corrupt_schema_version_zero.
     assert!(NonZeroU32::new(0).is_none(), "NonZeroU32 must reject 0");
-    // And try_new on the read path still rejects 0
-    let result = nexus_store::PersistedEnvelope::try_new(
-        Version::INITIAL,
-        GlobalSeq::INITIAL,
-        Bytes::from_static(b"E"),
-        0,
-        0..1,
-        1..1,
-        None,
-    );
     assert!(
-        result.is_err(),
-        "PersistedEnvelope::try_new must reject schema_version=0"
+        nexus_store::value::SchemaVersion::from_u32(0).is_err(),
+        "SchemaVersion::from_u32(0) must return Err"
     );
 }
 

--- a/crates/nexus-fjall/tests/snapshot_wire_format.rs
+++ b/crates/nexus-fjall/tests/snapshot_wire_format.rs
@@ -114,7 +114,12 @@ fn event_value_schema_zero_rejected() {
     let mut buf = Vec::new();
     let result = encode_event_value(&mut buf, 1, 0, "Empty", None, b"");
     assert!(
-        matches!(result, Err(EncodeError::InvalidSchemaVersion)),
+        matches!(
+            result,
+            Err(EncodeError::Value(
+                nexus_store::value::ValueError::SchemaVersionZero
+            ))
+        ),
         "encode_event_value must reject schema_version=0, got {result:?}",
     );
     assert!(

--- a/crates/nexus-store/benches/store_bench.rs
+++ b/crates/nexus-store/benches/store_bench.rs
@@ -81,7 +81,7 @@ fn build_persisted(
         nexus::Version::new(version).expect("non-zero version"),
         global_seq,
         value,
-        1,
+        nexus_store::value::SchemaVersion::INITIAL,
         0..et_end,
         et_end..pl_end,
         None,

--- a/crates/nexus-store/src/codec.rs
+++ b/crates/nexus-store/src/codec.rs
@@ -382,19 +382,23 @@ pub mod bytemuck {
         }
 
         fn build_test_envelope(payload: &[u8]) -> PersistedEnvelope {
+            let et = crate::value::EventType::from_static_str("Pos");
+            let pl = crate::value::Payload::from_bytes(bytes::Bytes::copy_from_slice(payload))
+                .expect("valid payload");
+            let sv = crate::value::SchemaVersion::INITIAL;
             let frame = wire::encode_frame(
                 crate::store::GlobalSeq::INITIAL.as_u64(),
-                1,
-                "Pos",
+                sv,
+                &et,
+                &pl,
                 None,
-                payload,
             )
             .expect("wire encode_frame ok");
             PersistedEnvelope::try_new(
                 nexus::Version::INITIAL,
                 crate::store::GlobalSeq::INITIAL,
                 frame.value,
-                1,
+                sv,
                 frame.offsets.event_type,
                 frame.offsets.payload,
                 None,
@@ -540,19 +544,23 @@ pub mod rkyv {
         }
 
         fn build_test_envelope(payload: &[u8]) -> PersistedEnvelope {
+            let et = crate::value::EventType::from_static_str("Move");
+            let pl = crate::value::Payload::from_bytes(bytes::Bytes::copy_from_slice(payload))
+                .expect("valid payload");
+            let sv = crate::value::SchemaVersion::INITIAL;
             let frame = wire::encode_frame(
                 crate::store::GlobalSeq::INITIAL.as_u64(),
-                1,
-                "Move",
+                sv,
+                &et,
+                &pl,
                 None,
-                payload,
             )
             .expect("wire encode_frame ok");
             PersistedEnvelope::try_new(
                 nexus::Version::INITIAL,
                 crate::store::GlobalSeq::INITIAL,
                 frame.value,
-                1,
+                sv,
                 frame.offsets.event_type,
                 frame.offsets.payload,
                 None,

--- a/crates/nexus-store/src/envelope.rs
+++ b/crates/nexus-store/src/envelope.rs
@@ -401,6 +401,75 @@ impl PersistedEnvelope {
         self.metadata_range.as_ref().map(|r| self.slice_range(r))
     }
 
+    /// Owned, validated event type — one Arc share over the underlying buffer.
+    ///
+    /// The UTF-8 and size invariants were established at `try_new` time;
+    /// this constructor skips re-validation via the crate-internal
+    /// `from_validated_bytes` path.
+    #[must_use]
+    pub fn event_type_owned(&self) -> EventType {
+        // SAFETY: `PersistedEnvelope::try_new` validated the
+        // `event_type_range` slice as UTF-8, and `check_range` ensured
+        // `event_type_range.end <= value.len()`. `event_type_range` is a
+        // `Range<u32>`, so the slice length is bounded by `u32::MAX`, which
+        // is well within `MAX_EVENT_TYPE_LEN = u16::MAX` only when the
+        // upstream decoder respected the wire-format `u16` length field —
+        // which `check_range` indirectly enforces via the buffer's own
+        // length bound. The `Bytes` returned by `event_type_bytes()` is a
+        // slice of the same validated buffer, preserving both invariants.
+        #[allow(
+            unsafe_code,
+            reason = "UTF-8 + size invariants established at PersistedEnvelope::try_new"
+        )]
+        unsafe {
+            EventType::from_validated_bytes(self.event_type_bytes())
+        }
+    }
+
+    /// Owned, validated payload — one Arc share over the underlying buffer.
+    #[must_use]
+    pub fn payload_owned(&self) -> Payload {
+        // SAFETY: `PersistedEnvelope::try_new` validated `payload_range`
+        // against `value.len()` via `check_range`. The range is a
+        // `Range<u32>`, so the resulting slice length is bounded by
+        // `u32::MAX = MAX_PAYLOAD_LEN`. `payload_bytes()` returns a slice
+        // of the same validated buffer.
+        #[allow(
+            unsafe_code,
+            reason = "size invariant established at PersistedEnvelope::try_new"
+        )]
+        unsafe {
+            Payload::from_validated_bytes(self.payload_bytes())
+        }
+    }
+
+    /// Owned, validated metadata — one Arc share per `Some` over the
+    /// underlying buffer.
+    ///
+    /// Returns `None` when the wire-level absent sentinel was present.
+    /// "Present but empty" metadata is structurally disallowed by the
+    /// [`Metadata`] invariant.
+    #[must_use]
+    pub fn metadata_owned(&self) -> Option<Metadata> {
+        self.metadata_bytes().map(|b| {
+            // SAFETY: `PersistedEnvelope::try_new` validated `metadata_range`
+            // against `value.len()` via `check_range`; `MAX_METADATA_LEN =
+            // u32::MAX - 1` accommodates any `Range<u32>`. `metadata_bytes()`
+            // returns `Some` only when `metadata_range` is `Some`, i.e. the
+            // wire frame carried real metadata (not the `u32::MAX` absent
+            // sentinel), so the slice is non-empty by wire-layer
+            // construction.
+            #[allow(
+                unsafe_code,
+                reason = "non-empty + size invariants established at PersistedEnvelope::try_new \
+                          and the wire-format absent sentinel"
+            )]
+            unsafe {
+                Metadata::from_validated_bytes(b)
+            }
+        })
+    }
+
     /// The schema version as a `Version` for upcaster APIs.
     ///
     /// # Panics
@@ -619,5 +688,72 @@ mod tests {
         )
         .expect_err("must reject non-UTF-8 event_type");
         assert!(matches!(err, EnvelopeError::InvalidUtf8 { .. }));
+    }
+
+    #[test]
+    fn persisted_envelope_event_type_owned_returns_validated_value_newtype() {
+        let env = PersistedEnvelope::try_new(
+            Version::INITIAL,
+            crate::store::GlobalSeq::new(1).expect("nonzero"),
+            Bytes::from_static(b"TYPEpayload"),
+            1,
+            0..4,
+            4..11,
+            None,
+        )
+        .expect("valid");
+
+        let et = env.event_type_owned();
+        assert_eq!(et.as_str(), "TYPE");
+    }
+
+    #[test]
+    fn persisted_envelope_payload_owned_returns_validated_value_newtype() {
+        let env = PersistedEnvelope::try_new(
+            Version::INITIAL,
+            crate::store::GlobalSeq::new(1).expect("nonzero"),
+            Bytes::from_static(b"TYPEpayload"),
+            1,
+            0..4,
+            4..11,
+            None,
+        )
+        .expect("valid");
+
+        let p = env.payload_owned();
+        assert_eq!(p.as_slice(), b"payload");
+    }
+
+    #[test]
+    fn persisted_envelope_metadata_owned_returns_some_when_present() {
+        let env = PersistedEnvelope::try_new(
+            Version::INITIAL,
+            crate::store::GlobalSeq::new(1).expect("nonzero"),
+            Bytes::from_static(b"TYPEpayloadMETA"),
+            1,
+            0..4,
+            4..11,
+            Some(11..15),
+        )
+        .expect("valid");
+
+        let m = env.metadata_owned().expect("present");
+        assert_eq!(m.as_slice(), b"META");
+    }
+
+    #[test]
+    fn persisted_envelope_metadata_owned_returns_none_when_absent() {
+        let env = PersistedEnvelope::try_new(
+            Version::INITIAL,
+            crate::store::GlobalSeq::new(1).expect("nonzero"),
+            Bytes::from_static(b"TYPEpayload"),
+            1,
+            0..4,
+            4..11,
+            None,
+        )
+        .expect("valid");
+
+        assert!(env.metadata_owned().is_none());
     }
 }

--- a/crates/nexus-store/src/envelope.rs
+++ b/crates/nexus-store/src/envelope.rs
@@ -401,34 +401,33 @@ impl PersistedEnvelope {
         self.metadata_range.as_ref().map(|r| self.slice_range(r))
     }
 
-    /// Owned, validated event type — one Arc share over the underlying buffer.
-    ///
-    /// The UTF-8 and size invariants were established at `try_new` time;
-    /// this constructor skips re-validation via the crate-internal
-    /// `from_validated_bytes` path.
+    /// Validated event type — one Arc share over the underlying buffer.
     #[must_use]
-    pub fn event_type_owned(&self) -> EventType {
-        // SAFETY: `PersistedEnvelope::try_new` validated the
-        // `event_type_range` slice as UTF-8, and `check_range` ensured
-        // `event_type_range.end <= value.len()`. `event_type_range` is a
-        // `Range<u32>`, so the slice length is bounded by `u32::MAX`, which
-        // is well within `MAX_EVENT_TYPE_LEN = u16::MAX` only when the
-        // upstream decoder respected the wire-format `u16` length field —
-        // which `check_range` indirectly enforces via the buffer's own
-        // length bound. The `Bytes` returned by `event_type_bytes()` is a
-        // slice of the same validated buffer, preserving both invariants.
+    pub fn event_type_value(&self) -> EventType {
+        // SAFETY: `from_validated_bytes` requires (1) valid UTF-8 and
+        // (2) `bytes.len() <= MAX_EVENT_TYPE_LEN`.
+        //
+        // (1) is established by `try_new`, which calls `std::str::from_utf8`
+        //     on the same buffer slice.
+        // (2) is not structurally enforced by `try_new` today — `check_range`
+        //     only verifies `range.end <= value.len()`. The cap holds whenever
+        //     the producer is `wire::decode_frame` (the `u16` event_type_len
+        //     wire field bounds the range). Task 3.2/3.3 adds structural
+        //     per-field validation to `try_new`. Until then, `EventType::as_str`
+        //     depends only on (1), so cap violation has no UB consequence —
+        //     it surfaces as `WireError::FrameLengthOverflow` at encode time.
         #[allow(
             unsafe_code,
-            reason = "UTF-8 + size invariants established at PersistedEnvelope::try_new"
+            reason = "UTF-8 established by try_new; cap holds for wire decoder; tightened in Task 3.2/3.3"
         )]
         unsafe {
             EventType::from_validated_bytes(self.event_type_bytes())
         }
     }
 
-    /// Owned, validated payload — one Arc share over the underlying buffer.
+    /// Validated payload — one Arc share over the underlying buffer.
     #[must_use]
-    pub fn payload_owned(&self) -> Payload {
+    pub fn payload_value(&self) -> Payload {
         // SAFETY: `PersistedEnvelope::try_new` validated `payload_range`
         // against `value.len()` via `check_range`. The range is a
         // `Range<u32>`, so the resulting slice length is bounded by
@@ -443,26 +442,27 @@ impl PersistedEnvelope {
         }
     }
 
-    /// Owned, validated metadata — one Arc share per `Some` over the
-    /// underlying buffer.
+    /// Validated metadata — one Arc share per `Some` over the underlying
+    /// buffer.
     ///
     /// Returns `None` when the wire-level absent sentinel was present.
-    /// "Present but empty" metadata is structurally disallowed by the
-    /// [`Metadata`] invariant.
     #[must_use]
-    pub fn metadata_owned(&self) -> Option<Metadata> {
+    pub fn metadata_value(&self) -> Option<Metadata> {
         self.metadata_bytes().map(|b| {
-            // SAFETY: `PersistedEnvelope::try_new` validated `metadata_range`
-            // against `value.len()` via `check_range`; `MAX_METADATA_LEN =
-            // u32::MAX - 1` accommodates any `Range<u32>`. `metadata_bytes()`
-            // returns `Some` only when `metadata_range` is `Some`, i.e. the
-            // wire frame carried real metadata (not the `u32::MAX` absent
-            // sentinel), so the slice is non-empty by wire-layer
-            // construction.
+            // SAFETY: `from_validated_bytes` requires (1) `!bytes.is_empty()` and
+            // (2) `bytes.len() <= MAX_METADATA_LEN`.
+            //
+            // Neither invariant is structurally enforced by `try_new` today —
+            // `check_range` accepts `Some(0..0)` and admits ranges up to `u32::MAX`.
+            // Both hold whenever the producer is `wire::decode_frame` (the absent
+            // sentinel decodes to `None`, length bounded by `u32::MAX - 1`).
+            // Task 3.2/3.3 adds structural per-field validation to `try_new`.
+            // Until then, `Metadata` has no `unsafe` reader path — invariant
+            // violation surfaces at encode time or as the `Bytes::slice(empty)`
+            // `STATIC_VTABLE` orphan footgun, not as UB.
             #[allow(
                 unsafe_code,
-                reason = "non-empty + size invariants established at PersistedEnvelope::try_new \
-                          and the wire-format absent sentinel"
+                reason = "invariants hold for wire decoder; no UB reader path; tightened in Task 3.2/3.3"
             )]
             unsafe {
                 Metadata::from_validated_bytes(b)
@@ -691,7 +691,7 @@ mod tests {
     }
 
     #[test]
-    fn persisted_envelope_event_type_owned_returns_validated_value_newtype() {
+    fn persisted_envelope_event_type_value_returns_validated_value_newtype() {
         let env = PersistedEnvelope::try_new(
             Version::INITIAL,
             crate::store::GlobalSeq::new(1).expect("nonzero"),
@@ -703,12 +703,12 @@ mod tests {
         )
         .expect("valid");
 
-        let et = env.event_type_owned();
+        let et = env.event_type_value();
         assert_eq!(et.as_str(), "TYPE");
     }
 
     #[test]
-    fn persisted_envelope_payload_owned_returns_validated_value_newtype() {
+    fn persisted_envelope_payload_value_returns_validated_value_newtype() {
         let env = PersistedEnvelope::try_new(
             Version::INITIAL,
             crate::store::GlobalSeq::new(1).expect("nonzero"),
@@ -720,12 +720,12 @@ mod tests {
         )
         .expect("valid");
 
-        let p = env.payload_owned();
+        let p = env.payload_value();
         assert_eq!(p.as_slice(), b"payload");
     }
 
     #[test]
-    fn persisted_envelope_metadata_owned_returns_some_when_present() {
+    fn persisted_envelope_metadata_value_returns_some_when_present() {
         let env = PersistedEnvelope::try_new(
             Version::INITIAL,
             crate::store::GlobalSeq::new(1).expect("nonzero"),
@@ -737,12 +737,12 @@ mod tests {
         )
         .expect("valid");
 
-        let m = env.metadata_owned().expect("present");
+        let m = env.metadata_value().expect("present");
         assert_eq!(m.as_slice(), b"META");
     }
 
     #[test]
-    fn persisted_envelope_metadata_owned_returns_none_when_absent() {
+    fn persisted_envelope_metadata_value_returns_none_when_absent() {
         let env = PersistedEnvelope::try_new(
             Version::INITIAL,
             crate::store::GlobalSeq::new(1).expect("nonzero"),
@@ -754,6 +754,6 @@ mod tests {
         )
         .expect("valid");
 
-        assert!(env.metadata_owned().is_none());
+        assert!(env.metadata_value().is_none());
     }
 }

--- a/crates/nexus-store/src/envelope.rs
+++ b/crates/nexus-store/src/envelope.rs
@@ -354,7 +354,7 @@ impl PersistedEnvelope {
         // newtypes; mirroring them here makes `event_type_value` /
         // `metadata_value` sound without re-validation.
         let et_range_len = event_type_range.end - event_type_range.start;
-        if usize::try_from(et_range_len).unwrap_or(usize::MAX) > MAX_EVENT_TYPE_LEN {
+        if idx(et_range_len) > MAX_EVENT_TYPE_LEN {
             return Err(EnvelopeError::EventTypeRangeTooLong {
                 actual: et_range_len,
                 max: MAX_EVENT_TYPE_LEN,
@@ -365,7 +365,7 @@ impl PersistedEnvelope {
             if meta_range_len == 0 {
                 return Err(EnvelopeError::MetadataRangeEmpty);
             }
-            if usize::try_from(meta_range_len).unwrap_or(usize::MAX) > MAX_METADATA_LEN {
+            if idx(meta_range_len) > MAX_METADATA_LEN {
                 return Err(EnvelopeError::MetadataRangeTooLong {
                     actual: meta_range_len,
                     max: MAX_METADATA_LEN,
@@ -696,6 +696,34 @@ mod tests {
         )
         .expect_err("must reject out-of-bounds range");
         assert!(matches!(err, EnvelopeError::RangeOutOfBounds { .. }));
+    }
+
+    #[test]
+    fn try_new_rejects_event_type_range_too_long() {
+        let len = MAX_EVENT_TYPE_LEN + 1;
+        let mut buf = vec![0u8; len];
+        // Fill with valid UTF-8 (all-zeros is valid UTF-8 ASCII).
+        buf[0] = b'A';
+        let value = Bytes::from(buf);
+        let too_long_end = u32::try_from(len).expect("len fits in u32 by construction");
+
+        let err = PersistedEnvelope::try_new(
+            Version::INITIAL,
+            crate::store::GlobalSeq::new(1).expect("nonzero"),
+            value,
+            SchemaVersion::INITIAL,
+            0..too_long_end,
+            too_long_end..too_long_end,
+            None,
+        )
+        .expect_err("event_type range > MAX_EVENT_TYPE_LEN must be rejected");
+
+        let expected_actual = u32::try_from(len).expect("len fits in u32 by construction (above)");
+        assert!(matches!(
+            err,
+            EnvelopeError::EventTypeRangeTooLong { actual, max }
+                if actual == expected_actual && max == MAX_EVENT_TYPE_LEN
+        ));
     }
 
     #[test]

--- a/crates/nexus-store/src/envelope.rs
+++ b/crates/nexus-store/src/envelope.rs
@@ -5,7 +5,9 @@ use nexus::Version;
 use thiserror::Error;
 
 use crate::store::GlobalSeq;
-use crate::value::{EventType, Metadata, Payload, SchemaVersion};
+use crate::value::{
+    EventType, MAX_EVENT_TYPE_LEN, MAX_METADATA_LEN, Metadata, Payload, SchemaVersion, ValueError,
+};
 
 /// Cast `u32` index to `usize` for slice indexing.
 ///
@@ -27,9 +29,6 @@ const fn idx(n: u32) -> usize {
 /// Errors from envelope construction.
 #[derive(Debug, Error)]
 pub enum EnvelopeError {
-    #[error("schema_version must be > 0 (got 0)")]
-    InvalidSchemaVersion,
-
     #[error("range {start}..{end} exceeds buffer length {len}")]
     RangeOutOfBounds { start: u32, end: u32, len: usize },
 
@@ -41,8 +40,45 @@ pub enum EnvelopeError {
         source: std::str::Utf8Error,
     },
 
+    /// The `event_type` range length exceeds the wire-format cap.
+    ///
+    /// Structurally rules out the only path that could otherwise hand
+    /// `EventType::from_validated_bytes` an oversize slice on the read
+    /// side, so the fast-path accessor is sound by construction.
+    #[error("event_type range length {actual} exceeds maximum {max}")]
+    EventTypeRangeTooLong { actual: u32, max: usize },
+
+    /// The metadata range length exceeds the wire-format cap.
+    ///
+    /// Mirrors `EventTypeRangeTooLong` for metadata.
+    #[error("metadata range length {actual} exceeds maximum {max}")]
+    MetadataRangeTooLong { actual: u32, max: usize },
+
+    /// `Some(range)` was passed where `range` is empty. The wire format
+    /// reserves the absent sentinel (`meta_len == u32::MAX`) for "no
+    /// metadata"; an empty range collides with the `Bytes::slice(empty)`
+    /// `STATIC_VTABLE` orphan footgun and the value newtype invariant
+    /// `!Metadata::is_empty()`.
+    #[error("metadata range is empty; use None to represent absent metadata")]
+    MetadataRangeEmpty,
+
     #[error(transparent)]
-    Value(#[from] crate::value::ValueError),
+    Value(#[from] ValueError),
+}
+
+/// Errors from [`PersistedEnvelope::for_decode`].
+///
+/// Combines the failure modes of the underlying value-newtype
+/// construction, the wire encode, and the envelope `try_new` — `?`
+/// promotes any of the three.
+#[derive(Debug, Error)]
+pub enum ForDecodeError {
+    #[error(transparent)]
+    Value(#[from] ValueError),
+    #[error(transparent)]
+    Wire(#[from] crate::wire::WireError),
+    #[error(transparent)]
+    Envelope(#[from] EnvelopeError),
 }
 
 // =============================================================================
@@ -266,13 +302,14 @@ pub const fn pending_envelope(version: Version) -> WithVersion {
 /// the one Arc; accessors return `&[u8]`/`&str` cheaply or `Bytes` via
 /// `value.slice(range)` for owned views.
 ///
-/// Construction validates ranges against the buffer and UTF-8 of `event_type`
-/// at one point; accessors are then panic-free fast paths.
+/// Construction validates ranges against the buffer, UTF-8 of `event_type`,
+/// and the structural per-field caps that the value newtypes own (so the
+/// fast-path `*_value()` accessors are sound without re-validation).
 #[derive(Debug, Clone)]
 pub struct PersistedEnvelope {
     version: Version,
     global_seq: GlobalSeq,
-    schema_version: u32,
+    schema_version: SchemaVersion,
     value: Bytes,
     event_type_range: Range<u32>,
     payload_range: Range<u32>,
@@ -284,9 +321,14 @@ impl PersistedEnvelope {
     ///
     /// # Errors
     ///
-    /// - `InvalidSchemaVersion` if `schema_version == 0`.
-    /// - `RangeOutOfBounds` if any range's `end` exceeds `value.len()`.
-    /// - `InvalidUtf8` if `event_type` bytes are not valid UTF-8.
+    /// - [`EnvelopeError::RangeOutOfBounds`] if any range's `end` exceeds `value.len()`.
+    /// - [`EnvelopeError::InvalidUtf8`] if `event_type` bytes are not valid UTF-8.
+    /// - [`EnvelopeError::EventTypeRangeTooLong`] if the event-type range
+    ///   length exceeds [`MAX_EVENT_TYPE_LEN`].
+    /// - [`EnvelopeError::MetadataRangeTooLong`] if the metadata range
+    ///   length exceeds [`MAX_METADATA_LEN`].
+    /// - [`EnvelopeError::MetadataRangeEmpty`] if `Some(range)` is passed
+    ///   with an empty range.
     #[allow(
         clippy::too_many_arguments,
         reason = "all 7 fields are required to construct a validated PersistedEnvelope; \
@@ -296,20 +338,41 @@ impl PersistedEnvelope {
         version: Version,
         global_seq: GlobalSeq,
         value: Bytes,
-        schema_version: u32,
+        schema_version: SchemaVersion,
         event_type_range: Range<u32>,
         payload_range: Range<u32>,
         metadata_range: Option<Range<u32>>,
     ) -> Result<Self, EnvelopeError> {
-        if schema_version == 0 {
-            return Err(EnvelopeError::InvalidSchemaVersion);
-        }
         let len = value.len();
         check_range(&event_type_range, len)?;
         check_range(&payload_range, len)?;
         if let Some(ref m) = metadata_range {
             check_range(m, len)?;
         }
+
+        // Structural per-field caps — owned upstream by the value
+        // newtypes; mirroring them here makes `event_type_value` /
+        // `metadata_value` sound without re-validation.
+        let et_range_len = event_type_range.end - event_type_range.start;
+        if usize::try_from(et_range_len).unwrap_or(usize::MAX) > MAX_EVENT_TYPE_LEN {
+            return Err(EnvelopeError::EventTypeRangeTooLong {
+                actual: et_range_len,
+                max: MAX_EVENT_TYPE_LEN,
+            });
+        }
+        if let Some(ref m) = metadata_range {
+            let meta_range_len = m.end - m.start;
+            if meta_range_len == 0 {
+                return Err(EnvelopeError::MetadataRangeEmpty);
+            }
+            if usize::try_from(meta_range_len).unwrap_or(usize::MAX) > MAX_METADATA_LEN {
+                return Err(EnvelopeError::MetadataRangeTooLong {
+                    actual: meta_range_len,
+                    max: MAX_METADATA_LEN,
+                });
+            }
+        }
+
         // UTF-8 validation of event_type once at construction.
         let et_start = idx(event_type_range.start);
         let et_end = idx(event_type_range.end);
@@ -339,8 +402,16 @@ impl PersistedEnvelope {
         self.global_seq
     }
 
+    /// The raw `u32` view of `schema_version` (always > 0 by the
+    /// [`SchemaVersion`] invariant).
     #[must_use]
     pub const fn schema_version(&self) -> u32 {
+        self.schema_version.get()
+    }
+
+    /// The typed [`SchemaVersion`].
+    #[must_use]
+    pub const fn schema_version_value(&self) -> SchemaVersion {
         self.schema_version
     }
 
@@ -391,11 +462,8 @@ impl PersistedEnvelope {
 
     /// Owned `Bytes` view of `metadata` — one atomic refcount inc per `Some`.
     ///
-    /// Note: per the design doc footgun F1, an empty range would collapse to
-    /// `STATIC_VTABLE` and orphan from the parent buffer. The wire format
-    /// MUST use `meta_len == u32::MAX` for absent (decoded to `None`), and
-    /// "present but empty" metadata is currently disallowed — the decoder
-    /// must enforce this.
+    /// `try_new` rejects `Some(empty)`, so the `Bytes::slice(empty)`
+    /// `STATIC_VTABLE` orphan footgun is structurally unreachable here.
     #[must_use]
     pub fn metadata_bytes(&self) -> Option<Bytes> {
         self.metadata_range.as_ref().map(|r| self.slice_range(r))
@@ -405,20 +473,13 @@ impl PersistedEnvelope {
     #[must_use]
     pub fn event_type_value(&self) -> EventType {
         // SAFETY: `from_validated_bytes` requires (1) valid UTF-8 and
-        // (2) `bytes.len() <= MAX_EVENT_TYPE_LEN`.
-        //
-        // (1) is established by `try_new`, which calls `std::str::from_utf8`
-        //     on the same buffer slice.
-        // (2) is not structurally enforced by `try_new` today — `check_range`
-        //     only verifies `range.end <= value.len()`. The cap holds whenever
-        //     the producer is `wire::decode_frame` (the `u16` event_type_len
-        //     wire field bounds the range). Task 3.2/3.3 adds structural
-        //     per-field validation to `try_new`. Until then, `EventType::as_str`
-        //     depends only on (1), so cap violation has no UB consequence —
-        //     it surfaces as `WireError::FrameLengthOverflow` at encode time.
+        // (2) `bytes.len() <= MAX_EVENT_TYPE_LEN`. Both invariants are
+        // established by `try_new`: UTF-8 via `std::str::from_utf8`, and
+        // the cap via the `EventTypeRangeTooLong` check on the range
+        // length.
         #[allow(
             unsafe_code,
-            reason = "UTF-8 established by try_new; cap holds for wire decoder; tightened in Task 3.2/3.3"
+            reason = "UTF-8 and length cap both established by try_new"
         )]
         unsafe {
             EventType::from_validated_bytes(self.event_type_bytes())
@@ -450,19 +511,13 @@ impl PersistedEnvelope {
     pub fn metadata_value(&self) -> Option<Metadata> {
         self.metadata_bytes().map(|b| {
             // SAFETY: `from_validated_bytes` requires (1) `!bytes.is_empty()` and
-            // (2) `bytes.len() <= MAX_METADATA_LEN`.
-            //
-            // Neither invariant is structurally enforced by `try_new` today —
-            // `check_range` accepts `Some(0..0)` and admits ranges up to `u32::MAX`.
-            // Both hold whenever the producer is `wire::decode_frame` (the absent
-            // sentinel decodes to `None`, length bounded by `u32::MAX - 1`).
-            // Task 3.2/3.3 adds structural per-field validation to `try_new`.
-            // Until then, `Metadata` has no `unsafe` reader path — invariant
-            // violation surfaces at encode time or as the `Bytes::slice(empty)`
-            // `STATIC_VTABLE` orphan footgun, not as UB.
+            // (2) `bytes.len() <= MAX_METADATA_LEN`. Both invariants are
+            // established by `try_new`: the `MetadataRangeEmpty` check rejects
+            // an empty `Some(range)`, and `MetadataRangeTooLong` enforces the
+            // cap on the range length.
             #[allow(
                 unsafe_code,
-                reason = "invariants hold for wire decoder; no UB reader path; tightened in Task 3.2/3.3"
+                reason = "non-empty and length cap both established by try_new"
             )]
             unsafe {
                 Metadata::from_validated_bytes(b)
@@ -470,17 +525,12 @@ impl PersistedEnvelope {
         })
     }
 
-    /// The schema version as a `Version` for upcaster APIs.
+    /// The schema version widened to the kernel's [`Version`] for upcaster APIs.
     ///
-    /// # Panics
-    ///
-    /// Panics if `schema_version == 0`, which `try_new` rejects — so this
-    /// can only fire if internal invariants are violated.
+    /// Total conversion — [`SchemaVersion`] is structurally nonzero.
     #[must_use]
-    #[allow(clippy::expect_used, reason = "try_new guarantees schema_version >= 1")]
     pub fn schema_version_as_version(&self) -> Version {
-        Version::new(u64::from(self.schema_version))
-            .expect("PersistedEnvelope invariant: schema_version >= 1")
+        Version::from(self.schema_version)
     }
 
     /// Wrap raw bytes in a synthetic envelope suitable for [`Decode`].
@@ -491,42 +541,32 @@ impl PersistedEnvelope {
     /// buffer — snapshot decoding, upcaster post-transform decoding, codec
     /// round-trip tests.
     ///
-    /// Reports `Version::INITIAL`, `GlobalSeq::INITIAL`, and `schema_version=1`.
-    /// Most codecs ignore those fields; when they don't (or you're bridging
-    /// an upcast back to a decode and need to preserve the original
-    /// envelope's version triple), construct the envelope manually via
-    /// [`try_new`](Self::try_new).
+    /// Reports `Version::INITIAL`, `GlobalSeq::INITIAL`, and
+    /// `schema_version = SchemaVersion::INITIAL`. Most codecs ignore those
+    /// fields; when they don't (or you're bridging an upcast back to a
+    /// decode and need to preserve the original envelope's version
+    /// triple), construct the envelope manually via [`try_new`](Self::try_new).
     ///
     /// # Errors
     ///
-    /// Returns [`WireError`](crate::wire::WireError) if `event_type` exceeds
-    /// 65,535 bytes or `payload` exceeds `u32::MAX` bytes.
-    ///
-    /// # Panics
-    ///
-    /// Never under normal use. The post-`encode_frame` [`try_new`](Self::try_new)
-    /// is `expect`'d because its inputs are controlled here: ranges come from
-    /// the just-built frame, `event_type` is a valid `&str`, and
-    /// `schema_version = 1` is nonzero — none of `try_new`'s failure
-    /// conditions can fire.
-    pub fn for_decode(event_type: &str, payload: &[u8]) -> Result<Self, crate::wire::WireError> {
-        let frame =
-            crate::wire::encode_frame(GlobalSeq::INITIAL.as_u64(), 1, event_type, None, payload)?;
-        #[allow(
-            clippy::expect_used,
-            reason = "ranges come from wire::encode_frame which validated them, \
-                      event_type is a valid &str, schema_version=1 is nonzero"
-        )]
+    /// Returns [`ForDecodeError`] if the value newtypes reject the inputs
+    /// (oversize `event_type`/`payload`), the wire encode fails
+    /// (`FrameLengthOverflow`), or the envelope `try_new` fails (range
+    /// invariants).
+    pub fn for_decode(event_type: &str, payload: &[u8]) -> Result<Self, ForDecodeError> {
+        let et = EventType::from_bytes(Bytes::copy_from_slice(event_type.as_bytes()))?;
+        let pl = Payload::from_bytes(Bytes::copy_from_slice(payload))?;
+        let sv = SchemaVersion::INITIAL;
+        let frame = crate::wire::encode_frame(GlobalSeq::INITIAL.as_u64(), sv, &et, &pl, None)?;
         Ok(Self::try_new(
             Version::INITIAL,
             GlobalSeq::INITIAL,
             frame.value,
-            1,
+            sv,
             frame.offsets.event_type,
             frame.offsets.payload,
             None,
-        )
-        .expect("try_new is infallible given encode_frame outputs and valid &str"))
+        )?)
     }
 
     fn slice_range(&self, range: &Range<u32>) -> Bytes {
@@ -613,7 +653,7 @@ mod tests {
             Version::INITIAL,
             crate::store::GlobalSeq::new(1).expect("nonzero"),
             value,
-            1,
+            SchemaVersion::INITIAL,
             0..4,
             4..11,
             Some(11..15),
@@ -631,7 +671,7 @@ mod tests {
             Version::INITIAL,
             crate::store::GlobalSeq::new(1).expect("nonzero"),
             Bytes::from_static(b"TYPEpayload"),
-            1,
+            SchemaVersion::INITIAL,
             0..4,
             4..11,
             None,
@@ -649,7 +689,7 @@ mod tests {
             Version::INITIAL,
             crate::store::GlobalSeq::new(1).expect("nonzero"),
             value,
-            1,
+            SchemaVersion::INITIAL,
             0..4,
             4..100,
             None,
@@ -659,19 +699,17 @@ mod tests {
     }
 
     #[test]
-    fn persisted_envelope_rejects_schema_version_zero() {
-        let value = Bytes::from_static(b"TYPEpayload");
-        let err = PersistedEnvelope::try_new(
+    fn persisted_envelope_rejects_empty_metadata_range() {
+        let env = PersistedEnvelope::try_new(
             Version::INITIAL,
             crate::store::GlobalSeq::new(1).expect("nonzero"),
-            value,
-            0,
+            Bytes::from_static(b"TYPEpayload"),
+            SchemaVersion::INITIAL,
             0..4,
             4..11,
-            None,
-        )
-        .expect_err("must reject schema_version == 0");
-        assert!(matches!(err, EnvelopeError::InvalidSchemaVersion));
+            Some(4..4),
+        );
+        assert!(matches!(env, Err(EnvelopeError::MetadataRangeEmpty)));
     }
 
     #[test]
@@ -681,7 +719,7 @@ mod tests {
             Version::INITIAL,
             crate::store::GlobalSeq::new(1).expect("nonzero"),
             value,
-            1,
+            SchemaVersion::INITIAL,
             0..2,
             2..5,
             None,
@@ -696,7 +734,7 @@ mod tests {
             Version::INITIAL,
             crate::store::GlobalSeq::new(1).expect("nonzero"),
             Bytes::from_static(b"TYPEpayload"),
-            1,
+            SchemaVersion::INITIAL,
             0..4,
             4..11,
             None,
@@ -713,7 +751,7 @@ mod tests {
             Version::INITIAL,
             crate::store::GlobalSeq::new(1).expect("nonzero"),
             Bytes::from_static(b"TYPEpayload"),
-            1,
+            SchemaVersion::INITIAL,
             0..4,
             4..11,
             None,
@@ -730,7 +768,7 @@ mod tests {
             Version::INITIAL,
             crate::store::GlobalSeq::new(1).expect("nonzero"),
             Bytes::from_static(b"TYPEpayloadMETA"),
-            1,
+            SchemaVersion::INITIAL,
             0..4,
             4..11,
             Some(11..15),
@@ -747,7 +785,7 @@ mod tests {
             Version::INITIAL,
             crate::store::GlobalSeq::new(1).expect("nonzero"),
             Bytes::from_static(b"TYPEpayload"),
-            1,
+            SchemaVersion::INITIAL,
             0..4,
             4..11,
             None,

--- a/crates/nexus-store/src/error.rs
+++ b/crates/nexus-store/src/error.rs
@@ -67,7 +67,7 @@ pub enum StoreError<A, EncErr, DecErr> {
     /// `event_type`/`payload`), the wire encode (`FrameLengthOverflow`),
     /// or the envelope construction (range invariants).
     #[error("envelope synthesis error: {0}")]
-    Wire(#[source] crate::envelope::ForDecodeError),
+    EnvelopeSynthesis(#[source] crate::envelope::ForDecodeError),
 
     /// Envelope construction rejected user-supplied bytes
     /// (payload exceeded its size cap, or another value-newtype invariant).

--- a/crates/nexus-store/src/error.rs
+++ b/crates/nexus-store/src/error.rs
@@ -55,18 +55,19 @@ pub enum StoreError<A, EncErr, DecErr> {
     #[error("version overflow: cannot advance past u64::MAX")]
     VersionOverflow,
 
-    /// Wire-format failure while synthesizing an envelope for codec decode.
+    /// Failure while synthesizing a fresh envelope for codec decode.
     ///
     /// Reachable only from upcaster-driven paths
     /// ([`EventStore::load_with`](crate::EventStore::load_with),
     /// [`ZeroCopyEventStore::load_with`](crate::ZeroCopyEventStore::load_with)):
     /// after the user's upcast transforms the event, a fresh aligned
     /// envelope is built from the transformed `event_type` + payload via
-    /// [`wire::encode_frame`](crate::wire::encode_frame), and that build can fail
-    /// if the transform produced a `event_type` longer than 65,535 bytes or
-    /// a `payload` longer than `u32::MAX` bytes.
-    #[error("wire-format error: {0}")]
-    Wire(#[source] crate::wire::WireError),
+    /// [`PersistedEnvelope::for_decode`](crate::PersistedEnvelope::for_decode).
+    /// The build can fail at the value-newtype boundary (oversize
+    /// `event_type`/`payload`), the wire encode (`FrameLengthOverflow`),
+    /// or the envelope construction (range invariants).
+    #[error("envelope synthesis error: {0}")]
+    Wire(#[source] crate::envelope::ForDecodeError),
 
     /// Envelope construction rejected user-supplied bytes
     /// (payload exceeded its size cap, or another value-newtype invariant).

--- a/crates/nexus-store/src/lib.rs
+++ b/crates/nexus-store/src/lib.rs
@@ -101,7 +101,9 @@ pub use codec::serde::json::{Json, JsonCodec};
 #[cfg(feature = "serde")]
 pub use codec::serde::{SerdeCodec, SerdeFormat};
 pub use codec::{Decode, Encode};
-pub use envelope::{EnvelopeError, PendingEnvelope, PersistedEnvelope, pending_envelope};
+pub use envelope::{
+    EnvelopeError, ForDecodeError, PendingEnvelope, PersistedEnvelope, pending_envelope,
+};
 pub use error::LoadWithError;
 pub use error::{AppendError, StoreError};
 pub use nexus::Version;

--- a/crates/nexus-store/src/repository.rs
+++ b/crates/nexus-store/src/repository.rs
@@ -345,7 +345,7 @@ impl<S, C> EventStore<S, C> {
                         transformed.event_type(),
                         transformed.payload(),
                     )
-                    .map_err(|e| LoadWithError::Store(StoreError::Wire(e)))?;
+                    .map_err(|e| LoadWithError::Store(StoreError::EnvelopeSynthesis(e)))?;
                     let event: EventOf<A> = <C as Decode<EventOf<A>>>::decode(&codec, &upcast_env)
                         .map_err(|e| LoadWithError::Store(StoreError::Decode(e)))?;
                     r.replay(version, &event)
@@ -641,7 +641,7 @@ impl<S, C> ZeroCopyEventStore<S, C> {
                         transformed.event_type(),
                         transformed.payload(),
                     )
-                    .map_err(|e| LoadWithError::Store(StoreError::Wire(e)))?;
+                    .map_err(|e| LoadWithError::Store(StoreError::EnvelopeSynthesis(e)))?;
                     let event: &EventOf<A> = <C as Decode<EventOf<A>>>::decode(&codec, &upcast_env)
                         .map_err(|e| LoadWithError::Store(StoreError::Decode(e)))?;
                     r.replay(version, event)

--- a/crates/nexus-store/src/state.rs
+++ b/crates/nexus-store/src/state.rs
@@ -212,7 +212,7 @@ where
         // snapshot wire format is *not* the event wire format; this
         // synthesis only carries the bytes through to `decode()`.
         let env = crate::envelope::PersistedEnvelope::for_decode(label.as_str(), &bytes)
-            .map_err(CodecSnapshotStoreError::Wire)?;
+            .map_err(CodecSnapshotStoreError::EnvelopeSynthesis)?;
         let state =
             <C as Decode<S>>::decode(&self.codec, &env).map_err(CodecSnapshotStoreError::Decode)?;
 
@@ -257,7 +257,7 @@ pub enum CodecSnapshotStoreError<S, EncErr, DecErr> {
     /// an envelope for the codec. Practically unreachable for in-budget
     /// labels (≤64 bytes via `Id::to_label`) and snapshot bytes ≤ 4 GiB.
     #[error("envelope synthesis error: {0}")]
-    Wire(#[source] crate::envelope::ForDecodeError),
+    EnvelopeSynthesis(#[source] crate::envelope::ForDecodeError),
 }
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/crates/nexus-store/src/state.rs
+++ b/crates/nexus-store/src/state.rs
@@ -256,8 +256,8 @@ pub enum CodecSnapshotStoreError<S, EncErr, DecErr> {
     /// Wire-format synthesis failed while wrapping the snapshot bytes in
     /// an envelope for the codec. Practically unreachable for in-budget
     /// labels (≤64 bytes via `Id::to_label`) and snapshot bytes ≤ 4 GiB.
-    #[error("wire-format error: {0}")]
-    Wire(#[source] crate::wire::WireError),
+    #[error("envelope synthesis error: {0}")]
+    Wire(#[source] crate::envelope::ForDecodeError),
 }
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/crates/nexus-store/src/testing.rs
+++ b/crates/nexus-store/src/testing.rs
@@ -43,6 +43,11 @@ pub enum InMemoryStoreError {
         #[source]
         source: EnvelopeError,
     },
+
+    /// Stored row carries `schema_version == 0` — structurally corrupt
+    /// (the write path uses `SchemaVersion`, which is `NonZeroU32`).
+    #[error("corrupt schema_version on stored row at version {version}: got 0, must be > 0")]
+    CorruptSchemaVersion { version: u64 },
 }
 
 /// A frame stored in the in-memory database.
@@ -152,10 +157,10 @@ fn encode_pending_to_frame(
 ) -> Result<StoredFrame, AppendError<InMemoryStoreError>> {
     let frame = wire::encode_frame(
         global_seq.as_u64(),
-        env.schema_version(),
-        env.event_type(),
-        env.metadata(),
-        env.payload(),
+        env.schema_version_value(),
+        &env.event_type_value(),
+        &env.payload_value(),
+        env.metadata_value().as_ref(),
     )
     .map_err(|e| AppendError::Store(InMemoryStoreError::Wire(e)))?;
 
@@ -193,12 +198,18 @@ fn frame_to_envelope(frame: &StoredFrame) -> Result<PersistedEnvelope, InMemoryS
             version: frame.version,
         });
     };
-    let schema_version = u32::from_le_bytes([
+    let schema_version_raw = u32::from_le_bytes([
         value[wire::SCHEMA_VERSION_OFFSET],
         value[wire::SCHEMA_VERSION_OFFSET + 1],
         value[wire::SCHEMA_VERSION_OFFSET + 2],
         value[wire::SCHEMA_VERSION_OFFSET + 3],
     ]);
+    let schema_version =
+        crate::value::SchemaVersion::from_u32(schema_version_raw).map_err(|_| {
+            InMemoryStoreError::CorruptSchemaVersion {
+                version: frame.version,
+            }
+        })?;
 
     PersistedEnvelope::try_new(
         version,

--- a/crates/nexus-store/src/value.rs
+++ b/crates/nexus-store/src/value.rs
@@ -126,12 +126,8 @@ impl EventType {
     /// behavior in release builds. The `debug_assert!`s below are
     /// diagnostic-only and compiled out in release.
     ///
-    /// The read path ([`crate::envelope::PersistedEnvelope::event_type_owned`],
-    /// added in a later PR) uses this after `try_new` has already validated.
-    #[expect(
-        dead_code,
-        reason = "wired up by the PersistedEnvelope read-path task later in this PR series"
-    )]
+    /// The read path ([`crate::envelope::PersistedEnvelope::event_type_owned`])
+    /// uses this after `try_new` has already validated.
     pub(crate) unsafe fn from_validated_bytes(bytes: Bytes) -> Self {
         debug_assert!(
             bytes.len() <= MAX_EVENT_TYPE_LEN,
@@ -212,13 +208,9 @@ impl Payload {
     /// this module and to make the invariant obligation visible at call
     /// sites.
     ///
-    /// The read path ([`crate::envelope::PersistedEnvelope::payload_owned`],
-    /// added in a later PR) uses this after the buffer's length has been
-    /// implicitly capped by the wire format's `u32` length field.
-    #[expect(
-        dead_code,
-        reason = "wired up by the PersistedEnvelope read-path task later in this PR series"
-    )]
+    /// The read path ([`crate::envelope::PersistedEnvelope::payload_owned`])
+    /// uses this after the buffer's length has been implicitly capped by
+    /// the wire format's `u32` length field.
     pub(crate) unsafe fn from_validated_bytes(bytes: Bytes) -> Self {
         debug_assert!(
             bytes.len() <= MAX_PAYLOAD_LEN,
@@ -294,13 +286,9 @@ impl Metadata {
     /// `from_validated_bytes` constructors and to make the invariant
     /// obligation visible at call sites.
     ///
-    /// The read path ([`crate::envelope::PersistedEnvelope::metadata_owned`],
-    /// added in a later PR) uses this after the wire decoder has rejected
-    /// the absent sentinel into `Option::None`.
-    #[expect(
-        dead_code,
-        reason = "wired up by the PersistedEnvelope read-path task later in this PR series"
-    )]
+    /// The read path ([`crate::envelope::PersistedEnvelope::metadata_owned`])
+    /// uses this after the wire decoder has rejected the absent sentinel
+    /// into `Option::None`.
     pub(crate) unsafe fn from_validated_bytes(bytes: Bytes) -> Self {
         debug_assert!(
             !bytes.is_empty(),

--- a/crates/nexus-store/src/value.rs
+++ b/crates/nexus-store/src/value.rs
@@ -126,7 +126,7 @@ impl EventType {
     /// behavior in release builds. The `debug_assert!`s below are
     /// diagnostic-only and compiled out in release.
     ///
-    /// The read path ([`crate::envelope::PersistedEnvelope::event_type_owned`])
+    /// The read path ([`crate::envelope::PersistedEnvelope::event_type_value`])
     /// uses this after `try_new` has already validated.
     pub(crate) unsafe fn from_validated_bytes(bytes: Bytes) -> Self {
         debug_assert!(
@@ -208,7 +208,7 @@ impl Payload {
     /// this module and to make the invariant obligation visible at call
     /// sites.
     ///
-    /// The read path ([`crate::envelope::PersistedEnvelope::payload_owned`])
+    /// The read path ([`crate::envelope::PersistedEnvelope::payload_value`])
     /// uses this after the buffer's length has been implicitly capped by
     /// the wire format's `u32` length field.
     pub(crate) unsafe fn from_validated_bytes(bytes: Bytes) -> Self {
@@ -286,7 +286,7 @@ impl Metadata {
     /// `from_validated_bytes` constructors and to make the invariant
     /// obligation visible at call sites.
     ///
-    /// The read path ([`crate::envelope::PersistedEnvelope::metadata_owned`])
+    /// The read path ([`crate::envelope::PersistedEnvelope::metadata_value`])
     /// uses this after the wire decoder has rejected the absent sentinel
     /// into `Option::None`.
     pub(crate) unsafe fn from_validated_bytes(bytes: Bytes) -> Self {

--- a/crates/nexus-store/src/wire.rs
+++ b/crates/nexus-store/src/wire.rs
@@ -465,6 +465,10 @@ fn execute(plan: FramePlan<'_>) -> EncodedFrame {
 
 /// Build one frame buffer with payload aligned to [`PAYLOAD_ALIGN`].
 ///
+/// Argument order: `(global_seq, schema_version, &event_type, &payload, metadata)`.
+/// `payload` precedes `metadata` to keep the optional argument trailing per
+/// Rust API conventions.
+///
 /// Layout:
 ///
 /// ```text

--- a/crates/nexus-store/src/wire.rs
+++ b/crates/nexus-store/src/wire.rs
@@ -18,9 +18,9 @@
 //! `meta_len == u32::MAX` is the absent-metadata sentinel
 //! (distinguishes `None` from `Some(empty)`).
 //!
-//! Pipeline: [`encode_frame`] is `execute(plan(...)?)` — `plan` does all
-//! the validation and layout math (fallible), `execute` does the buffer
-//! fill (infallible). Each stage is independently testable.
+//! Pipeline: [`encode_frame`] is `execute(plan(...)?)` — `plan` does the
+//! layout math (fallible only on `FrameLengthOverflow`), `execute` does
+//! the buffer fill (infallible). Each stage is independently testable.
 //!
 //! # Implicit couplings (deliberate, but worth knowing)
 //!
@@ -35,21 +35,24 @@
 //!   future change to the alignment formula is a wire break — both
 //!   sides must change together.
 //!
-//! # Validation symmetry
+//! # Validation home
 //!
-//! [`encode_frame`] rejects `schema_version == 0` to stay symmetric
-//! with [`crate::envelope::PersistedEnvelope::try_new`], which rejects
-//! the same value on the read path. This mirrors CLAUDE.md §3
-//! ("write-path and read-path must enforce the same invariants the
-//! same way") and §4 ("each crate validates at its own boundary").
-//! [`decode_frame`] itself does *not* reject `schema_version == 0` —
-//! its contract is faithful parsing; semantic validation is the
-//! envelope's job.
+//! All field invariants (`event_type` UTF-8 + size cap, payload size cap,
+//! metadata non-empty + size cap, `schema_version` > 0) are owned by the
+//! value newtypes in [`crate::value`]. By the time bytes reach
+//! [`encode_frame`], they have been validated at the value newtype
+//! boundary, so the only failure mode here is [`WireError::FrameLengthOverflow`]
+//! — pure arithmetic. On the read path, [`decode_frame`] reconstructs
+//! the `schema_version` through [`crate::value::SchemaVersion::from_u32`]
+//! so a corrupt on-disk zero surfaces as [`DecodeError::CorruptSchemaVersion`]
+//! rather than slipping through into a panic-on-conversion downstream.
 
 use aligned_vec::{AVec, ConstAlign};
 use bytes::Bytes;
 use core::ops::Range;
 use thiserror::Error;
+
+use crate::value::{EventType, Metadata, Payload, SchemaVersion};
 
 /// Payload alignment in bytes. Wire-format invariant.
 pub const PAYLOAD_ALIGN: usize = 16;
@@ -72,33 +75,6 @@ pub const META_LEN_OFFSET: usize = 14;
 /// Sentinel `meta_len` value meaning "no metadata field present".
 pub const META_LEN_ABSENT: u32 = u32::MAX;
 
-/// Maximum event-type length (matches the `u16` length-prefix field).
-///
-/// `u16::MAX` widens to `usize` losslessly on every supported target.
-#[allow(
-    clippy::as_conversions,
-    reason = "const-context u16→usize widening; lossless on all targets"
-)]
-const MAX_EVENT_TYPE_LEN: usize = u16::MAX as usize;
-
-/// Maximum metadata length (one less than `u32::MAX`, since `u32::MAX`
-/// is the absent sentinel).
-///
-/// `u32::MAX` widens to `usize` losslessly on 32+ bit targets — the only
-/// supported targets for nexus-store.
-#[allow(
-    clippy::as_conversions,
-    reason = "const-context u32→usize widening; lossless on 32+ bit targets"
-)]
-const MAX_METADATA_LEN: usize = (u32::MAX - 1) as usize;
-
-/// Maximum payload length.
-#[allow(
-    clippy::as_conversions,
-    reason = "const-context u32→usize widening; lossless on 32+ bit targets"
-)]
-const MAX_PAYLOAD_LEN: usize = u32::MAX as usize;
-
 /// Bytes needed after `offset` to reach the next multiple of `align`.
 ///
 /// Returns 0 when `offset` is already aligned. `align` must be a non-zero
@@ -109,95 +85,14 @@ const fn align_padding(offset: usize, align: usize) -> usize {
 }
 
 // ---------------------------------------------------------------------
-// Length newtypes — item 5
-//
-// Each carries the invariant "this length fits in its wire-format field
-// and (for metadata) does not collide with the absent sentinel."
-// Construction via TryFrom<usize> is the only path; the inner getter
-// returns the already-narrowed integer type for direct serialization.
-// ---------------------------------------------------------------------
-
-/// Event-type byte length that fits the wire `u16` field.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct EventTypeLen(u16);
-
-impl EventTypeLen {
-    #[inline]
-    const fn as_u16(self) -> u16 {
-        self.0
-    }
-}
-
-impl TryFrom<usize> for EventTypeLen {
-    type Error = WireError;
-    fn try_from(value: usize) -> Result<Self, Self::Error> {
-        u16::try_from(value)
-            .map(Self)
-            .map_err(|_| WireError::EventTypeTooLong {
-                actual: value,
-                max: MAX_EVENT_TYPE_LEN,
-            })
-    }
-}
-
-/// Metadata byte length that fits the wire `u32` field and is not the
-/// absent sentinel ([`META_LEN_ABSENT`]).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct MetadataLen(u32);
-
-impl MetadataLen {
-    #[inline]
-    const fn as_u32(self) -> u32 {
-        self.0
-    }
-}
-
-impl TryFrom<usize> for MetadataLen {
-    type Error = WireError;
-    fn try_from(value: usize) -> Result<Self, Self::Error> {
-        if value > MAX_METADATA_LEN {
-            return Err(WireError::MetadataTooLong {
-                actual: value,
-                max: MAX_METADATA_LEN,
-            });
-        }
-        u32::try_from(value)
-            .map(Self)
-            .map_err(|_| WireError::MetadataTooLong {
-                actual: value,
-                max: MAX_METADATA_LEN,
-            })
-    }
-}
-
-/// Payload byte length that fits the wire `u32` field.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct PayloadLen(u32);
-
-impl PayloadLen {
-    #[inline]
-    const fn as_u32(self) -> u32 {
-        self.0
-    }
-}
-
-impl TryFrom<usize> for PayloadLen {
-    type Error = WireError;
-    fn try_from(value: usize) -> Result<Self, Self::Error> {
-        u32::try_from(value)
-            .map(Self)
-            .map_err(|_| WireError::PayloadTooLong {
-                actual: value,
-                max: MAX_PAYLOAD_LEN,
-            })
-    }
-}
-
-// ---------------------------------------------------------------------
-// FrameHeader — item 4
+// FrameHeader
 //
 // The four fixed-position fields packed at the start of every frame.
 // `write_into` serializes to exactly 18 bytes; `read_from` is its inverse.
+// Stores `event_type_len`/`metadata_len` directly as the wire-format
+// integer widths (`u16` / `Option<u32>`) — there are no length newtypes
+// to enforce caps because the value newtypes (EventType / Metadata /
+// Payload / SchemaVersion) own those invariants at construction time.
 // ---------------------------------------------------------------------
 
 /// Fixed-position frame header (18 bytes on the wire).
@@ -209,8 +104,8 @@ impl TryFrom<usize> for PayloadLen {
 pub struct FrameHeader {
     pub global_seq: u64,
     pub schema_version: u32,
-    event_type_len: EventTypeLen,
-    metadata_len: Option<MetadataLen>,
+    event_type_len: u16,
+    metadata_len: Option<u32>,
 }
 
 impl FrameHeader {
@@ -221,7 +116,7 @@ impl FrameHeader {
     #[inline]
     #[must_use]
     pub const fn event_type_len(&self) -> u16 {
-        self.event_type_len.as_u16()
+        self.event_type_len
     }
 
     /// Public view of the metadata length as `Option<u32>`. `None` means
@@ -229,20 +124,50 @@ impl FrameHeader {
     #[inline]
     #[must_use]
     pub const fn metadata_len(&self) -> Option<u32> {
-        match self.metadata_len {
-            Some(n) => Some(n.as_u32()),
-            None => None,
+        self.metadata_len
+    }
+
+    /// Construct a header from already-validated raw lengths.
+    ///
+    /// Caller guarantees: `event_type_len` fits in `u16`, and
+    /// `metadata_len` (if `Some`) fits in `u32`. The value newtypes
+    /// (`EventType` / `Metadata`) provide these guarantees by
+    /// construction — they reject byte slices that would not fit the
+    /// wire field at their `from_bytes` constructors.
+    fn from_validated_lengths(
+        global_seq: u64,
+        schema_version: u32,
+        event_type_len: usize,
+        metadata_len: Option<usize>,
+    ) -> Self {
+        #[allow(
+            clippy::expect_used,
+            reason = "validated by EventType::from_bytes invariant: length ≤ u16::MAX"
+        )]
+        let event_type_len_u16 = u16::try_from(event_type_len)
+            .expect("event_type length validated by EventType invariant");
+        let metadata_len_u32 = metadata_len.map(|n| {
+            #[allow(
+                clippy::expect_used,
+                reason = "validated by Metadata::from_bytes invariant: length ≤ MAX_METADATA_LEN"
+            )]
+            let v = u32::try_from(n).expect("metadata length validated by Metadata invariant");
+            v
+        });
+        Self {
+            global_seq,
+            schema_version,
+            event_type_len: event_type_len_u16,
+            metadata_len: metadata_len_u32,
         }
     }
 
     /// Serialize this header into the start of `buf` (writes exactly 18 bytes).
     fn write_into(&self, buf: &mut AVec<u8, ConstAlign<PAYLOAD_ALIGN>>) {
-        let meta_field = self
-            .metadata_len
-            .map_or(META_LEN_ABSENT, MetadataLen::as_u32);
+        let meta_field = self.metadata_len.unwrap_or(META_LEN_ABSENT);
         buf.extend_from_slice(&self.global_seq.to_le_bytes());
         buf.extend_from_slice(&self.schema_version.to_le_bytes());
-        buf.extend_from_slice(&self.event_type_len.as_u16().to_le_bytes());
+        buf.extend_from_slice(&self.event_type_len.to_le_bytes());
         buf.extend_from_slice(&meta_field.to_le_bytes());
     }
 
@@ -274,10 +199,10 @@ impl FrameHeader {
             value[SCHEMA_VERSION_OFFSET + 2],
             value[SCHEMA_VERSION_OFFSET + 3],
         ]);
-        let event_type_len = EventTypeLen(u16::from_le_bytes([
+        let event_type_len = u16::from_le_bytes([
             value[EVENT_TYPE_LEN_OFFSET],
             value[EVENT_TYPE_LEN_OFFSET + 1],
-        ]));
+        ]);
         let meta_field = u32::from_le_bytes([
             value[META_LEN_OFFSET],
             value[META_LEN_OFFSET + 1],
@@ -287,7 +212,7 @@ impl FrameHeader {
         let metadata_len = if meta_field == META_LEN_ABSENT {
             None
         } else {
-            Some(MetadataLen(meta_field))
+            Some(meta_field)
         };
         Ok(Self {
             global_seq,
@@ -304,9 +229,10 @@ impl FrameHeader {
 
 /// Byte layout of one frame: where each field lives and how big the buffer is.
 ///
-/// Produced by [`FrameLayout::compute`] from already-validated length
-/// newtypes; the build path uses every field, the decode path uses only
-/// the padding formula via [`align_padding`].
+/// Produced by [`FrameLayout::compute_from_validated_lengths`] from raw
+/// lengths whose fit-the-wire-field invariant is owned upstream by the
+/// value newtypes. The build path uses every field; the decode path uses
+/// only the padding formula via [`align_padding`].
 #[derive(Debug, Clone)]
 struct FrameLayout {
     event_type: Range<u32>,
@@ -327,59 +253,57 @@ const fn length_overflow(header: usize, padding: usize, payload: usize) -> WireE
 }
 
 impl FrameLayout {
-    /// Compute the layout from validated lengths.
+    /// Compute the layout from already-validated raw lengths.
+    ///
+    /// Callers must guarantee `event_type_len <= u16::MAX`,
+    /// `metadata_len <= u32::MAX - 1` (the absent sentinel is reserved),
+    /// and `payload_len <= u32::MAX`. The value newtypes uphold these
+    /// invariants at construction time.
     ///
     /// # Errors
     ///
     /// Returns [`WireError::FrameLengthOverflow`] if combining the
     /// fields would overflow `usize` on the target platform or any
     /// computed offset would not fit in `u32`.
-    fn compute(
-        event_type_len: EventTypeLen,
-        metadata_len: Option<MetadataLen>,
-        payload_len: PayloadLen,
+    fn compute_from_validated_lengths(
+        event_type_len: usize,
+        metadata_len: Option<usize>,
+        payload_len: usize,
     ) -> Result<Self, WireError> {
-        let et_len = usize::from(event_type_len.as_u16());
-        let meta_len_usize = metadata_len
-            .map(|n| {
-                usize::try_from(n.as_u32()).map_err(|_| length_overflow(HEADER_FIXED_SIZE, 0, 0))
-            })
-            .transpose()?
-            .unwrap_or(0);
-        let pay_len = usize::try_from(payload_len.as_u32())
-            .map_err(|_| length_overflow(HEADER_FIXED_SIZE, 0, 0))?;
+        let meta_len_usize = metadata_len.unwrap_or(0);
 
         let pre_payload_len = HEADER_FIXED_SIZE
-            .checked_add(et_len)
+            .checked_add(event_type_len)
             .and_then(|n| n.checked_add(meta_len_usize))
-            .ok_or_else(|| length_overflow(HEADER_FIXED_SIZE, 0, pay_len))?;
+            .ok_or_else(|| length_overflow(HEADER_FIXED_SIZE, 0, payload_len))?;
 
         let padding = align_padding(pre_payload_len, PAYLOAD_ALIGN);
         let total = pre_payload_len
             .checked_add(padding)
-            .and_then(|n| n.checked_add(pay_len))
-            .ok_or_else(|| length_overflow(pre_payload_len, padding, pay_len))?;
+            .and_then(|n| n.checked_add(payload_len))
+            .ok_or_else(|| length_overflow(pre_payload_len, padding, payload_len))?;
 
-        let overflow = || length_overflow(pre_payload_len, padding, pay_len);
+        let overflow = || length_overflow(pre_payload_len, padding, payload_len);
 
         let event_type_start = u32::try_from(HEADER_FIXED_SIZE).map_err(|_| overflow())?;
+        let event_type_len_u32 = u32::try_from(event_type_len).map_err(|_| overflow())?;
         let event_type_end = event_type_start
-            .checked_add(u32::from(event_type_len.as_u16()))
+            .checked_add(event_type_len_u32)
             .ok_or_else(overflow)?;
 
         let metadata_range = metadata_len
             .map(|n| -> Result<Range<u32>, WireError> {
-                let end = event_type_end
-                    .checked_add(n.as_u32())
-                    .ok_or_else(overflow)?;
+                let n_u32 = u32::try_from(n).map_err(|_| overflow())?;
+                let end = event_type_end.checked_add(n_u32).ok_or_else(overflow)?;
                 Ok(event_type_end..end)
             })
             .transpose()?;
 
         let payload_start_usize = pre_payload_len.checked_add(padding).ok_or_else(overflow)?;
         let payload_start = u32::try_from(payload_start_usize).map_err(|_| overflow())?;
+        let payload_len_u32 = u32::try_from(payload_len).map_err(|_| overflow())?;
         let payload_end = payload_start
-            .checked_add(payload_len.as_u32())
+            .checked_add(payload_len_u32)
             .ok_or_else(overflow)?;
 
         Ok(Self {
@@ -416,20 +340,13 @@ pub struct FrameOffsets {
 }
 
 /// Errors from [`encode_frame`].
+///
+/// The only failure mode is arithmetic overflow when combining lengths.
+/// All field-shape invariants (`event_type` UTF-8 + cap, payload cap,
+/// metadata non-empty + cap, `schema_version` > 0) are upheld at the
+/// value newtype boundary in [`crate::value`].
 #[derive(Debug, Error)]
 pub enum WireError {
-    /// `schema_version == 0` is rejected. Mirrors the read-path check in
-    /// [`crate::envelope::PersistedEnvelope::try_new`] so the two paths
-    /// enforce the same invariant — see CLAUDE.md §4 "Each crate
-    /// validates at its own boundary."
-    #[error("schema_version must be > 0 (got 0)")]
-    InvalidSchemaVersion,
-    #[error("event type length {actual} exceeds maximum {max}")]
-    EventTypeTooLong { actual: usize, max: usize },
-    #[error("metadata length {actual} exceeds maximum {max}")]
-    MetadataTooLong { actual: usize, max: usize },
-    #[error("payload length {actual} exceeds maximum {max}")]
-    PayloadTooLong { actual: usize, max: usize },
     #[error(
         "frame length overflow combining header={header}, padding={padding}, payload={payload}"
     )]
@@ -444,7 +361,7 @@ pub enum WireError {
 #[derive(Debug)]
 pub struct DecodedFrame {
     pub global_seq: u64,
-    pub schema_version: u32,
+    pub schema_version: SchemaVersion,
     pub offsets: FrameOffsets,
 }
 
@@ -459,20 +376,26 @@ pub enum DecodeError {
     MetadataTruncated { meta_len: u32, value_len: usize },
     #[error("computed offset overflows u32 (value len={value_len})")]
     OffsetOverflow { value_len: usize },
+    /// Corrupt on-disk frame with `schema_version == 0`. The build path
+    /// uses [`SchemaVersion`], which makes this value structurally
+    /// unrepresentable — so the only way for a decoder to encounter zero
+    /// is bit-rot, truncation, or tampering of persisted data.
+    #[error("corrupt schema_version on wire: got 0, must be > 0")]
+    CorruptSchemaVersion,
 }
 
 // ---------------------------------------------------------------------
-// FramePlan + plan/execute — item 6
+// FramePlan + plan/execute
 //
-// `plan` does all fallible work (validation + layout math).
+// `plan` does the layout math.
 // `execute` is infallible — given a plan, fill the buffer.
 // ---------------------------------------------------------------------
 
 /// Everything needed to materialize one frame's bytes.
 ///
-/// Construction via [`plan`] guarantees: every length already fits its
-/// wire field, the layout has been computed without overflow, and the
-/// borrowed slices are the body bytes the layout describes.
+/// Construction via [`plan`] guarantees: the layout has been computed
+/// without overflow, and the borrowed slices are the body bytes the
+/// layout describes.
 #[derive(Debug)]
 struct FramePlan<'a> {
     header: FrameHeader,
@@ -482,36 +405,34 @@ struct FramePlan<'a> {
     layout: FrameLayout,
 }
 
-/// Validate inputs and compute the layout for one frame.
+/// Compute the layout and header for one frame from validated value newtypes.
 fn plan<'a>(
     global_seq: u64,
-    schema_version: u32,
-    event_type: &'a str,
-    metadata: Option<&'a [u8]>,
-    payload: &'a [u8],
+    schema_version: SchemaVersion,
+    event_type: &'a EventType,
+    payload: &'a Payload,
+    metadata: Option<&'a Metadata>,
 ) -> Result<FramePlan<'a>, WireError> {
-    if schema_version == 0 {
-        return Err(WireError::InvalidSchemaVersion);
-    }
     let event_type_bytes = event_type.as_bytes();
-    let event_type_len = EventTypeLen::try_from(event_type_bytes.len())?;
-    let metadata_len = metadata
-        .map(|m| MetadataLen::try_from(m.len()))
-        .transpose()?;
-    let payload_len = PayloadLen::try_from(payload.len())?;
+    let metadata_bytes = metadata.map(Metadata::as_slice);
+    let payload_bytes = payload.as_slice();
 
-    let layout = FrameLayout::compute(event_type_len, metadata_len, payload_len)?;
-    let header = FrameHeader {
+    let layout = FrameLayout::compute_from_validated_lengths(
+        event_type_bytes.len(),
+        metadata_bytes.map(<[u8]>::len),
+        payload_bytes.len(),
+    )?;
+    let header = FrameHeader::from_validated_lengths(
         global_seq,
-        schema_version,
-        event_type_len,
-        metadata_len,
-    };
+        schema_version.get(),
+        event_type_bytes.len(),
+        metadata_bytes.map(<[u8]>::len),
+    );
     Ok(FramePlan {
         header,
         event_type_bytes,
-        metadata,
-        payload,
+        metadata: metadata_bytes,
+        payload: payload_bytes,
         layout,
     })
 }
@@ -554,23 +475,29 @@ fn execute(plan: FramePlan<'_>) -> EncodedFrame {
 ///
 /// `meta_len == u32::MAX` is the absent-metadata sentinel.
 ///
+/// All field invariants (UTF-8, size caps, `schema_version` > 0) live on
+/// the value newtypes ([`EventType`], [`Payload`], [`Metadata`],
+/// [`SchemaVersion`]) — by the time inputs reach this function they are
+/// already wire-encodable. The only remaining failure mode is arithmetic
+/// overflow when combining lengths into the final frame size.
+///
 /// # Errors
 ///
-/// Returns [`WireError`] if any field exceeds its maximum length or if
-/// the assembled frame would overflow `usize` on the target platform.
+/// Returns [`WireError::FrameLengthOverflow`] if the assembled frame
+/// would overflow `usize` on the target platform.
 pub fn encode_frame(
     global_seq: u64,
-    schema_version: u32,
-    event_type: &str,
-    metadata: Option<&[u8]>,
-    payload: &[u8],
+    schema_version: SchemaVersion,
+    event_type: &EventType,
+    payload: &Payload,
+    metadata: Option<&Metadata>,
 ) -> Result<EncodedFrame, WireError> {
     Ok(execute(plan(
         global_seq,
         schema_version,
         event_type,
-        metadata,
         payload,
+        metadata,
     )?))
 }
 
@@ -578,6 +505,9 @@ pub fn encode_frame(
 ///
 /// Reads the fixed header, recovers event-type and metadata ranges, and
 /// computes the payload range honoring the 16-byte alignment padding.
+/// The `schema_version` is reconstructed through [`SchemaVersion::from_u32`]
+/// so a corrupt on-disk zero surfaces as
+/// [`DecodeError::CorruptSchemaVersion`].
 ///
 /// # Errors
 ///
@@ -585,9 +515,12 @@ pub fn encode_frame(
 /// - [`DecodeError::EventTypeTruncated`] if the event-type length runs past the buffer.
 /// - [`DecodeError::MetadataTruncated`] if `meta_len` claims bytes past the buffer end.
 /// - [`DecodeError::OffsetOverflow`] if any computed offset would not fit in `u32`.
+/// - [`DecodeError::CorruptSchemaVersion`] if the on-disk `schema_version` is 0.
 pub fn decode_frame(value: &[u8]) -> Result<DecodedFrame, DecodeError> {
     let header = FrameHeader::read_from(value)?;
-    let et_len = usize::from(header.event_type_len.as_u16());
+    let schema_version = SchemaVersion::from_u32(header.schema_version)
+        .map_err(|_| DecodeError::CorruptSchemaVersion)?;
+    let et_len = usize::from(header.event_type_len);
 
     let et_start = HEADER_FIXED_SIZE;
     let et_end = et_start
@@ -606,7 +539,7 @@ pub fn decode_frame(value: &[u8]) -> Result<DecodedFrame, DecodeError> {
         None => (None, et_end),
         Some(meta_len) => {
             let meta_len_usize =
-                usize::try_from(meta_len.as_u32()).map_err(|_| DecodeError::OffsetOverflow {
+                usize::try_from(meta_len).map_err(|_| DecodeError::OffsetOverflow {
                     value_len: value.len(),
                 })?;
             let meta_end =
@@ -617,7 +550,7 @@ pub fn decode_frame(value: &[u8]) -> Result<DecodedFrame, DecodeError> {
                     })?;
             if value.len() < meta_end {
                 return Err(DecodeError::MetadataTruncated {
-                    meta_len: meta_len.as_u32(),
+                    meta_len,
                     value_len: value.len(),
                 });
             }
@@ -660,7 +593,7 @@ pub fn decode_frame(value: &[u8]) -> Result<DecodedFrame, DecodeError> {
 
     Ok(DecodedFrame {
         global_seq: header.global_seq,
-        schema_version: header.schema_version,
+        schema_version,
         offsets: FrameOffsets {
             event_type: et_start_u32..et_end_u32,
             metadata: metadata_range,
@@ -681,6 +614,7 @@ pub fn decode_frame(value: &[u8]) -> Result<DecodedFrame, DecodeError> {
 )]
 mod tests {
     use super::*;
+    use crate::value::{MAX_EVENT_TYPE_LEN, MAX_METADATA_LEN, MAX_PAYLOAD_LEN};
     use proptest::prelude::*;
 
     fn payload_ptr_aligned(frame: &EncodedFrame) -> bool {
@@ -688,6 +622,26 @@ mod tests {
         let end = usize::try_from(frame.offsets.payload.end).expect("u32 fits usize");
         let payload_slice = &frame.value[start..end];
         payload_slice.as_ptr().addr().is_multiple_of(PAYLOAD_ALIGN)
+    }
+
+    /// Build an [`EventType`] from arbitrary bytes for testing.
+    /// Panics on cap violation; tests choose inputs within the cap.
+    fn et(s: &str) -> EventType {
+        EventType::from_bytes(Bytes::copy_from_slice(s.as_bytes())).expect("test event_type valid")
+    }
+
+    /// Build a [`Payload`] from arbitrary bytes for testing.
+    fn pl(b: &[u8]) -> Payload {
+        Payload::from_bytes(Bytes::copy_from_slice(b)).expect("test payload valid")
+    }
+
+    /// Build a [`Metadata`] from arbitrary non-empty bytes for testing.
+    fn md(b: &[u8]) -> Metadata {
+        Metadata::from_bytes(Bytes::copy_from_slice(b)).expect("test metadata non-empty + valid")
+    }
+
+    fn sv1() -> SchemaVersion {
+        SchemaVersion::INITIAL
     }
 
     // -----------------------------------------------------------------
@@ -739,12 +693,10 @@ mod tests {
         ]
     }
 
-    /// Nonzero `schema_version` strategy. `encode_frame` rejects 0 to
-    /// stay symmetric with [`crate::envelope::PersistedEnvelope::try_new`],
-    /// so the `encode_frame`-driving composite below must never generate
-    /// it. Boundaries follow the project's `0/1/MAX-1/MAX via prop_oneof!`
-    /// rule, adjusted for the nonzero domain.
-    fn schema_version_strategy() -> impl Strategy<Value = u32> {
+    /// Nonzero `schema_version` strategy — mirrors the [`SchemaVersion`]
+    /// invariant. Boundaries follow the project's `0/1/MAX-1/MAX via
+    /// prop_oneof!` rule, adjusted for the nonzero domain.
+    fn schema_version_strategy() -> impl Strategy<Value = SchemaVersion> {
         prop_oneof![
             1 => Just(1u32),
             1 => Just(2u32),
@@ -752,6 +704,7 @@ mod tests {
             1 => Just(u32::MAX),
             10 => 1u32..=u32::MAX,
         ]
+        .prop_map(|v| SchemaVersion::from_u32(v).expect("nonzero strategy"))
     }
 
     fn u16_strategy() -> impl Strategy<Value = u16> {
@@ -761,36 +714,6 @@ mod tests {
             1 => Just(u16::MAX - 1),
             1 => Just(u16::MAX),
             10 => any::<u16>(),
-        ]
-    }
-
-    fn event_type_len_strategy() -> impl Strategy<Value = usize> {
-        prop_oneof![
-            1 => Just(0usize),
-            1 => Just(1usize),
-            1 => Just(MAX_EVENT_TYPE_LEN - 1),
-            1 => Just(MAX_EVENT_TYPE_LEN),
-            10 => 0usize..=MAX_EVENT_TYPE_LEN,
-        ]
-    }
-
-    fn metadata_len_strategy() -> impl Strategy<Value = usize> {
-        prop_oneof![
-            1 => Just(0usize),
-            1 => Just(1usize),
-            1 => Just(MAX_METADATA_LEN - 1),
-            1 => Just(MAX_METADATA_LEN),
-            10 => 0usize..=MAX_METADATA_LEN,
-        ]
-    }
-
-    fn payload_len_strategy() -> impl Strategy<Value = usize> {
-        prop_oneof![
-            1 => Just(0usize),
-            1 => Just(1usize),
-            1 => Just(MAX_PAYLOAD_LEN - 1),
-            1 => Just(MAX_PAYLOAD_LEN),
-            10 => 0usize..=MAX_PAYLOAD_LEN,
         ]
     }
 
@@ -822,11 +745,13 @@ mod tests {
     }
 
     fn metadata_bytes_strategy() -> impl Strategy<Value = Option<Vec<u8>>> {
+        // Metadata::from_bytes rejects empty — so when generating Some,
+        // start at length 1 to keep the strategy inside the value-newtype
+        // domain (the wire layer no longer rejects on its own).
         prop_oneof![
             1 => Just(None),
-            1 => Just(Some(Vec::<u8>::new())),
             1 => Just(Some(vec![0u8])),
-            10 => prop::option::of(prop::collection::vec(any::<u8>(), 0..512)),
+            10 => prop::option::of(prop::collection::vec(any::<u8>(), 1..512)),
         ]
     }
 
@@ -848,7 +773,7 @@ mod tests {
             event_type in event_type_str_strategy(),
             metadata in metadata_bytes_strategy(),
             payload in payload_bytes_strategy(),
-        ) -> (u64, u32, String, Option<Vec<u8>>, Vec<u8>) {
+        ) -> (u64, SchemaVersion, String, Option<Vec<u8>>, Vec<u8>) {
             (global_seq, schema_version, event_type, metadata, payload)
         }
     }
@@ -858,8 +783,10 @@ mod tests {
         fn payload_pointer_is_16_aligned(
             (global_seq, schema_version, event_type, metadata, payload) in valid_frame_inputs(),
         ) {
-            let meta_ref = metadata.as_deref();
-            let frame = encode_frame(global_seq, schema_version, &event_type, meta_ref, &payload)
+            let et_v = et(&event_type);
+            let pl_v = pl(&payload);
+            let md_v = metadata.as_deref().map(md);
+            let frame = encode_frame(global_seq, schema_version, &et_v, &pl_v, md_v.as_ref())
                 .expect("encode_frame succeeds on bounded inputs");
             prop_assert!(payload_ptr_aligned(&frame));
         }
@@ -868,8 +795,10 @@ mod tests {
         fn ranges_recover_each_field(
             (global_seq, schema_version, event_type, metadata, payload) in valid_frame_inputs(),
         ) {
-            let meta_ref = metadata.as_deref();
-            let frame = encode_frame(global_seq, schema_version, &event_type, meta_ref, &payload)
+            let et_v = et(&event_type);
+            let pl_v = pl(&payload);
+            let md_v = metadata.as_deref().map(md);
+            let frame = encode_frame(global_seq, schema_version, &et_v, &pl_v, md_v.as_ref())
                 .expect("encode_frame succeeds on bounded inputs");
             let v = &frame.value;
             prop_assert_eq!(
@@ -880,7 +809,7 @@ mod tests {
                 &v[frame.offsets.payload.start as usize..frame.offsets.payload.end as usize],
                 payload.as_slice()
             );
-            if let (Some(meta), Some(range)) = (meta_ref, frame.offsets.metadata) {
+            if let (Some(meta), Some(range)) = (metadata.as_deref(), frame.offsets.metadata) {
                 prop_assert_eq!(
                     &v[range.start as usize..range.end as usize],
                     meta
@@ -892,8 +821,10 @@ mod tests {
         fn header_fields_are_recoverable(
             (global_seq, schema_version, event_type, metadata, payload) in valid_frame_inputs(),
         ) {
-            let meta_ref = metadata.as_deref();
-            let frame = encode_frame(global_seq, schema_version, &event_type, meta_ref, &payload)
+            let et_v = et(&event_type);
+            let pl_v = pl(&payload);
+            let md_v = metadata.as_deref().map(md);
+            let frame = encode_frame(global_seq, schema_version, &et_v, &pl_v, md_v.as_ref())
                 .expect("encode_frame succeeds on bounded inputs");
             let v = &frame.value;
 
@@ -903,7 +834,7 @@ mod tests {
 
             let mut sv_buf = [0u8; 4];
             sv_buf.copy_from_slice(&v[SCHEMA_VERSION_OFFSET..SCHEMA_VERSION_OFFSET + 4]);
-            prop_assert_eq!(u32::from_le_bytes(sv_buf), schema_version);
+            prop_assert_eq!(u32::from_le_bytes(sv_buf), schema_version.get());
 
             let mut et_len_buf = [0u8; 2];
             et_len_buf.copy_from_slice(&v[EVENT_TYPE_LEN_OFFSET..EVENT_TYPE_LEN_OFFSET + 2]);
@@ -912,7 +843,7 @@ mod tests {
             let mut ml_buf = [0u8; 4];
             ml_buf.copy_from_slice(&v[META_LEN_OFFSET..META_LEN_OFFSET + 4]);
             let ml = u32::from_le_bytes(ml_buf);
-            match meta_ref {
+            match metadata.as_deref() {
                 Some(m) => prop_assert_eq!(usize::try_from(ml).unwrap(), m.len()),
                 None => prop_assert_eq!(ml, META_LEN_ABSENT),
             }
@@ -921,36 +852,29 @@ mod tests {
 
     #[test]
     fn empty_payload_still_aligned() {
-        let frame = encode_frame(1, 1, "X", None, &[]).expect("trivial frame builds");
+        let frame = encode_frame(1, sv1(), &et("X"), &pl(b""), None).expect("trivial frame builds");
         assert!(payload_ptr_aligned(&frame));
         assert_eq!(frame.offsets.payload.start, frame.offsets.payload.end);
     }
 
     #[test]
     fn empty_event_type_permitted() {
-        let frame =
-            encode_frame(1, 1, "", None, b"data").expect("empty event_type accepted at wire layer");
+        let frame = encode_frame(1, sv1(), &et(""), &pl(b"data"), None)
+            .expect("empty event_type accepted at wire layer");
         assert!(payload_ptr_aligned(&frame));
     }
 
     #[test]
     fn max_event_type_accepted() {
         let huge = "a".repeat(MAX_EVENT_TYPE_LEN);
-        encode_frame(1, 1, &huge, None, b"d").expect("max-length event_type accepted");
-    }
-
-    #[test]
-    fn over_max_event_type_rejected() {
-        let huge = "a".repeat(MAX_EVENT_TYPE_LEN + 1);
-        assert!(matches!(
-            encode_frame(1, 1, &huge, None, b"d"),
-            Err(WireError::EventTypeTooLong { .. })
-        ));
+        encode_frame(1, sv1(), &et(&huge), &pl(b"d"), None)
+            .expect("max-length event_type accepted");
     }
 
     #[test]
     fn meta_len_u32_max_is_absent_sentinel() {
-        let frame = encode_frame(1, 1, "X", None, b"d").expect("none-metadata frame builds");
+        let frame =
+            encode_frame(1, sv1(), &et("X"), &pl(b"d"), None).expect("none-metadata frame builds");
         let mut ml_buf = [0u8; 4];
         ml_buf.copy_from_slice(&frame.value[META_LEN_OFFSET..META_LEN_OFFSET + 4]);
         assert_eq!(u32::from_le_bytes(ml_buf), META_LEN_ABSENT);
@@ -962,8 +886,10 @@ mod tests {
         fn build_then_decode_round_trips(
             (global_seq, schema_version, event_type, metadata, payload) in valid_frame_inputs(),
         ) {
-            let meta_ref = metadata.as_deref();
-            let frame = encode_frame(global_seq, schema_version, &event_type, meta_ref, &payload)
+            let et_v = et(&event_type);
+            let pl_v = pl(&payload);
+            let md_v = metadata.as_deref().map(md);
+            let frame = encode_frame(global_seq, schema_version, &et_v, &pl_v, md_v.as_ref())
                 .expect("encode_frame succeeds on bounded inputs");
             let decoded = decode_frame(&frame.value).expect("decode_frame succeeds on a built frame");
             prop_assert_eq!(decoded.global_seq, global_seq);
@@ -987,6 +913,7 @@ mod tests {
     fn decode_rejects_truncated_event_type() {
         // Header claims et_len = 100 but no event-type bytes follow.
         let mut buf = vec![0u8; HEADER_FIXED_SIZE];
+        buf[SCHEMA_VERSION_OFFSET..SCHEMA_VERSION_OFFSET + 4].copy_from_slice(&1u32.to_le_bytes());
         buf[EVENT_TYPE_LEN_OFFSET..EVENT_TYPE_LEN_OFFSET + 2]
             .copy_from_slice(&100u16.to_le_bytes());
         buf[META_LEN_OFFSET..META_LEN_OFFSET + 4].copy_from_slice(&META_LEN_ABSENT.to_le_bytes());
@@ -1000,6 +927,7 @@ mod tests {
     fn decode_rejects_truncated_metadata() {
         // Header claims meta_len = 100 but no metadata bytes follow.
         let mut buf = vec![0u8; HEADER_FIXED_SIZE];
+        buf[SCHEMA_VERSION_OFFSET..SCHEMA_VERSION_OFFSET + 4].copy_from_slice(&1u32.to_le_bytes());
         buf[EVENT_TYPE_LEN_OFFSET..EVENT_TYPE_LEN_OFFSET + 2].copy_from_slice(&0u16.to_le_bytes());
         buf[META_LEN_OFFSET..META_LEN_OFFSET + 4].copy_from_slice(&100u32.to_le_bytes());
         assert!(matches!(
@@ -1009,43 +937,24 @@ mod tests {
     }
 
     // -----------------------------------------------------------------
-    // schema_version asymmetry repair — both the build path and
-    // PersistedEnvelope::try_new must reject 0. CLAUDE.md §4 ("each
-    // crate validates at its own boundary") plus §3 ("write-path and
-    // read-path must enforce the same invariants the same way").
+    // schema_version corruption surfacing — read path must reject the
+    // structurally-impossible-to-encode value with a typed error rather
+    // than panicking on the SchemaVersion conversion downstream.
     // -----------------------------------------------------------------
 
     #[test]
-    fn encode_frame_rejects_schema_version_zero() {
-        match encode_frame(1, 0, "Evt", None, b"data") {
-            Err(WireError::InvalidSchemaVersion) => {}
-            other => panic!("expected InvalidSchemaVersion, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn plan_rejects_schema_version_zero() {
-        // plan() is the validation stage — surfacing the variant here
-        // pins the check at the right layer (not in execute()).
-        match plan(1, 0, "Evt", None, b"data") {
-            Err(WireError::InvalidSchemaVersion) => {}
-            other => panic!("expected InvalidSchemaVersion, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn encode_frame_accepts_schema_version_one() {
-        // The minimum valid schema_version. Boundary case for the
-        // newly-introduced rejection — if the off-by-one is wrong,
-        // this test fires.
-        encode_frame(1, 1, "Evt", None, b"data").expect("schema_version=1 is valid");
-    }
-
-    #[test]
-    fn encode_frame_accepts_schema_version_u32_max() {
-        // Upper boundary — encode_frame should accept the entire
-        // nonzero u32 range, not artificially cap below MAX.
-        encode_frame(1, u32::MAX, "Evt", None, b"data").expect("schema_version=u32::MAX is valid");
+    fn decode_rejects_corrupt_schema_version_zero() {
+        // The encoder cannot produce schema_version=0 (its input is
+        // SchemaVersion, which is NonZeroU32). Simulate corrupt disk
+        // bytes by hand-zeroing the header field.
+        let frame = encode_frame(1, sv1(), &et("X"), &pl(b"p"), None).expect("encode");
+        let mut bytes_vec = frame.value.to_vec();
+        bytes_vec[SCHEMA_VERSION_OFFSET..SCHEMA_VERSION_OFFSET + 4].fill(0);
+        let tampered = Bytes::from(bytes_vec);
+        assert!(matches!(
+            decode_frame(&tampered),
+            Err(DecodeError::CorruptSchemaVersion)
+        ));
     }
 
     // -----------------------------------------------------------------
@@ -1181,132 +1090,6 @@ mod tests {
     }
 
     // -----------------------------------------------------------------
-    // Length newtypes — boundary-rich coverage of every invariant
-    // -----------------------------------------------------------------
-
-    // EventTypeLen — fits u16 (max 65535).
-
-    #[test]
-    fn event_type_len_accepts_zero() {
-        let v = EventTypeLen::try_from(0usize).expect("0 accepted");
-        assert_eq!(v.as_u16(), 0);
-    }
-
-    #[test]
-    fn event_type_len_accepts_one() {
-        assert_eq!(EventTypeLen::try_from(1usize).unwrap().as_u16(), 1);
-    }
-
-    #[test]
-    fn event_type_len_accepts_max_minus_one() {
-        assert_eq!(
-            EventTypeLen::try_from(MAX_EVENT_TYPE_LEN - 1)
-                .unwrap()
-                .as_u16(),
-            u16::MAX - 1,
-        );
-    }
-
-    #[test]
-    fn event_type_len_accepts_max() {
-        assert_eq!(
-            EventTypeLen::try_from(MAX_EVENT_TYPE_LEN).unwrap().as_u16(),
-            u16::MAX,
-        );
-    }
-
-    #[test]
-    fn event_type_len_rejects_max_plus_one() {
-        // The error must carry the *actual* offending value, not zero.
-        match EventTypeLen::try_from(MAX_EVENT_TYPE_LEN + 1) {
-            Err(WireError::EventTypeTooLong { actual, max }) => {
-                assert_eq!(actual, MAX_EVENT_TYPE_LEN + 1);
-                assert_eq!(max, MAX_EVENT_TYPE_LEN);
-            }
-            other => panic!("expected EventTypeTooLong, got {other:?}"),
-        }
-    }
-
-    proptest! {
-        #[test]
-        fn event_type_len_round_trip(len in event_type_len_strategy()) {
-            let v = EventTypeLen::try_from(len).expect("valid length");
-            prop_assert_eq!(usize::from(v.as_u16()), len);
-        }
-    }
-
-    // MetadataLen — fits u32 but u32::MAX is reserved as the absent sentinel.
-
-    #[test]
-    fn metadata_len_accepts_zero() {
-        // Some(0) — empty metadata, distinct from None.
-        assert_eq!(MetadataLen::try_from(0usize).unwrap().as_u32(), 0);
-    }
-
-    #[test]
-    fn metadata_len_accepts_max_minus_one() {
-        // MAX_METADATA_LEN - 1 = u32::MAX - 2, well under sentinel.
-        assert_eq!(
-            MetadataLen::try_from(MAX_METADATA_LEN - 1)
-                .unwrap()
-                .as_u32(),
-            u32::MAX - 2,
-        );
-    }
-
-    #[test]
-    fn metadata_len_accepts_max() {
-        // MAX_METADATA_LEN = u32::MAX - 1, the largest value not colliding with sentinel.
-        assert_eq!(
-            MetadataLen::try_from(MAX_METADATA_LEN).unwrap().as_u32(),
-            u32::MAX - 1,
-        );
-    }
-
-    #[test]
-    fn metadata_len_rejects_at_sentinel_value() {
-        // u32::MAX itself = MAX_METADATA_LEN + 1 — reserved as absent sentinel.
-        match MetadataLen::try_from(MAX_METADATA_LEN + 1) {
-            Err(WireError::MetadataTooLong { actual, max }) => {
-                assert_eq!(actual, MAX_METADATA_LEN + 1);
-                assert_eq!(max, MAX_METADATA_LEN);
-            }
-            other => panic!("expected MetadataTooLong, got {other:?}"),
-        }
-    }
-
-    proptest! {
-        #[test]
-        fn metadata_len_round_trip(len in metadata_len_strategy()) {
-            let v = MetadataLen::try_from(len).expect("valid length");
-            prop_assert_eq!(usize::try_from(v.as_u32()).unwrap(), len);
-        }
-    }
-
-    // PayloadLen — fits u32.
-
-    #[test]
-    fn payload_len_accepts_zero() {
-        assert_eq!(PayloadLen::try_from(0usize).unwrap().as_u32(), 0);
-    }
-
-    #[test]
-    fn payload_len_accepts_max() {
-        assert_eq!(
-            PayloadLen::try_from(MAX_PAYLOAD_LEN).unwrap().as_u32(),
-            u32::MAX,
-        );
-    }
-
-    proptest! {
-        #[test]
-        fn payload_len_round_trip(len in payload_len_strategy()) {
-            let v = PayloadLen::try_from(len).expect("valid length");
-            prop_assert_eq!(usize::try_from(v.as_u32()).unwrap(), len);
-        }
-    }
-
-    // -----------------------------------------------------------------
     // FrameHeader
     // -----------------------------------------------------------------
 
@@ -1320,8 +1103,8 @@ mod tests {
         let header = FrameHeader {
             global_seq: 0x0102_0304_0506_0708,
             schema_version: 0x090A_0B0C,
-            event_type_len: EventTypeLen(0x0D0E),
-            metadata_len: Some(MetadataLen(0x0F10_1112)),
+            event_type_len: 0x0D0E,
+            metadata_len: Some(0x0F10_1112),
         };
         let mut buf = fresh_buf();
         header.write_into(&mut buf);
@@ -1355,7 +1138,7 @@ mod tests {
         let header = FrameHeader {
             global_seq: 1,
             schema_version: 1,
-            event_type_len: EventTypeLen(0),
+            event_type_len: 0,
             metadata_len: None,
         };
         let mut buf = fresh_buf();
@@ -1376,8 +1159,8 @@ mod tests {
         let with_empty = FrameHeader {
             global_seq: 1,
             schema_version: 1,
-            event_type_len: EventTypeLen(0),
-            metadata_len: Some(MetadataLen(0)),
+            event_type_len: 0,
+            metadata_len: Some(0),
         };
         let mut buf = fresh_buf();
         with_empty.write_into(&mut buf);
@@ -1387,7 +1170,7 @@ mod tests {
         assert_ne!(u32::from_le_bytes(ml), META_LEN_ABSENT);
 
         let read = FrameHeader::read_from(&buf).expect("read back");
-        assert_eq!(read.metadata_len.map(MetadataLen::as_u32), Some(0));
+        assert_eq!(read.metadata_len, Some(0));
     }
 
     #[test]
@@ -1413,8 +1196,8 @@ mod tests {
         let header = FrameHeader::read_from(&buf).expect("accepts at SIZE");
         assert_eq!(header.global_seq, 0);
         assert_eq!(header.schema_version, 0);
-        assert_eq!(header.event_type_len.as_u16(), 0);
-        assert_eq!(header.metadata_len.map(MetadataLen::as_u32), Some(0));
+        assert_eq!(header.event_type_len, 0);
+        assert_eq!(header.metadata_len, Some(0));
     }
 
     proptest! {
@@ -1428,14 +1211,14 @@ mod tests {
             // meta_choice selects: None, Some(0), Some(MAX-1=u32::MAX-2), Some(arbitrary <= u32::MAX-1).
             let metadata_len = match meta_choice {
                 0 => None,
-                1 => Some(MetadataLen(0)),
-                2 => Some(MetadataLen(u32::MAX - 2)),
-                _ => Some(MetadataLen((u32::MAX - 1) / 2)),
+                1 => Some(0u32),
+                2 => Some(u32::MAX - 2),
+                _ => Some((u32::MAX - 1) / 2),
             };
             let original = FrameHeader {
                 global_seq,
                 schema_version,
-                event_type_len: EventTypeLen(et_raw),
+                event_type_len: et_raw,
                 metadata_len,
             };
             let mut buf = fresh_buf();
@@ -1445,11 +1228,8 @@ mod tests {
             let read = FrameHeader::read_from(&buf).expect("round-trip read");
             prop_assert_eq!(read.global_seq, original.global_seq);
             prop_assert_eq!(read.schema_version, original.schema_version);
-            prop_assert_eq!(read.event_type_len.as_u16(), original.event_type_len.as_u16());
-            prop_assert_eq!(
-                read.metadata_len.map(MetadataLen::as_u32),
-                original.metadata_len.map(MetadataLen::as_u32),
-            );
+            prop_assert_eq!(read.event_type_len, original.event_type_len);
+            prop_assert_eq!(read.metadata_len, original.metadata_len);
         }
     }
 
@@ -1462,12 +1242,7 @@ mod tests {
         // Anchored example to nail down the exact arithmetic the
         // proptest checks structurally: pre_payload = 18 + 2 = 20;
         // padding = 12; payload starts at 32.
-        let layout = FrameLayout::compute(
-            EventTypeLen::try_from(2usize).unwrap(),
-            None,
-            PayloadLen::try_from(1usize).unwrap(),
-        )
-        .expect("ok");
+        let layout = FrameLayout::compute_from_validated_lengths(2, None, 1).expect("ok");
         assert_eq!(layout.padding, 12);
         assert_eq!(layout.event_type, 18..20);
         assert_eq!(layout.metadata, None);
@@ -1478,12 +1253,7 @@ mod tests {
     #[test]
     fn layout_concrete_with_metadata_example() {
         // pre_payload = 18 + 2 + 3 = 23; padding = 9; payload starts at 32.
-        let layout = FrameLayout::compute(
-            EventTypeLen::try_from(2usize).unwrap(),
-            Some(MetadataLen::try_from(3usize).unwrap()),
-            PayloadLen::try_from(4usize).unwrap(),
-        )
-        .expect("ok");
+        let layout = FrameLayout::compute_from_validated_lengths(2, Some(3), 4).expect("ok");
         assert_eq!(layout.event_type, 18..20);
         assert_eq!(layout.metadata, Some(20..23));
         assert_eq!(layout.padding, 9);
@@ -1500,10 +1270,14 @@ mod tests {
         ) {
             // Cap event_type at its actual ceiling.
             let et_len = et_len_raw.min(MAX_EVENT_TYPE_LEN);
-            let layout = FrameLayout::compute(
-                EventTypeLen::try_from(et_len).unwrap(),
-                meta.map(|n| MetadataLen::try_from(n).unwrap()),
-                PayloadLen::try_from(payload_len).unwrap(),
+            // Cap metadata at its actual ceiling.
+            let meta_capped = meta.map(|n| n.min(MAX_METADATA_LEN));
+            // Cap payload at its actual ceiling.
+            let payload_len_capped = payload_len.min(MAX_PAYLOAD_LEN);
+            let layout = FrameLayout::compute_from_validated_lengths(
+                et_len,
+                meta_capped,
+                payload_len_capped,
             ).expect("bounded inputs compute");
 
             // I1: event_type starts immediately after the fixed header.
@@ -1517,7 +1291,7 @@ mod tests {
                 (layout.event_type.end - layout.event_type.start) as usize,
                 et_len,
             );
-            match (meta, layout.metadata.clone()) {
+            match (meta_capped, layout.metadata.clone()) {
                 (None, None) => {},
                 (Some(meta_len), Some(range)) => {
                     prop_assert_eq!((range.end - range.start) as usize, meta_len);
@@ -1526,7 +1300,7 @@ mod tests {
             }
             prop_assert_eq!(
                 (layout.payload.end - layout.payload.start) as usize,
-                payload_len,
+                payload_len_capped,
             );
 
             // I3: ranges are non-overlapping and properly ordered.
@@ -1551,9 +1325,9 @@ mod tests {
 
             // I7: total accounts exactly for header + bodies + padding.
             let body_total = et_len
-                + meta.unwrap_or(0)
+                + meta_capped.unwrap_or(0)
                 + layout.padding
-                + payload_len;
+                + payload_len_capped;
             prop_assert_eq!(layout.total, HEADER_FIXED_SIZE + body_total);
         }
     }
@@ -1565,74 +1339,30 @@ mod tests {
     #[test]
     fn plan_then_execute_matches_encode_frame_concrete() {
         // Anchored equivalence; the proptest below generalizes.
-        let one_shot = encode_frame(7, 2, "Evt", Some(b"meta"), b"payload").expect("ok");
-        let staged = execute(plan(7, 2, "Evt", Some(b"meta"), b"payload").expect("plan ok"));
+        let sv = SchemaVersion::from_u32(2).expect("nonzero");
+        let et_v = et("Evt");
+        let pl_v = pl(b"payload");
+        let md_v = md(b"meta");
+        let one_shot = encode_frame(7, sv, &et_v, &pl_v, Some(&md_v)).expect("ok");
+        let staged = execute(plan(7, sv, &et_v, &pl_v, Some(&md_v)).expect("plan ok"));
         assert_eq!(one_shot.value.as_ref(), staged.value.as_ref());
         assert_eq!(one_shot.offsets.event_type, staged.offsets.event_type);
         assert_eq!(one_shot.offsets.metadata, staged.offsets.metadata);
         assert_eq!(one_shot.offsets.payload, staged.offsets.payload);
     }
 
-    // plan() must surface each WireError variant from the right input.
-
-    #[test]
-    fn plan_surfaces_event_type_too_long() {
-        let huge = "a".repeat(MAX_EVENT_TYPE_LEN + 1);
-        match plan(1, 1, &huge, None, b"") {
-            Err(WireError::EventTypeTooLong { actual, max }) => {
-                assert_eq!(actual, MAX_EVENT_TYPE_LEN + 1);
-                assert_eq!(max, MAX_EVENT_TYPE_LEN);
-            }
-            other => panic!("expected EventTypeTooLong, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn plan_surfaces_metadata_too_long_at_sentinel() {
-        // Building a real u32::MAX-byte slice is infeasible — but we can
-        // verify the error path via the newtype which is what plan() uses.
-        // The "encode_frame at the sentinel" route is checked indirectly.
-        match MetadataLen::try_from(MAX_METADATA_LEN + 1) {
-            Err(WireError::MetadataTooLong { actual, max }) => {
-                assert_eq!(actual, MAX_METADATA_LEN + 1);
-                assert_eq!(max, MAX_METADATA_LEN);
-            }
-            other => panic!("expected MetadataTooLong from newtype, got {other:?}"),
-        }
-    }
-
-    #[cfg(target_pointer_width = "64")]
-    #[test]
-    fn plan_surfaces_payload_too_long_via_newtype() {
-        // The newtype is the single point of payload-length validation
-        // plan() relies on. Building a real u32::MAX+1-byte slice is
-        // infeasible; we exercise the rejection path through the same
-        // type plan() uses.
-        //
-        // On 32-bit platforms there is no usize > MAX_PAYLOAD_LEN, so
-        // the rejection path is structurally unreachable there and the
-        // test is gated to 64-bit pointer widths.
-        let over_max: usize = usize::MAX;
-        match PayloadLen::try_from(over_max) {
-            Err(WireError::PayloadTooLong { actual, max }) => {
-                assert!(actual > MAX_PAYLOAD_LEN);
-                assert_eq!(max, MAX_PAYLOAD_LEN);
-            }
-            other => panic!("expected PayloadTooLong, got {other:?}"),
-        }
-    }
-
     // execute() invariants.
 
     #[test]
     fn execute_buffer_length_equals_layout_total() {
-        for (et, meta, payload) in [
-            ("", None::<&[u8]>, b"" as &[u8]),
-            ("X", None, b""),
-            ("Evt", Some(b"meta".as_slice()), b"payload"),
-            ("LongerType", Some(b"".as_slice()), b"x"),
-        ] {
-            let p = plan(1, 1, et, meta, payload).expect("plan ok");
+        let cases: Vec<(EventType, Option<Metadata>, Payload)> = vec![
+            (et(""), None, pl(b"")),
+            (et("X"), None, pl(b"")),
+            (et("Evt"), Some(md(b"meta")), pl(b"payload")),
+            (et("LongerType"), Some(md(b"x")), pl(b"x")),
+        ];
+        for (et_v, md_v, pl_v) in cases {
+            let p = plan(1, sv1(), &et_v, &pl_v, md_v.as_ref()).expect("plan ok");
             let total = p.layout.total;
             let frame = execute(p);
             assert_eq!(frame.value.len(), total);
@@ -1642,7 +1372,7 @@ mod tests {
     #[test]
     fn execute_padding_bytes_are_zero() {
         // Choose inputs where padding > 0: 18 + 1 (et) = 19, padding = 13.
-        let frame = encode_frame(1, 1, "x", None, b"payload").expect("ok");
+        let frame = encode_frame(1, sv1(), &et("x"), &pl(b"payload"), None).expect("ok");
         let pad_start = usize::try_from(frame.offsets.event_type.end).unwrap();
         let pad_end = usize::try_from(frame.offsets.payload.start).unwrap();
         assert!(pad_end > pad_start, "expected at least one padding byte");
@@ -1662,12 +1392,14 @@ mod tests {
         fn plan_execute_equals_encode_frame(
             (global_seq, schema_version, event_type, metadata, payload) in valid_frame_inputs(),
         ) {
-            let meta_ref = metadata.as_deref();
+            let et_v = et(&event_type);
+            let pl_v = pl(&payload);
+            let md_v = metadata.as_deref().map(md);
             let one_shot = encode_frame(
-                global_seq, schema_version, &event_type, meta_ref, &payload,
+                global_seq, schema_version, &et_v, &pl_v, md_v.as_ref(),
             ).expect("valid inputs encode");
             let staged = execute(
-                plan(global_seq, schema_version, &event_type, meta_ref, &payload)
+                plan(global_seq, schema_version, &et_v, &pl_v, md_v.as_ref())
                     .expect("valid inputs plan"),
             );
             // Whole-buffer equality is the strongest equivalence.
@@ -1681,8 +1413,10 @@ mod tests {
         fn execute_invariants(
             (global_seq, schema_version, event_type, metadata, payload) in valid_frame_inputs(),
         ) {
-            let meta_ref = metadata.as_deref();
-            let p = plan(global_seq, schema_version, &event_type, meta_ref, &payload)
+            let et_v = et(&event_type);
+            let pl_v = pl(&payload);
+            let md_v = metadata.as_deref().map(md);
+            let p = plan(global_seq, schema_version, &et_v, &pl_v, md_v.as_ref())
                 .expect("valid inputs plan");
             let layout_total = p.layout.total;
             let event_type_range = p.layout.event_type.clone();
@@ -1702,7 +1436,7 @@ mod tests {
             let et_start = usize::try_from(event_type_range.start).unwrap();
             let et_end = usize::try_from(event_type_range.end).unwrap();
             prop_assert_eq!(&frame.value[et_start..et_end], event_type.as_bytes());
-            if let (Some(range), Some(meta)) = (metadata_range.clone(), meta_ref) {
+            if let (Some(range), Some(meta)) = (metadata_range.clone(), metadata.as_deref()) {
                 let s = usize::try_from(range.start).unwrap();
                 let e = usize::try_from(range.end).unwrap();
                 prop_assert_eq!(&frame.value[s..e], meta);
@@ -1719,5 +1453,37 @@ mod tests {
                 prop_assert_eq!(*byte, 0u8);
             }
         }
+    }
+
+    // -----------------------------------------------------------------
+    // Value-newtype input acceptance + corrupt-disk schema_version
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn encode_frame_accepts_value_newtypes() {
+        let et_v = EventType::from_static_str("UserCreated");
+        let payload = Payload::from_bytes(Bytes::from_static(b"hello")).expect("valid");
+        let metadata = Metadata::from_bytes(Bytes::from_static(b"m")).expect("valid");
+        let sv = SchemaVersion::INITIAL;
+        let frame = encode_frame(1, sv, &et_v, &payload, Some(&metadata)).expect("valid frame");
+        let decoded = decode_frame(&frame.value).expect("decodes");
+        assert_eq!(decoded.global_seq, 1);
+        assert_eq!(decoded.schema_version, sv);
+    }
+
+    #[test]
+    fn decode_frame_rejects_corrupt_schema_version_zero() {
+        // Hand-craft a frame with schema_version=0 on the wire, simulating
+        // corrupt on-disk data. Going through encode_frame with a
+        // SchemaVersion is structurally impossible.
+        let et_v = EventType::from_static_str("X");
+        let payload = Payload::from_bytes(Bytes::from_static(b"p")).expect("valid");
+        let sv_one = SchemaVersion::INITIAL;
+        let frame = encode_frame(1, sv_one, &et_v, &payload, None).expect("valid frame for tamper");
+        let mut bytes_vec = frame.value.to_vec();
+        bytes_vec[SCHEMA_VERSION_OFFSET..SCHEMA_VERSION_OFFSET + 4].fill(0);
+        let tampered = Bytes::from(bytes_vec);
+        let err = decode_frame(&tampered).expect_err("schema_version=0 on wire rejected");
+        assert!(matches!(err, DecodeError::CorruptSchemaVersion));
     }
 }

--- a/crates/nexus-store/tests/adversarial_property_tests.rs
+++ b/crates/nexus-store/tests/adversarial_property_tests.rs
@@ -66,6 +66,7 @@ use std::fmt;
 use std::sync::Arc;
 
 use arrayvec::ArrayString;
+use bytes::Bytes;
 use futures::StreamExt;
 use nexus::Version;
 use nexus_store::InMemoryStoreError;
@@ -78,6 +79,8 @@ use nexus_store::pending_envelope;
 use nexus_store::store::{GlobalSeq, RawEventStore};
 use nexus_store::testing::InMemoryStore;
 use nexus_store::upcasting::EventMorsel;
+use nexus_store::value::{EventType, Metadata, Payload, SchemaVersion};
+use nexus_store::wire;
 
 use proptest::prelude::*;
 
@@ -2039,5 +2042,55 @@ proptest! {
             prop_assert_eq!(loaded.state().events_applied, u64::try_from(n + 1).unwrap());
             Ok(())
         })?;
+    }
+}
+
+// 25. Wire+envelope round-trip through the typed value-newtype accessors.
+//
+// Closes the loop the validate-once design rests on: arbitrary
+// well-formed value newtypes → wire::encode_frame → wire::decode_frame →
+// PersistedEnvelope::try_new → owned-value accessors → equality with
+// the originals. Asserts the read-path accessors recover the same bytes
+// the write-path injected, across the encode/decode boundary.
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(256))]
+
+    #[test]
+    fn wire_roundtrip_through_value_accessors_preserves_values(
+        et in "[a-zA-Z][a-zA-Z0-9_]{0,63}",
+        payload in proptest::collection::vec(any::<u8>(), 0..4096),
+        meta in proptest::collection::vec(any::<u8>(), 1..4096),
+    ) {
+        let event_type = EventType::from_bytes(Bytes::from(et.clone().into_bytes()))
+            .expect("valid event type by strategy");
+        let payload_v = Payload::from_bytes(Bytes::from(payload.clone()))
+            .expect("valid payload by strategy");
+        let metadata_v = Metadata::from_bytes(Bytes::from(meta.clone()))
+            .expect("valid metadata by strategy");
+        let sv = SchemaVersion::INITIAL;
+
+        let frame = wire::encode_frame(1, sv, &event_type, &payload_v, Some(&metadata_v))
+            .expect("encode_frame succeeds on validated newtypes");
+
+        let decoded = wire::decode_frame(&frame.value)
+            .expect("decode_frame succeeds on a freshly encoded frame");
+
+        let env = PersistedEnvelope::try_new(
+            Version::INITIAL,
+            GlobalSeq::new(1).expect("nonzero"),
+            frame.value,
+            decoded.schema_version,
+            decoded.offsets.event_type,
+            decoded.offsets.payload,
+            decoded.offsets.metadata,
+        )
+        .expect("try_new succeeds with offsets from decode_frame");
+
+        let recovered_event_type = env.event_type_value();
+        let recovered_payload = env.payload_value();
+        let recovered_metadata = env.metadata_value().expect("metadata present");
+        prop_assert_eq!(recovered_event_type.as_str(), et.as_str());
+        prop_assert_eq!(recovered_payload.as_slice(), payload.as_slice());
+        prop_assert_eq!(recovered_metadata.as_slice(), meta.as_slice());
     }
 }

--- a/crates/nexus-store/tests/adversarial_property_tests.rs
+++ b/crates/nexus-store/tests/adversarial_property_tests.rs
@@ -94,11 +94,13 @@ fn build_persisted(
     let value = bytes::Bytes::from(buf);
     let et_end = u32::try_from(event_type.len()).expect("event_type fits u32");
     let pl_end = u32::try_from(event_type.len() + payload.len()).expect("payload fits u32");
+    let sv = nexus_store::value::SchemaVersion::from_u32(schema_version)
+        .expect("test fixture schema_version nonzero");
     PersistedEnvelope::try_new(
         version,
         global_seq,
         value,
-        schema_version,
+        sv,
         0..et_end,
         et_end..pl_end,
         None,
@@ -360,34 +362,25 @@ fn schema_version_strategy() -> impl Strategy<Value = u32> {
 }
 
 // ============================================================================
-// ATTACK 1: PersistedEnvelope schema_version=0 MUST panic/error
+// ATTACK 1: schema_version=0 is structurally unrepresentable
 // ============================================================================
+//
+// `PersistedEnvelope::try_new` now takes `SchemaVersion` (NonZeroU32) — zero
+// can't be constructed, so the entire "ATTACK" surface lives on
+// `SchemaVersion::from_u32`. The wire-decode side is pinned in
+// `nexus_store::wire::tests::decode_frame_rejects_corrupt_schema_version_zero`.
 
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(256))]
 
     #[test]
-    fn attack_persisted_envelope_try_new_rejects_zero(
-        version in 1..1000u64,
-        event_type in "[A-Z]{1,10}",
-        payload in prop::collection::vec(any::<u8>(), 0..100),
+    fn attack_schema_version_from_u32_rejects_zero(
+        _ignored in 0u32..1,
     ) {
-        let mut buf = Vec::with_capacity(event_type.len() + payload.len());
-        buf.extend_from_slice(event_type.as_bytes());
-        buf.extend_from_slice(&payload);
-        let value = bytes::Bytes::from(buf);
-        let et_end = u32::try_from(event_type.len()).unwrap();
-        let pl_end = u32::try_from(event_type.len() + payload.len()).unwrap();
-        let result = PersistedEnvelope::try_new(
-            Version::new(version).unwrap(),
-            GlobalSeq::INITIAL,
-            value,
-            0, // ATTACK
-            0..et_end,
-            et_end..pl_end,
-            None,
-        );
-        prop_assert!(result.is_err(), "try_new with schema_version=0 must return Err");
+        // SchemaVersion::from_u32(0) is the only construction surface for
+        // raw u32 inputs. Verify rejection.
+        let result = nexus_store::value::SchemaVersion::from_u32(0);
+        prop_assert!(result.is_err(), "SchemaVersion::from_u32(0) must return Err");
     }
 }
 
@@ -1474,9 +1467,9 @@ proptest! {
         schema_version in schema_version_strategy(),
     ) {
         if schema_version == 0 {
-            // try_new must return Err for schema_version=0
-            let result = PersistedEnvelope::try_new(Version::new(1).unwrap(), GlobalSeq::INITIAL, bytes::Bytes::from_static(b"E"), 0, 0..1, 1..1, None);
-            prop_assert!(result.is_err(), "try_new(schema_version=0) must error");
+            // SchemaVersion::from_u32(0) errors — try_new can't even be called.
+            let result = nexus_store::value::SchemaVersion::from_u32(schema_version);
+            prop_assert!(result.is_err(), "SchemaVersion::from_u32(0) must error");
         } else {
             // Must succeed
             let env = build_persisted(Version::new(1).unwrap(), GlobalSeq::INITIAL, "E", schema_version, &[]);

--- a/crates/nexus-store/tests/adversarial_tests.rs
+++ b/crates/nexus-store/tests/adversarial_tests.rs
@@ -46,7 +46,7 @@ fn build_persisted(
         version,
         global_seq,
         value,
-        1,
+        nexus_store::value::SchemaVersion::INITIAL,
         0..et_end,
         et_end..pl_end,
         None,

--- a/crates/nexus-store/tests/bug_hunt_tests.rs
+++ b/crates/nexus-store/tests/bug_hunt_tests.rs
@@ -55,7 +55,7 @@ fn build_persisted(
         version,
         global_seq,
         value,
-        1,
+        nexus_store::value::SchemaVersion::INITIAL,
         0..et_end,
         et_end..pl_end,
         None,

--- a/crates/nexus-store/tests/envelope_tests.rs
+++ b/crates/nexus-store/tests/envelope_tests.rs
@@ -6,6 +6,7 @@ use nexus::Version;
 use nexus_store::envelope::{EnvelopeError, PersistedEnvelope};
 use nexus_store::pending_envelope;
 use nexus_store::store::GlobalSeq;
+use nexus_store::value::SchemaVersion;
 
 fn make_persisted(
     version: Version,
@@ -19,11 +20,12 @@ fn make_persisted(
     let value = Bytes::from(buf);
     let et_end = u32::try_from(event_type.len()).expect("fits");
     let pl_end = u32::try_from(event_type.len() + payload.len()).expect("fits");
+    let sv = SchemaVersion::from_u32(schema_version).expect("nonzero test fixture");
     PersistedEnvelope::try_new(
         version,
         GlobalSeq::INITIAL,
         value,
-        schema_version,
+        sv,
         0..et_end,
         et_end..pl_end,
         None,
@@ -88,7 +90,7 @@ fn persisted_envelope_metadata_bytes() {
         Version::new(1).unwrap(),
         GlobalSeq::INITIAL,
         value,
-        1,
+        SchemaVersion::INITIAL,
         0..et_end,
         et_end..pl_end,
         Some(pl_end..meta_end),
@@ -147,23 +149,10 @@ fn build_without_metadata_has_no_metadata() {
 // PersistedEnvelope::try_new() tests
 // =============================================================================
 
-#[test]
-fn try_new_rejects_zero_schema_version() {
-    let result = PersistedEnvelope::try_new(
-        Version::new(1).unwrap(),
-        GlobalSeq::INITIAL,
-        Bytes::from_static(b"Epayload"),
-        0,
-        0..1,
-        1..8,
-        None,
-    );
-    assert!(result.is_err());
-    assert!(matches!(
-        result.unwrap_err(),
-        EnvelopeError::InvalidSchemaVersion
-    ));
-}
+// Note: `try_new` no longer takes a raw `u32` schema_version — the `SchemaVersion`
+// newtype makes zero structurally unrepresentable. The corrupt-on-disk zero case
+// is now surfaced one layer down by `wire::decode_frame`, pinned in
+// `wire::tests::decode_frame_rejects_corrupt_schema_version_zero`.
 
 #[test]
 fn try_new_accepts_valid_schema_version() {
@@ -184,7 +173,7 @@ fn try_new_rejects_out_of_bounds_range() {
         Version::new(1).unwrap(),
         GlobalSeq::INITIAL,
         Bytes::from_static(b"E"),
-        1,
+        SchemaVersion::INITIAL,
         0..100, // ATTACK: range beyond buffer
         100..100,
         None,
@@ -204,7 +193,7 @@ fn try_new_rejects_invalid_utf8_event_type() {
         Version::new(1).unwrap(),
         GlobalSeq::INITIAL,
         value,
-        1,
+        SchemaVersion::INITIAL,
         0..2, // invalid UTF-8 bytes as event_type
         2..3,
         None,

--- a/crates/nexus-store/tests/security_tests.rs
+++ b/crates/nexus-store/tests/security_tests.rs
@@ -289,7 +289,7 @@ fn store_error_variants_are_known() {
         StoreError::Adapter(_) => {}
         StoreError::Kernel(_) => {}
         StoreError::VersionOverflow => {} // If you add a variant, add it here
-        StoreError::Wire(_) => {}
+        StoreError::EnvelopeSynthesis(_) => {}
         StoreError::Envelope(_) => {}
     }
 }

--- a/crates/nexus-store/tests/stream_alloc_tests.rs
+++ b/crates/nexus-store/tests/stream_alloc_tests.rs
@@ -183,7 +183,7 @@ impl futures::Stream for VecStream {
             Version::new(row.version).expect("non-zero"),
             GlobalSeq::INITIAL,
             row.value,
-            1,
+            nexus_store::value::SchemaVersion::INITIAL,
             row.event_type_range,
             row.payload_range,
             None,


### PR DESCRIPTION
## Summary
- `wire::encode_frame` takes `(u64, SchemaVersion, &EventType, &Payload, Option<&Metadata>)` — no more raw bytes, no wire-side validation. Argument order: `payload` precedes `metadata` (optional trails per Rust convention).
- `wire::decode_frame` returns `DecodedFrame { schema_version: SchemaVersion, ... }`; gains `DecodeError::CorruptSchemaVersion` for the on-disk `schema_version=0` case.
- Deleted `EventTypeLen`, `MetadataLen`, `PayloadLen` newtypes from `wire.rs`.
- Deleted `WireError::{EventTypeTooLong, MetadataTooLong, PayloadTooLong, InvalidSchemaVersion}` — only `FrameLengthOverflow` remains.
- Deleted `EnvelopeError::InvalidSchemaVersion` — `PersistedEnvelope::try_new` takes `SchemaVersion` and the check is structurally unreachable.
- Added new `EnvelopeError` per-field cap variants (`EventTypeRangeTooLong`, `MetadataRangeTooLong`, `MetadataRangeEmpty`) so the value-newtype `SAFETY` claims on the new read-path accessors are structural, not upstream-trust.
- `PersistedEnvelope` gains `event_type_value()`, `payload_value()`, `metadata_value()` (validated value newtypes, one Arc share over the underlying buffer), plus `schema_version_value()` and a now-total `schema_version_as_version()`.
- `PersistedEnvelope::for_decode` now returns a new `ForDecodeError` enum combining `ValueError`, `WireError`, `EnvelopeError` via `#[from]`.
- `nexus-fjall::EncodeError` loses the size-cap and `InvalidSchemaVersion` variants and gains `Value(ValueError)` — wire-level checks are now value-newtype checks at the boundary.
- `StoreError::Wire` / `CodecSnapshotStoreError::Wire` renamed to `EnvelopeSynthesis` (variant now wraps the widened `ForDecodeError`, so the old name was misleading).

PR3 of the value-newtype refactor (depends on #187, #188 — both merged).

## Breaking changes
- `wire::encode_frame` signature change (typed inputs; argument order rearranged).
- `wire::decode_frame` return type change (`SchemaVersion` field).
- `WireError::{EventTypeTooLong, MetadataTooLong, PayloadTooLong, InvalidSchemaVersion}` removed.
- `EnvelopeError::InvalidSchemaVersion` removed; new `EventTypeRangeTooLong` / `MetadataRangeTooLong` / `MetadataRangeEmpty` added.
- `DecodeError::CorruptSchemaVersion` added.
- `PersistedEnvelope::try_new` takes `SchemaVersion` (was `u32`).
- `PersistedEnvelope::for_decode` returns `ForDecodeError` (was `WireError`).
- `nexus-fjall::EncodeError::{EventTypeTooLong, MetadataTooLong, PayloadTooLong, InvalidSchemaVersion}` removed; `Value(ValueError)` and `Wire(wire::WireError)` added.
- `nexus-fjall::DecodedEvent::schema_version` now typed `SchemaVersion`.
- `StoreError::Wire` → `StoreError::EnvelopeSynthesis`; same rename on `CodecSnapshotStoreError`.

## Test plan
- [x] Owned-accessor unit tests on `PersistedEnvelope` (`event_type_value`, `payload_value`, `metadata_value` both `Some` and `None`).
- [x] `wire::encode_frame` accepts value newtypes (unit test).
- [x] `wire::decode_frame` rejects `schema_version=0` on the wire with `DecodeError::CorruptSchemaVersion` (unit test).
- [x] `PersistedEnvelope::try_new` rejects `event_type_range > MAX_EVENT_TYPE_LEN` (new boundary test).
- [x] Round-trip property: build value newtypes → `wire::encode_frame` → `wire::decode_frame` → `PersistedEnvelope::try_new` → `*_value()` accessors recover originals.
- [x] All existing wire / envelope / codec / fjall tests pass (635/635).
- [x] `nix flake check` passes (clippy, fmt, taplo, audit, deny, nextest, hakari, doc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)