### PR TITLE
feat: bound subscription/read batch size (#176)

### DIFF
--- a/crates/nexus-fjall/src/builder.rs
+++ b/crates/nexus-fjall/src/builder.rs
@@ -2,6 +2,7 @@ use crate::error::FjallError;
 use crate::partition::{KeyspaceConfig, point_read_defaults, scan_defaults};
 use crate::store::FjallStore;
 use fjall::KeyspaceCreateOptions;
+use nexus_store::batch::BatchSize;
 use nexus_store::notify::StreamNotifiers;
 use std::path::{Path, PathBuf};
 
@@ -22,6 +23,7 @@ pub struct FjallStoreBuilder<S = (), E = ()> {
     path: PathBuf,
     streams_config: S,
     events_config: E,
+    batch_size: BatchSize,
 }
 
 impl FjallStoreBuilder {
@@ -31,6 +33,7 @@ impl FjallStoreBuilder {
             path: path.as_ref().to_path_buf(),
             streams_config: (),
             events_config: (),
+            batch_size: BatchSize::DEFAULT,
         }
     }
 }
@@ -50,6 +53,7 @@ impl<S, E> FjallStoreBuilder<S, E> {
             path: self.path,
             streams_config: f,
             events_config: self.events_config,
+            batch_size: self.batch_size,
         }
     }
 
@@ -67,7 +71,20 @@ impl<S, E> FjallStoreBuilder<S, E> {
             path: self.path,
             streams_config: self.streams_config,
             events_config: f,
+            batch_size: self.batch_size,
         }
+    }
+
+    /// Set the read / refill batch size — the maximum number of event rows
+    /// held in memory at once by a read stream or subscription refill.
+    ///
+    /// Out-of-range values are rejected when constructing the
+    /// [`BatchSize`](nexus_store::batch::BatchSize), so this setter is
+    /// infallible. Defaults to [`BatchSize::DEFAULT`].
+    #[must_use]
+    pub const fn batch_size(mut self, batch_size: BatchSize) -> Self {
+        self.batch_size = batch_size;
+        self
     }
 }
 
@@ -103,6 +120,7 @@ impl<S: KeyspaceConfig, E: KeyspaceConfig> FjallStoreBuilder<S, E> {
             snapshots,
             global,
             notifiers: StreamNotifiers::new(),
+            batch_size: self.batch_size,
         })
     }
 }

--- a/crates/nexus-fjall/src/error.rs
+++ b/crates/nexus-fjall/src/error.rs
@@ -1,6 +1,15 @@
 use arrayvec::ArrayString;
 use nexus_store::envelope::EnvelopeError;
+use std::fmt::Write;
 use thiserror::Error;
+
+/// Format a `Display` value into a stack-allocated reason label,
+/// silently truncating at 128 bytes on a char boundary.
+pub(crate) fn reason_label(value: &impl std::fmt::Display) -> ArrayString<128> {
+    let mut buf = ArrayString::<128>::new();
+    let _ = write!(buf, "{value}");
+    buf
+}
 
 /// Errors produced by the fjall event store adapter.
 ///

--- a/crates/nexus-fjall/src/store.rs
+++ b/crates/nexus-fjall/src/store.rs
@@ -1,9 +1,8 @@
 use crate::builder::FjallStoreBuilder;
 use crate::encoding::{decode_stream_version, encode_event_key, encode_stream_version};
-use crate::error::FjallError;
+use crate::error::{FjallError, reason_label};
 use crate::stream::FjallStream;
 use crate::subscription_stream::{FjallSubscriptionStream, OwnedStreamId};
-use arrayvec::ArrayString;
 use fjall::{Readable, Slice};
 use nexus::{Id, Version};
 use nexus_store::PendingEnvelope;
@@ -12,17 +11,8 @@ use nexus_store::notify::StreamNotifiers;
 use nexus_store::store::RawEventStore;
 use nexus_store::subscription::{RawSubscription, sealed};
 use nexus_store::wire;
-use std::fmt::Write;
 use std::path::Path;
 use std::sync::Arc;
-
-/// Format a `Display` value into a stack-allocated reason label,
-/// silently truncating at 128 bytes on a char boundary.
-fn reason_label(value: &impl std::fmt::Display) -> ArrayString<128> {
-    let mut buf = ArrayString::<128>::new();
-    let _ = write!(buf, "{value}");
-    buf
-}
 
 /// The single key under which the store-global sequence counter is kept
 /// in the `global` partition.

--- a/crates/nexus-fjall/src/store.rs
+++ b/crates/nexus-fjall/src/store.rs
@@ -601,4 +601,70 @@ mod tests {
         }
         assert_eq!(seen, (1..=10).collect::<Vec<_>>());
     }
+
+    // ---- linearizability / concurrency tests ----
+
+    #[allow(clippy::as_conversions, reason = "test code: v as u8 for payload byte")]
+    #[allow(
+        clippy::cast_possible_truncation,
+        reason = "test code: v stays within 0..=20"
+    )]
+    #[tokio::test]
+    async fn reader_sees_monotonic_gapfree_while_writer_appends() {
+        use crate::store::batch_test_helpers::{seed, store_with_batch, tid as btid};
+        use std::sync::Arc as StdArc;
+        use tokio::sync::Barrier;
+
+        let (raw_store, _dir) = store_with_batch(4);
+        let store = StdArc::new(raw_store);
+        let id = btid("s");
+        seed(&store, &id, 4).await;
+
+        // Force the writer and reader to start together so the reader's
+        // pagination genuinely races concurrent appends.
+        let barrier = StdArc::new(Barrier::new(2));
+
+        let writer = StdArc::clone(&store);
+        let wid = id.clone();
+        let wbarrier = StdArc::clone(&barrier);
+        let handle = tokio::spawn(async move {
+            wbarrier.wait().await;
+            for v in 5..=20u64 {
+                let env = nexus_store::envelope::pending_envelope(Version::new(v).unwrap())
+                    .event_type("E")
+                    .payload(vec![v as u8])
+                    .unwrap()
+                    .build();
+                writer
+                    .append(&wid, Version::new(v - 1), &[env])
+                    .await
+                    .unwrap();
+            }
+        });
+
+        // Concurrent read: assert a strictly monotonic, gap-free prefix
+        // (linearizability — never observe a gap, reorder, dup, or phantom).
+        barrier.wait().await;
+        let mut stream = store.read_stream(&id, Version::INITIAL).await.unwrap();
+        let mut prev = 0u64;
+        while let Some(item) = futures::StreamExt::next(&mut stream).await {
+            let v = item.unwrap().version().as_u64();
+            assert_eq!(
+                v,
+                prev + 1,
+                "concurrent read saw gap/reorder: {prev} -> {v}"
+            );
+            prev = v;
+        }
+        handle.await.unwrap();
+
+        // Deterministic completeness check: after all writes commit, a fresh
+        // paginating read must yield every event 1..=20 in order.
+        let mut full = store.read_stream(&id, Version::INITIAL).await.unwrap();
+        let mut seen = Vec::new();
+        while let Some(item) = futures::StreamExt::next(&mut full).await {
+            seen.push(item.unwrap().version().as_u64());
+        }
+        assert_eq!(seen, (1..=20).collect::<Vec<_>>());
+    }
 }

--- a/crates/nexus-fjall/src/store.rs
+++ b/crates/nexus-fjall/src/store.rs
@@ -572,6 +572,23 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn read_from_midpoint_resumes_across_refills() {
+        use crate::store::batch_test_helpers::{seed, store_with_batch, tid as btid};
+        let (store, _dir) = store_with_batch(3);
+        let id = btid("s");
+        seed(&store, &id, 10).await;
+        let mut stream = store
+            .read_stream(&id, Version::new(6).unwrap())
+            .await
+            .unwrap();
+        let mut seen = Vec::new();
+        while let Some(item) = futures::StreamExt::next(&mut stream).await {
+            seen.push(item.unwrap().version().as_u64());
+        }
+        assert_eq!(seen, vec![6, 7, 8, 9, 10]);
+    }
+
+    #[tokio::test]
     async fn read_reopened_store_recovers_all_across_refills() {
         use nexus_store::batch::BatchSize;
         let dir = tempfile::tempdir().unwrap();

--- a/crates/nexus-fjall/src/store.rs
+++ b/crates/nexus-fjall/src/store.rs
@@ -6,6 +6,7 @@ use crate::subscription_stream::{FjallSubscriptionStream, OwnedStreamId};
 use fjall::{Readable, Slice};
 use nexus::{Id, Version};
 use nexus_store::PendingEnvelope;
+use nexus_store::batch::BatchSize;
 use nexus_store::error::AppendError;
 use nexus_store::notify::StreamNotifiers;
 use nexus_store::store::RawEventStore;
@@ -40,6 +41,8 @@ pub struct FjallStore {
     /// `append` calls `wake(X)`, rousing only the subscribers parked on
     /// `X` rather than every subscriber in the store.
     pub(crate) notifiers: Arc<StreamNotifiers>,
+    /// Maximum event rows materialized per read batch / refill.
+    pub(crate) batch_size: BatchSize,
 }
 
 impl FjallStore {
@@ -209,62 +212,15 @@ impl RawEventStore for FjallStore {
     }
 
     async fn read_stream(&self, id: &impl Id, from: Version) -> Result<Self::Stream, Self::Error> {
-        let id_bytes = id.as_ref();
-
-        // Check if the stream exists. If not, return an empty stream.
-        if self.streams.get(id_bytes)?.is_none() {
-            return Ok(FjallStream {
-                events: std::collections::VecDeque::new(),
-                stream_id: id.to_label(),
-                poisoned: false,
-                #[cfg(debug_assertions)]
-                prev_version: None,
-            });
-        }
-
-        // Range scan from (id_bytes, from_version) to (id_bytes, u64::MAX).
-        let start =
-            encode_event_key(id_bytes, from.as_u64()).map_err(|e| FjallError::InvalidInput {
-                stream_id: id.to_label(),
-                version: from.as_u64(),
-                reason: reason_label(&e),
-            })?;
-        let end = encode_event_key(id_bytes, u64::MAX).map_err(|e| FjallError::InvalidInput {
-            stream_id: id.to_label(),
-            version: u64::MAX,
-            reason: reason_label(&e),
-        })?;
-
-        // Precondition: start key must sort <= end key (same ID bytes).
-        debug_assert!(
-            start <= end,
-            "read_stream precondition: start key must sort <= end key"
-        );
-
-        let events_vec: Vec<_> = self
-            .events
-            .inner()
-            .range(start..=end)
-            .map(fjall::Guard::into_inner)
-            .collect::<Result<_, _>>()?;
-
-        // Postcondition: events must be sorted by key (fjall guarantees this,
-        // but we verify in debug mode).
-        #[cfg(debug_assertions)]
-        for window in events_vec.windows(2) {
-            debug_assert!(
-                window[0].0 < window[1].0,
-                "read_stream postcondition: events must be strictly sorted by key"
-            );
-        }
-
-        Ok(FjallStream {
-            events: events_vec.into(),
-            stream_id: id.to_label(),
-            poisoned: false,
-            #[cfg(debug_assertions)]
-            prev_version: None,
-        })
+        // A single bounded range scan; a nonexistent stream simply yields an
+        // empty first batch (done), so no separate existence check is needed.
+        FjallStream::new(
+            self.events.clone(),
+            OwnedStreamId::from_id(id),
+            from.as_u64(),
+            self.batch_size.get(),
+            id.to_label(),
+        )
     }
 }
 
@@ -361,6 +317,54 @@ impl RawSubscription for FjallStore {
             from,
             guard,
         ))
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, reason = "test code")]
+pub(crate) mod batch_test_helpers {
+    use super::*;
+    use nexus_store::batch::BatchSize;
+    use nexus_store::envelope::pending_envelope;
+
+    #[derive(Debug, Clone, Hash, PartialEq, Eq)]
+    pub struct Tid(pub String);
+    impl std::fmt::Display for Tid {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.write_str(&self.0)
+        }
+    }
+    impl AsRef<[u8]> for Tid {
+        fn as_ref(&self) -> &[u8] {
+            self.0.as_bytes()
+        }
+    }
+    impl nexus::Id for Tid {
+        const BYTE_LEN: usize = 0;
+    }
+
+    pub fn tid(s: &str) -> Tid {
+        Tid(s.to_owned())
+    }
+
+    pub fn store_with_batch(n: usize) -> (FjallStore, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = FjallStore::builder(dir.path().join("db"))
+            .batch_size(BatchSize::new(n).unwrap())
+            .open()
+            .unwrap();
+        (store, dir)
+    }
+
+    pub async fn seed(store: &FjallStore, id: &Tid, count: u64) {
+        for v in 1..=count {
+            let env = pending_envelope(Version::new(v).unwrap())
+                .event_type("E")
+                .payload(b"payload".to_vec())
+                .unwrap()
+                .build();
+            store.append(id, Version::new(v - 1), &[env]).await.unwrap();
+        }
     }
 }
 
@@ -534,5 +538,67 @@ mod tests {
             assert_eq!(e2.version().as_u64(), 2);
         }
         assert!(stream.next().await.is_none());
+    }
+
+    // ---- bounded-read (batch pagination) tests ----
+
+    #[tokio::test]
+    async fn read_yields_all_across_refills() {
+        use crate::store::batch_test_helpers::{seed, store_with_batch, tid as btid};
+        let (store, _dir) = store_with_batch(4);
+        let id = btid("s");
+        seed(&store, &id, 14).await;
+        let mut stream = store.read_stream(&id, Version::INITIAL).await.unwrap();
+        let mut seen = Vec::new();
+        while let Some(item) = futures::StreamExt::next(&mut stream).await {
+            seen.push(item.unwrap().version().as_u64());
+        }
+        assert_eq!(seen, (1..=14).collect::<Vec<_>>());
+    }
+
+    #[tokio::test]
+    async fn read_terminates_at_exact_batch_boundary() {
+        use crate::store::batch_test_helpers::{seed, store_with_batch, tid as btid};
+        let (store, _dir) = store_with_batch(4);
+        let id = btid("s");
+        seed(&store, &id, 8).await; // exactly 2 full batches
+        let mut stream = store.read_stream(&id, Version::INITIAL).await.unwrap();
+        let mut count = 0u64;
+        while let Some(item) = futures::StreamExt::next(&mut stream).await {
+            item.unwrap();
+            count += 1;
+        }
+        assert_eq!(count, 8);
+    }
+
+    #[tokio::test]
+    async fn read_reopened_store_recovers_all_across_refills() {
+        use nexus_store::batch::BatchSize;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("db");
+        let id = tid("s");
+        {
+            let store = FjallStore::builder(&path)
+                .batch_size(BatchSize::new(4).unwrap())
+                .open()
+                .unwrap();
+            for v in 1..=10u64 {
+                let env = make_envelope(v, "E", b"payload");
+                store
+                    .append(&id, Version::new(v - 1), &[env])
+                    .await
+                    .unwrap();
+            }
+        }
+        let store = FjallStore::builder(&path)
+            .batch_size(BatchSize::new(4).unwrap())
+            .open()
+            .unwrap();
+        let mut stream = store.read_stream(&id, Version::INITIAL).await.unwrap();
+        let mut seen = Vec::new();
+        while let Some(item) = futures::StreamExt::next(&mut stream).await {
+            seen.push(item.unwrap().version().as_u64());
+        }
+        assert_eq!(seen, (1..=10).collect::<Vec<_>>());
     }
 }

--- a/crates/nexus-fjall/src/stream.rs
+++ b/crates/nexus-fjall/src/stream.rs
@@ -10,6 +10,52 @@ use nexus_store::PersistedEnvelope;
 use crate::encoding::{decode_event_key, decode_event_value};
 use crate::error::FjallError;
 
+/// Decode one stored `(key, value)` row into a [`PersistedEnvelope`].
+///
+/// Pure: no store handle, no cursor state — so unit tests can exercise it
+/// with hand-built rows. Maps every malformed shape to a typed `FjallError`.
+fn decode_row(
+    key: &Slice,
+    value: Slice,
+    stream_id: ArrayString<64>,
+) -> Result<PersistedEnvelope, FjallError> {
+    let (_id_bytes, version) = decode_event_key(key).map_err(|_| FjallError::CorruptValue {
+        stream_id,
+        version: None,
+    })?;
+
+    let bytes_value: Bytes = value.into();
+    let decoded = decode_event_value(&bytes_value).map_err(|_| FjallError::CorruptValue {
+        stream_id,
+        version: Some(version),
+    })?;
+
+    let ver = Version::new(version).ok_or(FjallError::CorruptValue {
+        stream_id,
+        version: Some(version),
+    })?;
+
+    let global_seq = GlobalSeq::new(decoded.global_seq).ok_or(FjallError::CorruptValue {
+        stream_id,
+        version: Some(version),
+    })?;
+
+    PersistedEnvelope::try_new(
+        ver,
+        global_seq,
+        bytes_value,
+        decoded.schema_version,
+        decoded.event_type_range,
+        decoded.payload_range,
+        decoded.metadata_range,
+    )
+    .map_err(|source| FjallError::EnvelopeCorrupt {
+        stream_id,
+        version,
+        source,
+    })
+}
+
 /// `futures::Stream` of fjall event rows.
 ///
 /// Created by `FjallStore::read_stream`. Events are eagerly loaded into a
@@ -33,69 +79,24 @@ impl FjallStream {
             return None;
         }
         let (key, value) = self.events.pop_front()?;
-
-        let Ok((_id_bytes, version)) = decode_event_key(&key) else {
-            self.poisoned = true;
-            return Some(Err(FjallError::CorruptValue {
-                stream_id: self.stream_id,
-                version: None,
-            }));
-        };
-
-        #[cfg(debug_assertions)]
-        {
-            if let Some(prev) = self.prev_version {
-                debug_assert!(
-                    version > prev,
-                    "EventStream monotonicity violated: version {version} \
-                     is not greater than previous {prev}",
-                );
+        match decode_row(&key, value, self.stream_id) {
+            Ok(env) => {
+                #[cfg(debug_assertions)]
+                {
+                    let v = env.version().as_u64();
+                    if let Some(prev) = self.prev_version {
+                        debug_assert!(
+                            v > prev,
+                            "EventStream monotonicity violated: version {v} is not greater than previous {prev}",
+                        );
+                    }
+                    self.prev_version = Some(v);
+                }
+                Some(Ok(env))
             }
-            self.prev_version = Some(version);
-        }
-
-        let bytes_value: Bytes = value.into();
-        let Ok(decoded) = decode_event_value(&bytes_value) else {
-            self.poisoned = true;
-            return Some(Err(FjallError::CorruptValue {
-                stream_id: self.stream_id,
-                version: Some(version),
-            }));
-        };
-
-        let Some(ver) = Version::new(version) else {
-            self.poisoned = true;
-            return Some(Err(FjallError::CorruptValue {
-                stream_id: self.stream_id,
-                version: Some(version),
-            }));
-        };
-
-        let Some(global_seq) = GlobalSeq::new(decoded.global_seq) else {
-            self.poisoned = true;
-            return Some(Err(FjallError::CorruptValue {
-                stream_id: self.stream_id,
-                version: Some(version),
-            }));
-        };
-
-        match PersistedEnvelope::try_new(
-            ver,
-            global_seq,
-            bytes_value,
-            decoded.schema_version,
-            decoded.event_type_range,
-            decoded.payload_range,
-            decoded.metadata_range,
-        ) {
-            Ok(envelope) => Some(Ok(envelope)),
-            Err(source) => {
+            Err(e) => {
                 self.poisoned = true;
-                Some(Err(FjallError::EnvelopeCorrupt {
-                    stream_id: self.stream_id,
-                    version,
-                    source,
-                }))
+                Some(Err(e))
             }
         }
     }
@@ -115,87 +116,39 @@ impl futures::Stream for FjallStream {
 #[cfg(test)]
 #[allow(clippy::unwrap_used, reason = "test code")]
 #[allow(clippy::panic, reason = "test code")]
-#[allow(clippy::too_many_arguments, reason = "test fixture helper")]
 mod tests {
     use super::*;
     use crate::encoding::{encode_event_key, encode_event_value};
-    use futures::StreamExt;
 
-    fn make_row(
-        id: &[u8],
-        version: u64,
-        global_seq: u64,
-        schema_ver: u32,
-        event_type: &str,
-        payload: &[u8],
-    ) -> (Slice, Slice) {
+    fn row(id: &[u8], version: u64, global_seq: u64, et: &str, payload: &[u8]) -> (Slice, Slice) {
         let key = encode_event_key(id, version).unwrap();
-        let mut val_buf = Vec::new();
-        encode_event_value(
-            &mut val_buf,
-            global_seq,
-            schema_ver,
-            event_type,
-            None,
-            payload,
-        )
-        .unwrap();
-        (Slice::from(key), Slice::from(val_buf))
+        let mut val = Vec::new();
+        encode_event_value(&mut val, global_seq, 1, et, None, payload).unwrap();
+        (Slice::from(key), Slice::from(val))
     }
 
-    #[tokio::test]
-    async fn yields_events_in_order() {
-        let row1 = make_row(b"user-123", 1, 10, 1, "UserCreated", b"payload-1");
-        let row2 = make_row(b"user-123", 2, 11, 1, "UserUpdated", b"payload-2");
-
-        let mut stream = FjallStream {
-            events: VecDeque::from(vec![row1, row2]),
-            stream_id: ArrayString::try_from("user-123").unwrap(),
-            poisoned: false,
-            #[cfg(debug_assertions)]
-            prev_version: None,
-        };
-
-        {
-            let env1 = stream.next().await.unwrap().unwrap();
-            assert_eq!(env1.version(), Version::new(1).unwrap());
-            assert_eq!(env1.global_seq(), GlobalSeq::new(10).unwrap());
-            assert_eq!(env1.event_type(), "UserCreated");
-            assert_eq!(env1.schema_version(), 1);
-            assert_eq!(env1.payload(), b"payload-1");
-        }
-
-        {
-            let env2 = stream.next().await.unwrap().unwrap();
-            assert_eq!(env2.version(), Version::new(2).unwrap());
-            assert_eq!(env2.global_seq(), GlobalSeq::new(11).unwrap());
-            assert_eq!(env2.event_type(), "UserUpdated");
-            assert_eq!(env2.schema_version(), 1);
-            assert_eq!(env2.payload(), b"payload-2");
-        }
+    #[test]
+    fn decode_row_yields_envelope() {
+        let (k, v) = row(b"user-1", 7, 42, "Created", b"data");
+        let sid = ArrayString::try_from("user-1").unwrap();
+        let env = decode_row(&k, v, sid).unwrap();
+        assert_eq!(env.version(), Version::new(7).unwrap());
+        assert_eq!(env.global_seq(), GlobalSeq::new(42).unwrap());
+        assert_eq!(env.event_type(), "Created");
+        assert_eq!(env.payload(), b"data");
     }
 
-    #[tokio::test]
-    async fn corrupt_value_returns_error() {
-        // Valid key, but truncated value (only 3 bytes, header requires 18).
-        let key = encode_event_key(b"corrupt-stream", 1).unwrap();
-        let truncated_value: &[u8] = &[0, 1, 2];
-
-        let mut stream = FjallStream {
-            events: VecDeque::from(vec![(Slice::from(key), Slice::from(truncated_value))]),
-            stream_id: ArrayString::try_from("corrupt-stream").unwrap(),
-            poisoned: false,
-            #[cfg(debug_assertions)]
-            prev_version: None,
-        };
-
-        let err = stream.next().await.unwrap().unwrap_err();
-        match err {
+    #[test]
+    fn decode_row_rejects_truncated_value() {
+        let k = Slice::from(encode_event_key(b"corrupt", 1).unwrap());
+        let v = Slice::from(&[0u8, 1, 2][..]);
+        let sid = ArrayString::try_from("corrupt").unwrap();
+        match decode_row(&k, v, sid).unwrap_err() {
             FjallError::CorruptValue { stream_id, version } => {
-                assert_eq!(stream_id.as_str(), "corrupt-stream");
+                assert_eq!(stream_id.as_str(), "corrupt");
                 assert_eq!(version, Some(1));
             }
-            other => panic!("expected CorruptValue, got: {other:?}"),
+            other => panic!("expected CorruptValue, got {other:?}"),
         }
     }
 }

--- a/crates/nexus-fjall/src/stream.rs
+++ b/crates/nexus-fjall/src/stream.rs
@@ -2,13 +2,14 @@ use std::collections::VecDeque;
 
 use arrayvec::ArrayString;
 use bytes::Bytes;
-use fjall::Slice;
+use fjall::{SingleWriterTxKeyspace, Slice};
 use nexus::Version;
 use nexus_store::GlobalSeq;
 use nexus_store::PersistedEnvelope;
 
-use crate::encoding::{decode_event_key, decode_event_value};
-use crate::error::FjallError;
+use crate::encoding::{decode_event_key, decode_event_value, encode_event_key};
+use crate::error::{FjallError, reason_label};
+use crate::subscription_stream::OwnedStreamId;
 
 /// Decode one stored `(key, value)` row into a [`PersistedEnvelope`].
 ///
@@ -58,45 +59,138 @@ fn decode_row(
 
 /// `futures::Stream` of fjall event rows.
 ///
-/// Created by `FjallStore::read_stream`. Events are eagerly loaded into a
-/// `VecDeque` (range scan over the events partition) at construction so
-/// `poll_next` is pure sync over the queue — no LSM-tree iterator stays
-/// open while the stream is held.
+/// Created by `FjallStore::read_stream`. Events are loaded in bounded batches
+/// (at most `batch_size` rows at a time) via keyset pagination, so the
+/// in-memory footprint is bounded regardless of stream length.
 pub struct FjallStream {
-    pub(crate) events: VecDeque<(Slice, Slice)>,
-    pub(crate) stream_id: ArrayString<64>,
-    /// Once an error is yielded, the stream is poisoned — all subsequent
-    /// `poll_next` calls return `None`. This prevents silently skipping
-    /// corrupt entries on retry.
-    pub(crate) poisoned: bool,
+    /// Current in-memory batch, drained front-to-back.
+    events: VecDeque<(Slice, Slice)>,
+    /// Cloned `events` partition handle — Arc-backed, cheap to hold; used to
+    /// scan the next batch when `events` drains.
+    keyspace: SingleWriterTxKeyspace,
+    /// Stream key bytes for refill key encoding.
+    id: OwnedStreamId,
+    /// Next version to scan from on the following refill (keyset cursor).
+    next_version: u64,
+    /// Max rows per batch.
+    batch_size: usize,
+    /// Set once a refill returns fewer than `batch_size` rows — no more data.
+    done: bool,
+    stream_id: ArrayString<64>,
+    /// Once an error is yielded, the stream is poisoned — subsequent polls
+    /// return `None` rather than silently skipping corrupt entries.
+    poisoned: bool,
     #[cfg(debug_assertions)]
-    pub(crate) prev_version: Option<u64>,
+    prev_version: Option<u64>,
 }
 
 impl FjallStream {
+    /// Build a stream and eagerly load the first batch (so the first poll is
+    /// IO-free), scanning from `from`.
+    pub(crate) fn new(
+        keyspace: SingleWriterTxKeyspace,
+        id: OwnedStreamId,
+        from: u64,
+        batch_size: usize,
+        stream_id: ArrayString<64>,
+    ) -> Result<Self, FjallError> {
+        let mut stream = Self {
+            events: VecDeque::new(),
+            keyspace,
+            id,
+            next_version: from,
+            batch_size,
+            done: false,
+            stream_id,
+            poisoned: false,
+            #[cfg(debug_assertions)]
+            prev_version: None,
+        };
+        stream.refill()?;
+        Ok(stream)
+    }
+
+    /// Scan the next `batch_size` rows from `next_version` into `events`.
+    /// A short batch (fewer than `batch_size`) sets `done`.
+    fn refill(&mut self) -> Result<(), FjallError> {
+        let id_bytes = self.id.as_ref();
+        let start = encode_event_key(id_bytes, self.next_version).map_err(|e| {
+            FjallError::InvalidInput {
+                stream_id: self.stream_id,
+                version: self.next_version,
+                reason: reason_label(&e),
+            }
+        })?;
+        let end = encode_event_key(id_bytes, u64::MAX).map_err(|e| FjallError::InvalidInput {
+            stream_id: self.stream_id,
+            version: u64::MAX,
+            reason: reason_label(&e),
+        })?;
+
+        let batch: Vec<(Slice, Slice)> = self
+            .keyspace
+            .inner()
+            .range(start..=end)
+            .take(self.batch_size)
+            .map(fjall::Guard::into_inner)
+            .collect::<Result<_, _>>()?;
+
+        self.done = batch.len() < self.batch_size;
+        self.events = batch.into();
+        Ok(())
+    }
+
+    /// Returns `true` if the current batch buffer is empty.
+    ///
+    /// Used by [`crate::subscription_stream`] to decide whether to sleep on the
+    /// per-stream `Notify` after a refill that found no new events.
+    pub(crate) fn is_empty(&self) -> bool {
+        self.events.is_empty()
+    }
+
     pub(crate) fn poll_one(&mut self) -> Option<Result<PersistedEnvelope, FjallError>> {
         if self.poisoned {
             return None;
         }
-        let (key, value) = self.events.pop_front()?;
-        match decode_row(&key, value, self.stream_id) {
-            Ok(env) => {
-                #[cfg(debug_assertions)]
-                {
-                    let v = env.version().as_u64();
-                    if let Some(prev) = self.prev_version {
-                        debug_assert!(
-                            v > prev,
-                            "EventStream monotonicity violated: version {v} is not greater than previous {prev}",
-                        );
+        loop {
+            if let Some((key, value)) = self.events.pop_front() {
+                return Some(match decode_row(&key, value, self.stream_id) {
+                    Ok(env) => {
+                        let v = env.version().as_u64();
+                        #[cfg(debug_assertions)]
+                        {
+                            if let Some(prev) = self.prev_version {
+                                debug_assert!(
+                                    v > prev,
+                                    "EventStream monotonicity violated: version {v} is not greater than previous {prev}",
+                                );
+                            }
+                            self.prev_version = Some(v);
+                        }
+                        // Advance keyset cursor. No event can follow u64::MAX.
+                        if let Some(n) = v.checked_add(1) {
+                            self.next_version = n;
+                        } else {
+                            self.done = true;
+                            self.next_version = v;
+                        }
+                        Ok(env)
                     }
-                    self.prev_version = Some(v);
-                }
-                Some(Ok(env))
+                    Err(e) => {
+                        self.poisoned = true;
+                        Err(e)
+                    }
+                });
             }
-            Err(e) => {
+            if self.done {
+                return None;
+            }
+            if let Err(e) = self.refill() {
                 self.poisoned = true;
-                Some(Err(e))
+                return Some(Err(e));
+            }
+            if self.events.is_empty() {
+                return None;
             }
         }
     }

--- a/crates/nexus-fjall/src/subscription_stream.rs
+++ b/crates/nexus-fjall/src/subscription_stream.rs
@@ -172,13 +172,14 @@ mod tests {
 
     #[tokio::test]
     async fn subscription_drains_many_batches_then_sees_live_event() {
+        // 10× batch_size backlog: batch_size 4, 40 pre-seeded events (10 full refills).
         let (raw_store, _dir) = store_with_batch(4);
         let store = Arc::new(raw_store);
         let id = tid("s");
-        seed(&store, &id, 10).await; // 3 bounded catch-up refills (4+4+2)
+        seed(&store, &id, 40).await; // 10 bounded catch-up refills (4×10)
 
         let mut sub = FjallStore::subscribe(&store, &id, None).await.unwrap();
-        for expected in 1..=10u64 {
+        for expected in 1..=40u64 {
             let got = sub.next().await.unwrap().unwrap();
             assert_eq!(got.version().as_u64(), expected);
         }
@@ -186,14 +187,14 @@ mod tests {
         let store2 = Arc::clone(&store);
         let id2 = id.clone();
         tokio::spawn(async move {
-            let env = pending_envelope(Version::new(11).unwrap())
+            let env = pending_envelope(Version::new(41).unwrap())
                 .event_type("E")
-                .payload(vec![11u8])
+                .payload(vec![41u8])
                 .unwrap()
                 .build();
-            store2.append(&id2, Version::new(10), &[env]).await.unwrap();
+            store2.append(&id2, Version::new(40), &[env]).await.unwrap();
         });
         let live = sub.next().await.unwrap().unwrap();
-        assert_eq!(live.version().as_u64(), 11);
+        assert_eq!(live.version().as_u64(), 41);
     }
 }

--- a/crates/nexus-fjall/src/subscription_stream.rs
+++ b/crates/nexus-fjall/src/subscription_stream.rs
@@ -172,8 +172,8 @@ mod tests {
 
     #[tokio::test]
     async fn subscription_drains_many_batches_then_sees_live_event() {
-        let (store, _dir) = store_with_batch(4);
-        let store = Arc::new(store);
+        let (raw_store, _dir) = store_with_batch(4);
+        let store = Arc::new(raw_store);
         let id = tid("s");
         seed(&store, &id, 10).await; // 3 bounded catch-up refills (4+4+2)
 

--- a/crates/nexus-fjall/src/subscription_stream.rs
+++ b/crates/nexus-fjall/src/subscription_stream.rs
@@ -111,7 +111,7 @@ impl FjallSubscriptionStream {
                 if let Err(e) = s.refill(from).await {
                     return Some((Err(e), s));
                 }
-                if s.inner.events.is_empty() {
+                if s.inner.is_empty() {
                     notified.await;
                 }
             }

--- a/crates/nexus-fjall/src/subscription_stream.rs
+++ b/crates/nexus-fjall/src/subscription_stream.rs
@@ -160,3 +160,40 @@ impl SubState {
         Ok(())
     }
 }
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, reason = "test code")]
+mod tests {
+    use super::*;
+    use crate::store::batch_test_helpers::{seed, store_with_batch, tid};
+    use futures::StreamExt;
+    use nexus_store::envelope::pending_envelope;
+    use nexus_store::subscription::RawSubscription;
+
+    #[tokio::test]
+    async fn subscription_drains_many_batches_then_sees_live_event() {
+        let (store, _dir) = store_with_batch(4);
+        let store = Arc::new(store);
+        let id = tid("s");
+        seed(&store, &id, 10).await; // 3 bounded catch-up refills (4+4+2)
+
+        let mut sub = FjallStore::subscribe(&store, &id, None).await.unwrap();
+        for expected in 1..=10u64 {
+            let got = sub.next().await.unwrap().unwrap();
+            assert_eq!(got.version().as_u64(), expected);
+        }
+
+        let store2 = Arc::clone(&store);
+        let id2 = id.clone();
+        tokio::spawn(async move {
+            let env = pending_envelope(Version::new(11).unwrap())
+                .event_type("E")
+                .payload(vec![11u8])
+                .unwrap()
+                .build();
+            store2.append(&id2, Version::new(10), &[env]).await.unwrap();
+        });
+        let live = sub.next().await.unwrap().unwrap();
+        assert_eq!(live.version().as_u64(), 11);
+    }
+}

--- a/crates/nexus-store/src/batch.rs
+++ b/crates/nexus-store/src/batch.rs
@@ -1,0 +1,104 @@
+//! Bounded batch size for stream reads and subscription refills.
+//!
+//! Read paths never materialize more than `batch_size` event rows at once.
+//! [`BatchSize`] carries the `1..=MAX_BATCH` invariant by construction, so an
+//! out-of-range value is unrepresentable past [`BatchSize::new`] — the builder
+//! that accepts a `BatchSize` cannot be handed an invalid one.
+
+use thiserror::Error;
+
+/// Largest permitted batch size — the compile-time ceiling on resident rows.
+pub const MAX_BATCH: usize = 4096;
+
+/// Default batch size when none is configured.
+pub const DEFAULT_BATCH: usize = 256;
+
+/// A validated read / refill batch size in `1..=MAX_BATCH`.
+///
+/// Construct via [`BatchSize::new`]; the invalid range is rejected there, so
+/// every `BatchSize` value in the program is in range by construction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BatchSize(usize);
+
+impl BatchSize {
+    /// The default batch size ([`DEFAULT_BATCH`]).
+    pub const DEFAULT: Self = Self(DEFAULT_BATCH);
+
+    /// Construct a `BatchSize`, rejecting `0` and values above [`MAX_BATCH`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BatchSizeError`] if `n == 0` or `n > MAX_BATCH`.
+    pub const fn new(n: usize) -> Result<Self, BatchSizeError> {
+        if n == 0 || n > MAX_BATCH {
+            return Err(BatchSizeError {
+                requested: n,
+                max: MAX_BATCH,
+            });
+        }
+        Ok(Self(n))
+    }
+
+    /// The validated value, always in `1..=MAX_BATCH`.
+    #[must_use]
+    pub const fn get(self) -> usize {
+        self.0
+    }
+}
+
+impl Default for BatchSize {
+    fn default() -> Self {
+        Self::DEFAULT
+    }
+}
+
+/// Error returned when a configured batch size is out of range.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+#[error("batch size must be in 1..={max}, got {requested}")]
+pub struct BatchSizeError {
+    /// The rejected value.
+    pub requested: usize,
+    /// The compile-time maximum ([`MAX_BATCH`]).
+    pub max: usize,
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, reason = "test code")]
+#[allow(clippy::expect_used, reason = "test code")]
+mod tests {
+    use super::{BatchSize, BatchSizeError, DEFAULT_BATCH, MAX_BATCH};
+
+    #[test]
+    fn rejects_zero() {
+        let err = BatchSize::new(0).unwrap_err();
+        assert_eq!(
+            err,
+            BatchSizeError {
+                requested: 0,
+                max: MAX_BATCH
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_above_max() {
+        let err = BatchSize::new(MAX_BATCH + 1).unwrap_err();
+        assert_eq!(err.requested, MAX_BATCH + 1);
+        assert_eq!(err.max, MAX_BATCH);
+    }
+
+    #[test]
+    fn accepts_lower_and_upper_bound() {
+        assert_eq!(BatchSize::new(1).expect("1 is valid").get(), 1);
+        assert_eq!(
+            BatchSize::new(MAX_BATCH).expect("MAX is valid").get(),
+            MAX_BATCH
+        );
+    }
+
+    #[test]
+    fn default_is_default_batch() {
+        assert_eq!(BatchSize::DEFAULT.get(), DEFAULT_BATCH);
+        assert_eq!(BatchSize::default().get(), DEFAULT_BATCH);
+    }
+}

--- a/crates/nexus-store/src/lib.rs
+++ b/crates/nexus-store/src/lib.rs
@@ -80,6 +80,7 @@
 //! (kernel-pure → store-persistence → adapters); the boundary that
 //! didn't matter was inside `nexus-store`.
 
+pub mod batch;
 pub mod builder;
 pub mod codec;
 pub mod envelope;
@@ -102,6 +103,7 @@ pub mod value;
 pub mod wire;
 
 pub use arrayvec::ArrayString;
+pub use batch::{BatchSize, BatchSizeError, DEFAULT_BATCH, MAX_BATCH};
 #[cfg(feature = "snapshot")]
 pub use builder::WithSnapshot;
 pub use builder::{NeedsCodec, NoSnapshot, RepositoryBuilder};

--- a/crates/nexus-store/src/notify.rs
+++ b/crates/nexus-store/src/notify.rs
@@ -234,6 +234,14 @@ impl Drop for SubscriptionGuard {
 #[cfg(test)]
 #[allow(clippy::unwrap_used, reason = "test code")]
 #[allow(clippy::expect_used, reason = "test code")]
+#[allow(
+    clippy::similar_names,
+    reason = "notifier/notified are domain-accurate names"
+)]
+#[allow(
+    clippy::shadow_reuse,
+    reason = "Arc::clone rebinds are idiomatic for task captures"
+)]
 mod tests {
     use super::{Arc, StreamNotifiers};
     use std::time::Duration;

--- a/crates/nexus-store/src/store.rs
+++ b/crates/nexus-store/src/store.rs
@@ -160,6 +160,16 @@ pub trait RawEventStore: Send + Sync {
     ///
     /// Events are yielded one at a time as a `futures::Stream` of
     /// owned [`PersistedEnvelope`](crate::envelope::PersistedEnvelope)s.
+    ///
+    /// # Batching
+    ///
+    /// An adapter materializes at most its configured `batch_size` rows at a
+    /// time and refills the next batch internally as the cursor drains, by
+    /// keyset resume on the stream version. This is invisible to callers:
+    /// `next()` has the same contract regardless of how the events are
+    /// chunked, and the stream returns `None` once the persisted stream is
+    /// exhausted. The bound caps resident memory so a large stream cannot be
+    /// loaded all at once.
     fn read_stream(
         &self,
         id: &impl Id,

--- a/crates/nexus-store/src/subscription.rs
+++ b/crates/nexus-store/src/subscription.rs
@@ -122,6 +122,11 @@ impl<S: RawSubscription> Subscription<S> {
     /// the event *after* version `v`. The returned cursor **never returns
     /// `None`** — it waits for new events when caught up.
     ///
+    /// Catch-up is bounded: the cursor materializes at most the adapter's
+    /// configured `batch_size` events per refill, paginating by keyset resume
+    /// until caught up, then waits for new events. A slow consumer never forces
+    /// the whole backlog into memory at once.
+    ///
     /// # Errors
     ///
     /// Returns `S::Error` if the adapter cannot open the cursor (e.g. an

--- a/crates/nexus-store/src/testing.rs
+++ b/crates/nexus-store/src/testing.rs
@@ -11,6 +11,7 @@ use bytes::Bytes;
 use nexus::Id;
 use nexus::Version;
 use std::collections::HashMap;
+use std::collections::VecDeque;
 use std::sync::Arc;
 use thiserror::Error;
 use tokio::sync::Mutex;
@@ -130,15 +131,50 @@ impl Default for InMemoryStore {
     }
 }
 
-/// `futures::Stream` of envelopes over an in-memory snapshot.
-///
-/// Yields each row from a pre-loaded `VecDeque<StoredFrame>` in sequence.
-/// `poll_next` is pure sync (no IO) — the events were materialized at
-/// `read_stream()` time.
-pub struct InMemoryStream {
-    events: std::collections::VecDeque<StoredFrame>,
+/// Keyset-paginating read state for a one-shot `read_stream`.
+struct ReadState {
+    streams: Arc<Mutex<HashMap<String, Vec<StoredFrame>>>>,
+    stream_id: String,
+    /// Start version of the *first* batch (used until the first yield).
+    from: Version,
+    last_version: Option<Version>,
+    batch_size: usize,
+    buffer: VecDeque<StoredFrame>,
+    /// Set when a refill returns fewer than `batch_size` rows — no more data.
+    done: bool,
     #[cfg(debug_assertions)]
     prev_version: Option<u64>,
+}
+
+impl ReadState {
+    fn next_read_version(&self) -> Result<Version, InMemoryStoreError> {
+        self.last_version.map_or(Ok(self.from), |v| {
+            v.next().ok_or(InMemoryStoreError::VersionOverflow)
+        })
+    }
+
+    async fn refill(&mut self, from: Version) {
+        let batch = {
+            let guard = self.streams.lock().await;
+            guard
+                .get(&self.stream_id)
+                .map(|rows| scan_batch(rows, from.as_u64(), self.batch_size))
+                .unwrap_or_default()
+        };
+        self.done = batch.len() < self.batch_size;
+        self.buffer = batch;
+    }
+}
+
+/// `futures::Stream` of envelopes over an in-memory stream.
+///
+/// Loads at most `batch_size` rows at a time and keyset-resumes
+/// (`last_version + 1`) when the buffer drains, terminating with `None` once a
+/// refill returns a short (or empty) batch.
+pub struct InMemoryStream {
+    inner: core::pin::Pin<
+        Box<dyn futures::Stream<Item = Result<PersistedEnvelope, InMemoryStoreError>> + Send>,
+    >,
 }
 
 impl futures::Stream for InMemoryStream {
@@ -146,24 +182,9 @@ impl futures::Stream for InMemoryStream {
 
     fn poll_next(
         mut self: core::pin::Pin<&mut Self>,
-        _cx: &mut core::task::Context<'_>,
+        cx: &mut core::task::Context<'_>,
     ) -> core::task::Poll<Option<Self::Item>> {
-        let Some(row) = self.events.pop_front() else {
-            return core::task::Poll::Ready(None);
-        };
-        #[cfg(debug_assertions)]
-        {
-            if let Some(prev) = self.prev_version {
-                debug_assert!(
-                    row.version > prev,
-                    "EventStream monotonicity violated: version {} is not greater than previous {}",
-                    row.version,
-                    prev,
-                );
-            }
-            self.prev_version = Some(row.version);
-        }
-        core::task::Poll::Ready(Some(frame_to_envelope(&row)))
+        self.inner.as_mut().poll_next(cx)
     }
 }
 
@@ -244,6 +265,18 @@ fn frame_to_envelope(frame: &StoredFrame) -> Result<PersistedEnvelope, InMemoryS
         version: frame.version,
         source,
     })
+}
+
+/// Collect up to `batch_size` frames with `version >= from`, in version order.
+///
+/// `rows` is in insertion = version order, so the matching frames are a
+/// contiguous suffix; `take(batch_size)` bounds the materialized slice.
+fn scan_batch(rows: &[StoredFrame], from: u64, batch_size: usize) -> VecDeque<StoredFrame> {
+    rows.iter()
+        .filter(|r| r.version >= from)
+        .take(batch_size)
+        .cloned()
+        .collect()
 }
 
 impl RawEventStore for InMemoryStore {
@@ -328,23 +361,63 @@ impl RawEventStore for InMemoryStore {
     }
 
     async fn read_stream(&self, id: &impl Id, from: Version) -> Result<Self::Stream, Self::Error> {
-        let key = id.to_string();
-        let events: std::collections::VecDeque<StoredFrame> = self
-            .streams
-            .lock()
-            .await
-            .get(&key)
-            .map(|rows| {
-                rows.iter()
-                    .filter(|r| r.version >= from.as_u64())
-                    .cloned()
-                    .collect()
-            })
-            .unwrap_or_default();
-        Ok(InMemoryStream {
-            events,
+        let state = ReadState {
+            streams: Arc::clone(&self.streams),
+            stream_id: id.to_string(),
+            from,
+            last_version: None,
+            batch_size: self.batch_size.get(),
+            buffer: VecDeque::new(),
+            done: false,
             #[cfg(debug_assertions)]
             prev_version: None,
+        };
+
+        let unfolded = futures::stream::unfold(state, |mut s| async move {
+            loop {
+                if let Some(row) = s.buffer.pop_front() {
+                    #[cfg(debug_assertions)]
+                    {
+                        if let Some(prev) = s.prev_version {
+                            debug_assert!(
+                                row.version > prev,
+                                "InMemoryStream monotonicity violated: version {} not > previous {}",
+                                row.version,
+                                prev,
+                            );
+                        }
+                        s.prev_version = Some(row.version);
+                    }
+                    return match frame_to_envelope(&row) {
+                        Ok(env) => {
+                            s.last_version = Some(env.version());
+                            Some((Ok(env), s))
+                        }
+                        Err(e) => {
+                            s.done = true;
+                            Some((Err(e), s))
+                        }
+                    };
+                }
+                if s.done {
+                    return None;
+                }
+                let next_from = match s.next_read_version() {
+                    Ok(v) => v,
+                    Err(e) => {
+                        s.done = true;
+                        return Some((Err(e), s));
+                    }
+                };
+                s.refill(next_from).await;
+                if s.buffer.is_empty() {
+                    return None;
+                }
+            }
+        });
+
+        Ok(InMemoryStream {
+            inner: Box::pin(futures::StreamExt::fuse(unfolded)),
         })
     }
 }
@@ -366,7 +439,7 @@ impl RawEventStore for InMemoryStore {
 struct SubState {
     store: Arc<InMemoryStore>,
     stream_id: String,
-    buffer: std::collections::VecDeque<StoredFrame>,
+    buffer: VecDeque<StoredFrame>,
     last_version: Option<Version>,
     /// Keeps this stream's wake entry registered for the cursor's whole
     /// life and supplies the per-stream `Notify`. Dropped with the cursor,
@@ -448,7 +521,7 @@ impl RawSubscription for InMemoryStore {
         let mut state = SubState {
             store: Arc::clone(arc),
             stream_id,
-            buffer: std::collections::VecDeque::new(),
+            buffer: VecDeque::new(),
             last_version: from,
             guard,
             #[cfg(debug_assertions)]
@@ -527,5 +600,124 @@ mod batch_config_tests {
     fn with_batch_size_overrides_default() {
         let store = InMemoryStore::with_batch_size(BatchSize::new(8).unwrap());
         assert_eq!(store.batch_size().get(), 8);
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::cast_possible_truncation,
+    clippy::as_conversions,
+    reason = "test code"
+)]
+mod bounded_read_tests {
+    use super::*;
+    use crate::batch::BatchSize;
+    use crate::envelope::pending_envelope;
+    use futures::StreamExt;
+
+    #[derive(Debug, Clone, Hash, PartialEq, Eq)]
+    struct Tid(String);
+    impl std::fmt::Display for Tid {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.write_str(&self.0)
+        }
+    }
+    impl AsRef<[u8]> for Tid {
+        fn as_ref(&self) -> &[u8] {
+            self.0.as_bytes()
+        }
+    }
+    impl nexus::Id for Tid {
+        const BYTE_LEN: usize = 0;
+    }
+
+    fn env(v: u64) -> PendingEnvelope {
+        pending_envelope(Version::new(v).unwrap())
+            .event_type("E")
+            .payload(vec![v as u8])
+            .unwrap()
+            .build()
+    }
+
+    async fn seed(store: &InMemoryStore, id: &Tid, count: u64) {
+        for v in 1..=count {
+            let expected = Version::new(v - 1);
+            store.append(id, expected, &[env(v)]).await.unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn read_yields_all_events_across_refills() {
+        let store = InMemoryStore::with_batch_size(BatchSize::new(4).unwrap());
+        let id = Tid("s".into());
+        seed(&store, &id, 14).await;
+
+        let mut stream = store.read_stream(&id, Version::INITIAL).await.unwrap();
+        let mut seen = Vec::new();
+        while let Some(item) = stream.next().await {
+            seen.push(item.unwrap().version().as_u64());
+        }
+        assert_eq!(seen, (1..=14).collect::<Vec<_>>());
+    }
+
+    #[tokio::test]
+    async fn read_terminates_at_exact_batch_boundary() {
+        let store = InMemoryStore::with_batch_size(BatchSize::new(4).unwrap());
+        let id = Tid("s".into());
+        seed(&store, &id, 4).await;
+
+        let mut stream = store.read_stream(&id, Version::INITIAL).await.unwrap();
+        let mut seen = Vec::new();
+        while let Some(item) = stream.next().await {
+            seen.push(item.unwrap().version().as_u64());
+        }
+        assert_eq!(seen, vec![1, 2, 3, 4]);
+    }
+
+    #[tokio::test]
+    async fn read_empty_stream_yields_nothing() {
+        let store = InMemoryStore::with_batch_size(BatchSize::new(4).unwrap());
+        let id = Tid("missing".into());
+        let mut stream = store.read_stream(&id, Version::INITIAL).await.unwrap();
+        assert!(stream.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn read_from_midpoint_resumes_correctly() {
+        let store = InMemoryStore::with_batch_size(BatchSize::new(3).unwrap());
+        let id = Tid("s".into());
+        seed(&store, &id, 10).await;
+        let mut stream = store
+            .read_stream(&id, Version::new(6).unwrap())
+            .await
+            .unwrap();
+        let mut seen = Vec::new();
+        while let Some(item) = stream.next().await {
+            seen.push(item.unwrap().version().as_u64());
+        }
+        assert_eq!(seen, vec![6, 7, 8, 9, 10]);
+    }
+
+    // Error paths in the unfold closure set `s.done = true` before returning
+    // `Some((Err(_), s))`, so an errored stream goes terminal. In-memory frames
+    // are always valid, so the error path can't be injected cheaply here; the
+    // observable terminal property is the same one the fuse guarantees, so we
+    // assert that a fully drained stream keeps returning `None`.
+    #[tokio::test]
+    async fn read_stays_none_after_exhaustion() {
+        let store = InMemoryStore::with_batch_size(BatchSize::new(4).unwrap());
+        let id = Tid("s".into());
+        seed(&store, &id, 5).await;
+        let mut stream = store.read_stream(&id, Version::INITIAL).await.unwrap();
+        let mut count = 0u64;
+        while let Some(item) = stream.next().await {
+            item.unwrap();
+            count += 1;
+        }
+        assert_eq!(count, 5);
+        // Exhausted stream must keep returning None (fused), not panic or re-yield.
+        assert!(stream.next().await.is_none());
+        assert!(stream.next().await.is_none());
     }
 }

--- a/crates/nexus-store/src/testing.rs
+++ b/crates/nexus-store/src/testing.rs
@@ -759,10 +759,10 @@ mod bounded_subscription_tests {
 
     #[tokio::test]
     async fn subscription_drains_many_batches_then_sees_new_event() {
-        // batch_size 4; pre-seed 10 (catch-up across 3 refills), then push 1 live.
+        // batch_size 4; pre-seed 40 (10× batch_size backlog, 10 full refills), then push 1 live.
         let store = Arc::new(InMemoryStore::with_batch_size(BatchSize::new(4).unwrap()));
         let id = Tid("s".into());
-        for v in 1..=10 {
+        for v in 1..=40 {
             store
                 .append(&id, Version::new(v - 1), &[env(v)])
                 .await
@@ -771,7 +771,7 @@ mod bounded_subscription_tests {
 
         let mut sub = InMemoryStore::subscribe(&store, &id, None).await.unwrap();
 
-        for expected in 1..=10u64 {
+        for expected in 1..=40u64 {
             let got = sub.next().await.unwrap().unwrap();
             assert_eq!(got.version().as_u64(), expected);
         }
@@ -780,11 +780,11 @@ mod bounded_subscription_tests {
         let id2 = id.clone();
         tokio::spawn(async move {
             store2
-                .append(&id2, Version::new(10), &[env(11)])
+                .append(&id2, Version::new(40), &[env(41)])
                 .await
                 .unwrap();
         });
         let live = sub.next().await.unwrap().unwrap();
-        assert_eq!(live.version().as_u64(), 11);
+        assert_eq!(live.version().as_u64(), 41);
     }
 }

--- a/crates/nexus-store/src/testing.rs
+++ b/crates/nexus-store/src/testing.rs
@@ -1,5 +1,6 @@
 //! Test utilities for nexus-store. Gated behind the `testing` feature.
 
+use crate::batch::BatchSize;
 use crate::envelope::{EnvelopeError, PendingEnvelope, PersistedEnvelope};
 use crate::error::AppendError;
 use crate::notify::{NotifyError, StreamNotifiers, SubscriptionGuard};
@@ -92,20 +93,34 @@ struct StoredFrame {
 /// - **Distributed concurrency**: Single-process only. Cannot simulate
 ///   multiple writers on different machines racing on the same stream.
 pub struct InMemoryStore {
-    streams: Mutex<HashMap<String, Vec<StoredFrame>>>,
+    streams: Arc<Mutex<HashMap<String, Vec<StoredFrame>>>>,
     notifiers: Arc<StreamNotifiers>,
     next_global_seq: Mutex<GlobalSeq>,
+    batch_size: BatchSize,
 }
 
 impl InMemoryStore {
-    /// Create a new empty in-memory store.
+    /// Create a new empty in-memory store with the default batch size.
     #[must_use]
     pub fn new() -> Self {
+        Self::with_batch_size(BatchSize::DEFAULT)
+    }
+
+    /// Create a new empty in-memory store with an explicit batch size.
+    #[must_use]
+    pub fn with_batch_size(batch_size: BatchSize) -> Self {
         Self {
-            streams: Mutex::new(HashMap::new()),
+            streams: Arc::new(Mutex::new(HashMap::new())),
             notifiers: StreamNotifiers::new(),
             next_global_seq: Mutex::new(GlobalSeq::INITIAL),
+            batch_size,
         }
+    }
+
+    /// The configured read / refill batch size.
+    #[must_use]
+    pub const fn batch_size(&self) -> BatchSize {
+        self.batch_size
     }
 }
 
@@ -493,5 +508,24 @@ impl RawSubscription for InMemoryStore {
         Ok(InMemorySubscriptionStream {
             inner: Box::pin(unfolded),
         })
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, reason = "test code")]
+mod batch_config_tests {
+    use super::*;
+    use crate::batch::{BatchSize, DEFAULT_BATCH};
+
+    #[test]
+    fn default_store_uses_default_batch() {
+        let store = InMemoryStore::new();
+        assert_eq!(store.batch_size().get(), DEFAULT_BATCH);
+    }
+
+    #[test]
+    fn with_batch_size_overrides_default() {
+        let store = InMemoryStore::with_batch_size(BatchSize::new(8).unwrap());
+        assert_eq!(store.batch_size().get(), 8);
     }
 }

--- a/crates/nexus-store/src/testing.rs
+++ b/crates/nexus-store/src/testing.rs
@@ -441,6 +441,7 @@ struct SubState {
     stream_id: String,
     buffer: VecDeque<StoredFrame>,
     last_version: Option<Version>,
+    batch_size: usize,
     /// Keeps this stream's wake entry registered for the cursor's whole
     /// life and supplies the per-stream `Notify`. Dropped with the cursor,
     /// which reaps the entry once the last subscriber leaves.
@@ -455,12 +456,7 @@ impl SubState {
             let guard = self.store.streams.lock().await;
             guard
                 .get(&self.stream_id)
-                .map(|rows| {
-                    rows.iter()
-                        .filter(|r| r.version >= from_version.as_u64())
-                        .cloned()
-                        .collect()
-                })
+                .map(|rows| scan_batch(rows, from_version.as_u64(), self.batch_size))
                 .unwrap_or_default()
         };
         self.buffer = buffer;
@@ -523,6 +519,7 @@ impl RawSubscription for InMemoryStore {
             stream_id,
             buffer: VecDeque::new(),
             last_version: from,
+            batch_size: arc.batch_size().get(),
             guard,
             #[cfg(debug_assertions)]
             prev_version: from.map(Version::as_u64),
@@ -719,5 +716,75 @@ mod bounded_read_tests {
         // Exhausted stream must keep returning None (fused), not panic or re-yield.
         assert!(stream.next().await.is_none());
         assert!(stream.next().await.is_none());
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::cast_possible_truncation,
+    clippy::as_conversions,
+    reason = "test code"
+)]
+mod bounded_subscription_tests {
+    use super::*;
+    use crate::batch::BatchSize;
+    use crate::envelope::pending_envelope;
+    use crate::subscription::RawSubscription;
+    use futures::StreamExt;
+
+    #[derive(Debug, Clone, Hash, PartialEq, Eq)]
+    struct Tid(String);
+    impl std::fmt::Display for Tid {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.write_str(&self.0)
+        }
+    }
+    impl AsRef<[u8]> for Tid {
+        fn as_ref(&self) -> &[u8] {
+            self.0.as_bytes()
+        }
+    }
+    impl nexus::Id for Tid {
+        const BYTE_LEN: usize = 0;
+    }
+
+    fn env(v: u64) -> PendingEnvelope {
+        pending_envelope(Version::new(v).unwrap())
+            .event_type("E")
+            .payload(vec![v as u8])
+            .unwrap()
+            .build()
+    }
+
+    #[tokio::test]
+    async fn subscription_drains_many_batches_then_sees_new_event() {
+        // batch_size 4; pre-seed 10 (catch-up across 3 refills), then push 1 live.
+        let store = Arc::new(InMemoryStore::with_batch_size(BatchSize::new(4).unwrap()));
+        let id = Tid("s".into());
+        for v in 1..=10 {
+            store
+                .append(&id, Version::new(v - 1), &[env(v)])
+                .await
+                .unwrap();
+        }
+
+        let mut sub = InMemoryStore::subscribe(&store, &id, None).await.unwrap();
+
+        for expected in 1..=10u64 {
+            let got = sub.next().await.unwrap().unwrap();
+            assert_eq!(got.version().as_u64(), expected);
+        }
+
+        let store2 = Arc::clone(&store);
+        let id2 = id.clone();
+        tokio::spawn(async move {
+            store2
+                .append(&id2, Version::new(10), &[env(11)])
+                .await
+                .unwrap();
+        });
+        let live = sub.next().await.unwrap().unwrap();
+        assert_eq!(live.version().as_u64(), 11);
     }
 }

--- a/crates/nexus-store/tests/bounded_batch_proptest.rs
+++ b/crates/nexus-store/tests/bounded_batch_proptest.rs
@@ -1,0 +1,84 @@
+//! Property: a bounded paginating read yields exactly the stream's events,
+//! in order, regardless of how `batch_size` chunks them.
+#![allow(clippy::unwrap_used, reason = "test code")]
+#![allow(
+    clippy::as_conversions,
+    clippy::cast_possible_truncation,
+    reason = "test code"
+)]
+
+use futures::StreamExt;
+use nexus::Version;
+use nexus_store::batch::BatchSize;
+use nexus_store::envelope::pending_envelope;
+use nexus_store::store::RawEventStore;
+use nexus_store::testing::InMemoryStore;
+use proptest::prelude::*;
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+struct Tid(String);
+
+impl std::fmt::Display for Tid {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl AsRef<[u8]> for Tid {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_bytes()
+    }
+}
+
+impl nexus::Id for Tid {
+    const BYTE_LEN: usize = 0;
+}
+
+fn batch_strategy() -> impl Strategy<Value = usize> {
+    prop_oneof![
+        Just(1usize),
+        Just(2),
+        Just(255),
+        Just(256),
+        Just(257),
+        1usize..512
+    ]
+}
+
+fn len_strategy() -> impl Strategy<Value = u64> {
+    prop_oneof![
+        Just(0u64),
+        Just(1),
+        Just(255),
+        Just(256),
+        Just(257),
+        0u64..600
+    ]
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+    #[test]
+    fn read_yields_all_in_order(batch in batch_strategy(), len in len_strategy()) {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let store = InMemoryStore::with_batch_size(BatchSize::new(batch).unwrap());
+            let id = Tid("s".into());
+            for v in 1..=len {
+                let env = pending_envelope(Version::new(v).unwrap())
+                    .event_type("E")
+                    .payload(vec![(v % 256) as u8])
+                    .unwrap()
+                    .build();
+                store.append(&id, Version::new(v - 1), &[env]).await.unwrap();
+            }
+            let mut stream = store.read_stream(&id, Version::INITIAL).await.unwrap();
+            let mut seen = Vec::new();
+            while let Some(item) = stream.next().await {
+                seen.push(item.unwrap().version().as_u64());
+            }
+            prop_assert_eq!(seen, (1..=len).collect::<Vec<_>>());
+            Ok(())
+        })?;
+    }
+}

--- a/docs/plans/2026-06-16-bounded-batch-size-design.md
+++ b/docs/plans/2026-06-16-bounded-batch-size-design.md
@@ -1,0 +1,188 @@
+# Bounded Subscription / Read Batch Size
+
+**Date:** 2026-06-16
+**Status:** Approved
+**Issue:** [#176](https://github.com/devrandom-labs/nexus/issues/176) — *Bound subscription/read batch size: compile-time const cap + runtime config*
+**Scope:** `nexus-store` (`testing.rs` in-memory adapter, a new batch-size const), `nexus-fjall` (store, stream, subscription cursor, builder)
+
+## Problem
+
+`FjallStore::read_stream` and both subscription cursors load the **entire** remaining
+stream — `from_version..=u64::MAX` — into a single `Vec` before yielding the first
+event:
+
+- `crates/nexus-fjall/src/store.rs:254` — `range(start..=end).collect::<Vec<_>>()`
+- `crates/nexus-fjall/src/subscription_stream.rs:157` — `refill` calls `read_stream`
+- `crates/nexus-store/src/testing.rs:315` — `read_stream` filters + collects all rows
+- `crates/nexus-store/src/testing.rs:365` — in-memory subscription `refill`, same shape
+
+There is no batch-size cap, no compile-time bound, no operator-configurable limit. A
+consumer that falls behind a high-throughput writer, a large catch-up replay, or a
+pathological aggregate stream loads an unbounded number of events into RAM before the
+first yield. On the project's IoT/mobile targets this can OOM the process.
+
+## Goals
+
+1. **Hard resident-memory bound.** No read path ever holds more than `batch_size` event
+   rows in memory at once.
+2. **Compile-time ceiling.** A `const MAX_BATCH` baked into the binary; runtime config
+   that exceeds it is rejected at builder time, not silently clamped.
+3. **Operator-configurable batch size.** `FjallStoreBuilder::batch_size(n)` and
+   `InMemoryStore::with_batch_size(n)`, defaulting to a sane value.
+4. **Transparent refill on the one-shot read path too.** `FjallStream` / `InMemoryStream`
+   paginate internally until the persisted stream is exhausted — callers see the same
+   `next()` contract; chunking is invisible.
+5. **No churn to the trait surface.** `RawEventStore::read_stream(&self, …)` keeps its
+   signature; the change stays inside the two adapters plus one shared const.
+
+## Non-Goals
+
+- Backpressure on writers when subscribers are slow (separate, larger design — see issue).
+- A streaming-without-iterator cursor (per-event fjall range scan) — explicitly ruled out
+  in the design walkthrough as the wrong tradeoff.
+- Bounding the *global* (all-streams) log scan — no such read path exists yet.
+
+## Key facts established during design
+
+These are load-bearing; the design depends on them.
+
+### Batch buffer: `Vec` + `take(batch_size)`, not `ArrayVec`
+
+Both options bound resident memory equally — neither scans more than `batch_size` rows.
+`ArrayVec<(Slice, Slice), MAX>`'s only added property is stack residence (no heap alloc),
+but `(Slice, Slice)` is ~64 bytes (`bytes::Bytes` is four machine words), so
+`ArrayVec<_, 4096>` is ~256 KiB **inline on the stack**, moved with the cursor — the wrong
+place for a buffer of that size on the small-stack targets we care about. It also has no
+O(1) `pop_front`, so the existing front-drain `VecDeque` cursor would have to become an
+index cursor. `Vec`/`VecDeque` capped by `.take(batch_size)` bounds memory just as hard,
+puts the buffer on the heap where it belongs, validates against the `const` ceiling, and
+fits the existing cursor unchanged.
+
+### fjall `range()` is lazy — `.take(batch_size)` *is* the bound
+
+`Keyspace::range()` (fjall 3.1.4, `keyspace/mod.rs:444`) returns `Iter`, a
+`Box<dyn DoubleEndedIterator>` (`iter.rs:7`) pulled one `next()` at a time. `.take(n)`
+genuinely stops the LSM scan after `n` items — it does not scan-then-truncate. fjall's own
+docs warn against unbounded ranges *"unless limited"*; `.take()` is that limiting. So the
+bound is literally `range(start..=end).take(batch_size)`.
+
+### The fjall keyspace handle is a cheap Arc clone
+
+`SingleWriterTxKeyspace` is `#[derive(Clone)]` over `Keyspace(Arc<KeyspaceInner>)`
+(`keyspace/mod.rs:158`). `FjallStream` can hold a clone of the `events` handle and refill
+itself — no `Arc<FjallStore>` threading, no `read_stream` signature change.
+
+### Snapshots exist but must NOT be used here
+
+fjall offers `db.snapshot()` / `read_tx()` → `Snapshot: Readable` for repeatable reads.
+We deliberately avoid them: the `Iter` holds a `SnapshotNonce` that **pins fjall's GC
+watermark while alive** — which is exactly why today's `FjallStream` eagerly loads then
+drops the iterator (`stream.rs:16`: *"no LSM-tree iterator stays open while the stream is
+held"*). A long-lived subscription holding a snapshot open would block compaction
+indefinitely.
+
+We don't need a snapshot anyway. The event store is **append-only with gapless per-stream
+versions**: version N's bytes never change once written, and a stream's versions are a
+contiguous `1..=N`. So keyset pagination (resume at `last_version + 1`) across independent
+scans can only ever observe *more* events, never changed or missing ones. Immutability is
+the snapshot. Re-scanning per batch preserves the no-GC-pinning property.
+
+## Design
+
+### The shared primitive: bounded scan + keyset resume
+
+One read primitive, two termination rules:
+
+| | source of next batch | termination |
+|---|---|---|
+| one-shot read (`read_stream`) | scan from `next_version`, `take(batch_size)` | batch shorter than `batch_size` → end of persisted data → `None` |
+| subscription | same | shorter batch → park on the per-stream wake registry, then re-scan |
+
+Both hold at most `batch_size` rows resident. A refill that returns exactly `batch_size`
+rows is ambiguous (there may be more), so the cursor always attempts another scan; a
+short or empty batch is the unambiguous end-of-data signal.
+
+### `nexus-store` — the const + the in-memory adapter
+
+- **`const MAX_BATCH: usize = 4096`** and **`const DEFAULT_BATCH: usize = 256`**, defined
+  in `nexus-store` (the crate both adapters depend on) so the ceiling is shared. A
+  `BatchSize` newtype validating `1..=MAX_BATCH` at construction carries the invariant by
+  type rather than re-checking it in each builder.
+- **`InMemoryStore`**: its `streams` map moves behind a shared handle so the returned
+  `InMemoryStream` can re-read for refills (the store already holds the data; the stream
+  needs read access to it). `read_stream` filters `version >= from` and `.take(batch_size)`.
+  `InMemoryStream` keyset-resumes at `last_version + 1` when its buffer drains, terminating
+  on a short batch. `InMemoryStore::with_batch_size(n)` sets the limit (rejecting
+  `n > MAX_BATCH`); default `DEFAULT_BATCH`.
+
+### `nexus-fjall` — store, stream, subscription, builder
+
+- **`read_stream`**: `range(start..=end).take(self.batch_size)` instead of collecting the
+  whole tail. Still loads the first batch eagerly (so the first `poll` is IO-free), then
+  drops the `Iter` (no GC pin).
+- **`FjallStream`** gains `{ events: SingleWriterTxKeyspace, id: OwnedStreamId,
+  next_version, batch_size, done }`. When the `VecDeque` drains and `!done`, it re-scans
+  `range(next_key..=end).take(batch_size)` synchronously (fjall scans are sync), advancing
+  `next_version`. A batch shorter than `batch_size` sets `done`. `poll` returns `None` only
+  when `done && empty`.
+- **Subscription cursor** (`FjallSubscriptionStream`): unchanged in shape. It already
+  drives a `FjallStream` via `poll_one` and parks on the wake registry when empty; now the
+  inner `FjallStream` is itself bounded + paginating, so each catch-up cycle is capped.
+- **`FjallStoreBuilder::batch_size(n)`**: stores the validated `BatchSize` on `FjallStore`;
+  rejected at `open()` (or at the setter) if `n > MAX_BATCH`. Default `DEFAULT_BATCH`.
+  `FjallStore` carries the `batch_size` so `read_stream` and `subscribe` both read it.
+
+### Configuration values
+
+- `DEFAULT_BATCH = 256` — resident cost ≈ `batch_size × avg row size` (256 × ~1 KiB ≈
+  256 KiB), acceptable on mobile.
+- `MAX_BATCH = 4096` — 16× headroom for server deployments while keeping the validated
+  ceiling meaningful.
+
+These are tunables, not load-bearing constants; changing them is a one-line edit.
+
+## Error handling
+
+- Oversized batch-size config is an **input validation error**, surfaced at the builder /
+  setter — distinct from corruption or IO errors (per the crate's "input validation errors
+  are not corruption errors" rule). fjall: a new `FjallError` variant or a builder-time
+  `Result`. In-memory: `with_batch_size` returns `Result` (or takes a pre-validated
+  `BatchSize`).
+- Keyset-resume arithmetic (`last_version + 1`) already uses `Version::next()` →
+  `VersionOverflow`; reused unchanged.
+- Refill IO/corruption errors propagate as today: a yielded `Err` poisons the cursor.
+
+## Testing (the 4 cross-cutting categories first)
+
+1. **Sequence/Protocol** — append 10× `batch_size` events; one-shot `read_stream` yields all
+   of them, in strict version order, across multiple internal refills. Subscription falls
+   behind a writer pushing 10× `batch_size`; consumer drains correctly across refills.
+2. **Lifecycle** — write > `batch_size` events, close, reopen, read: all events recovered
+   across refills in order. (fjall only.)
+3. **Defensive boundary** — `batch_size` of exactly `1`, exactly `MAX_BATCH`, and
+   `MAX_BATCH + 1` (rejected at builder). Stream length of exactly `batch_size` (the
+   ambiguous-refill boundary: must still terminate correctly, not hang or double-yield).
+   Empty stream, single-event stream.
+4. **Linearizability/Isolation** — concurrent writer appending while a reader paginates;
+   assert the reader sees a monotonic, gap-free version sequence (immutability guarantee)
+   and never a torn batch.
+
+Then the standard methodologies. Property test: for random `stream_len` and `batch_size`
+(strategies include `0, 1, MAX-1, MAX` boundaries), `read_stream` yields exactly
+`stream_len` events in order regardless of how the chunk boundaries fall.
+
+Each invariant is tested once in a canonical location; in-memory and fjall share the
+behavioral assertions where the adapter difference is irrelevant.
+
+## Documentation
+
+- `RawEventStore::read_stream` doc: events arrive in chunks; the cursor refills internally;
+  callers see the same `next()` contract.
+- `Subscription::subscribe` doc: catch-up is bounded per cycle by the configured batch size.
+- Both builders' `batch_size` setters: default, ceiling, and rejection behavior.
+
+## Out of scope (restated)
+
+- Writer backpressure.
+- Per-event (iterator-held-open) streaming.
+- All-streams / global-log bounded scan.

--- a/docs/plans/2026-06-16-bounded-batch-size-implementation.md
+++ b/docs/plans/2026-06-16-bounded-batch-size-implementation.md
@@ -1,0 +1,1543 @@
+# Bounded Batch Size Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Cap how many event rows `read_stream` and subscription refills hold in memory at once, with a compile-time ceiling and a runtime-configurable batch size, so a slow consumer or large replay cannot OOM the process.
+
+**Architecture:** A validated `BatchSize` newtype (`1..=MAX_BATCH`) lives in `nexus-store`. Each adapter's read cursor loads at most `batch_size` rows, then refills the next batch by keyset resume (`last_version + 1`) until a short batch signals end-of-data (one-shot read → `None`; subscription → park on the wake registry). This works without transactional snapshots because the event store is append-only with gapless per-stream versions.
+
+**Tech Stack:** Rust 2024, `fjall` 3.1.4 (lazy `range().take(n)`), `futures::Stream` / `stream::unfold`, `tokio` (in-memory test store), `thiserror`, `proptest`. Build/test via `nix develop -c cargo …`.
+
+**Spec:** `docs/plans/2026-06-16-bounded-batch-size-design.md`
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `crates/nexus-store/src/batch.rs` | `BatchSize` newtype, `MAX_BATCH`/`DEFAULT_BATCH`, `BatchSizeError` | **create** |
+| `crates/nexus-store/src/lib.rs` | module decl + re-export | modify |
+| `crates/nexus-store/src/store.rs` | doc the refill chunking on `read_stream` | modify (docs) |
+| `crates/nexus-store/src/subscription.rs` | doc bounded catch-up on `subscribe` | modify (docs) |
+| `crates/nexus-store/src/testing.rs` | `InMemoryStore` batch config, Arc-wrap map, paginating `InMemoryStream`, bounded subscription refill | modify |
+| `crates/nexus-fjall/src/error.rs` | host `pub(crate) reason_label` (moved from store.rs) | modify |
+| `crates/nexus-fjall/src/store.rs` | `batch_size` field, bounded `read_stream` | modify |
+| `crates/nexus-fjall/src/stream.rs` | extract `decode_row`, paginating `FjallStream` | modify |
+| `crates/nexus-fjall/src/builder.rs` | `batch_size(BatchSize)` setter | modify |
+
+---
+
+## Task 1: `BatchSize` newtype + ceiling const (nexus-store)
+
+**Files:**
+- Create: `crates/nexus-store/src/batch.rs`
+- Modify: `crates/nexus-store/src/lib.rs:83` (module decls) and `:130` area (re-exports)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `crates/nexus-store/src/batch.rs` with the test module only at first is not allowed (the SUT must exist to compile). Instead create the full file in Step 3; here, write the tests appended to the same file. To keep TDD honest, write the test module now and the impl in Step 3 — but the file must compile, so write both in Step 3 and run the test first there. Practically: create the file in Step 3, then run tests. (This task's "fail" gate is Step 2's compile error before the file exists.)
+
+Test code to include in `crates/nexus-store/src/batch.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::{BatchSize, BatchSizeError, DEFAULT_BATCH, MAX_BATCH};
+
+    #[test]
+    fn rejects_zero() {
+        let err = BatchSize::new(0).unwrap_err();
+        assert_eq!(err, BatchSizeError { requested: 0, max: MAX_BATCH });
+    }
+
+    #[test]
+    fn rejects_above_max() {
+        let err = BatchSize::new(MAX_BATCH + 1).unwrap_err();
+        assert_eq!(err.requested, MAX_BATCH + 1);
+        assert_eq!(err.max, MAX_BATCH);
+    }
+
+    #[test]
+    fn accepts_lower_and_upper_bound() {
+        assert_eq!(BatchSize::new(1).expect("1 is valid").get(), 1);
+        assert_eq!(BatchSize::new(MAX_BATCH).expect("MAX is valid").get(), MAX_BATCH);
+    }
+
+    #[test]
+    fn default_is_default_batch() {
+        assert_eq!(BatchSize::DEFAULT.get(), DEFAULT_BATCH);
+        assert_eq!(BatchSize::default().get(), DEFAULT_BATCH);
+    }
+}
+```
+
+- [ ] **Step 2: Verify it fails to compile**
+
+Run: `nix develop -c cargo build -p nexus-store`
+Expected: FAIL — `file not found for module batch` (until Step 3 adds the module decl) / `cannot find type BatchSize`.
+
+- [ ] **Step 3: Write the implementation**
+
+Prepend to `crates/nexus-store/src/batch.rs` (above the test module):
+
+```rust
+//! Bounded batch size for stream reads and subscription refills.
+//!
+//! Read paths never materialize more than `batch_size` event rows at once.
+//! [`BatchSize`] carries the `1..=MAX_BATCH` invariant by construction, so an
+//! out-of-range value is unrepresentable past [`BatchSize::new`] — the builder
+//! that accepts a `BatchSize` cannot be handed an invalid one.
+
+use thiserror::Error;
+
+/// Largest permitted batch size — the compile-time ceiling on resident rows.
+pub const MAX_BATCH: usize = 4096;
+
+/// Default batch size when none is configured.
+pub const DEFAULT_BATCH: usize = 256;
+
+/// A validated read / refill batch size in `1..=MAX_BATCH`.
+///
+/// Construct via [`BatchSize::new`]; the invalid range is rejected there, so
+/// every `BatchSize` value in the program is in range by construction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BatchSize(usize);
+
+impl BatchSize {
+    /// The default batch size ([`DEFAULT_BATCH`]).
+    pub const DEFAULT: Self = Self(DEFAULT_BATCH);
+
+    /// Construct a `BatchSize`, rejecting `0` and values above [`MAX_BATCH`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BatchSizeError`] if `n == 0` or `n > MAX_BATCH`.
+    pub const fn new(n: usize) -> Result<Self, BatchSizeError> {
+        if n == 0 || n > MAX_BATCH {
+            return Err(BatchSizeError {
+                requested: n,
+                max: MAX_BATCH,
+            });
+        }
+        Ok(Self(n))
+    }
+
+    /// The validated value, always in `1..=MAX_BATCH`.
+    #[must_use]
+    pub const fn get(self) -> usize {
+        self.0
+    }
+}
+
+impl Default for BatchSize {
+    fn default() -> Self {
+        Self::DEFAULT
+    }
+}
+
+/// Error returned when a configured batch size is out of range.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+#[error("batch size must be in 1..={max}, got {requested}")]
+pub struct BatchSizeError {
+    /// The rejected value.
+    pub requested: usize,
+    /// The compile-time maximum ([`MAX_BATCH`]).
+    pub max: usize,
+}
+```
+
+Add the module decl in `crates/nexus-store/src/lib.rs` next to the other `pub mod` lines (alphabetically near `pub mod builder;` at line 83):
+
+```rust
+pub mod batch;
+```
+
+Add the re-export near `pub use store::{GlobalSeq, RawEventStore, Store};` (line 130):
+
+```rust
+pub use batch::{BatchSize, BatchSizeError, DEFAULT_BATCH, MAX_BATCH};
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `nix develop -c cargo nextest run -p nexus-store batch::`
+Expected: PASS — 4 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/nexus-store/src/batch.rs crates/nexus-store/src/lib.rs
+git commit -m "feat(store): BatchSize newtype with MAX_BATCH ceiling (#176)"
+```
+
+(The pre-commit hook runs `nix flake check`; let it complete.)
+
+---
+
+## Task 2: In-memory store — batch config plumbing (nexus-store)
+
+Add the configurable batch size and Arc-wrap the map so the read cursor can refill. No behavior change yet (read still returns everything — bounded in Task 3).
+
+**Files:**
+- Modify: `crates/nexus-store/src/testing.rs:94-110` (struct + constructors), `:244` (append lock), `:315` (read_stream lock)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to the `tests` module of `crates/nexus-store/src/testing.rs` (create the module section if needed — see existing test helpers in that file; if none, add `#[cfg(test)] mod tests { use super::*; ... }` at the end):
+
+```rust
+#[cfg(test)]
+#[allow(clippy::unwrap_used, reason = "test code")]
+mod batch_config_tests {
+    use super::*;
+    use crate::batch::{BatchSize, DEFAULT_BATCH};
+
+    #[test]
+    fn default_store_uses_default_batch() {
+        let store = InMemoryStore::new();
+        assert_eq!(store.batch_size().get(), DEFAULT_BATCH);
+    }
+
+    #[test]
+    fn with_batch_size_overrides_default() {
+        let store = InMemoryStore::with_batch_size(BatchSize::new(8).unwrap());
+        assert_eq!(store.batch_size().get(), 8);
+    }
+}
+```
+
+- [ ] **Step 2: Verify it fails**
+
+Run: `nix develop -c cargo nextest run -p nexus-store --features testing batch_config`
+Expected: FAIL — `no method named batch_size` / `no function with_batch_size`.
+
+- [ ] **Step 3: Write the implementation**
+
+In `crates/nexus-store/src/testing.rs`, update imports at the top (after the existing `use` block):
+
+```rust
+use crate::batch::BatchSize;
+```
+
+Change the struct (lines 94-98) to Arc-wrap the map and carry the batch size:
+
+```rust
+pub struct InMemoryStore {
+    streams: Arc<Mutex<HashMap<String, Vec<StoredFrame>>>>,
+    notifiers: Arc<StreamNotifiers>,
+    next_global_seq: Mutex<GlobalSeq>,
+    batch_size: BatchSize,
+}
+```
+
+Replace `new` and add `with_batch_size` + `batch_size` accessor (lines 100-110):
+
+```rust
+impl InMemoryStore {
+    /// Create a new empty in-memory store with the default batch size.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::with_batch_size(BatchSize::DEFAULT)
+    }
+
+    /// Create a new empty in-memory store with an explicit batch size.
+    #[must_use]
+    pub fn with_batch_size(batch_size: BatchSize) -> Self {
+        Self {
+            streams: Arc::new(Mutex::new(HashMap::new())),
+            notifiers: StreamNotifiers::new(),
+            next_global_seq: Mutex::new(GlobalSeq::INITIAL),
+            batch_size,
+        }
+    }
+
+    /// The configured read / refill batch size.
+    #[must_use]
+    pub const fn batch_size(&self) -> BatchSize {
+        self.batch_size
+    }
+}
+```
+
+The `append` and `read_stream` bodies already call `self.streams.lock().await`; `Arc<Mutex<…>>` derefs to `Mutex`, so those lines are unchanged.
+
+- [ ] **Step 4: Run the tests**
+
+Run: `nix develop -c cargo nextest run -p nexus-store --features testing,subscription`
+Expected: PASS — new batch_config tests plus all existing in-memory tests still green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/nexus-store/src/testing.rs
+git commit -m "feat(store): configurable batch size on InMemoryStore (#176)"
+```
+
+---
+
+## Task 3: In-memory store — bounded, paginating `read_stream`
+
+Replace the all-rows `InMemoryStream` with an unfold cursor that loads `batch_size` rows at a time and keyset-resumes until a short batch ends it.
+
+**Files:**
+- Modify: `crates/nexus-store/src/testing.rs:118-153` (`InMemoryStream`), `:315-335` (`read_stream`)
+- Add: free fn `scan_batch` (shared by read + subscription refill)
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `crates/nexus-store/src/testing.rs` test section:
+
+```rust
+#[cfg(test)]
+#[allow(clippy::unwrap_used, reason = "test code")]
+mod bounded_read_tests {
+    use super::*;
+    use crate::batch::BatchSize;
+    use crate::envelope::pending_envelope;
+    use futures::StreamExt;
+
+    #[derive(Debug, Clone, Hash, PartialEq, Eq)]
+    struct Tid(String);
+    impl std::fmt::Display for Tid {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.write_str(&self.0)
+        }
+    }
+    impl AsRef<[u8]> for Tid {
+        fn as_ref(&self) -> &[u8] {
+            self.0.as_bytes()
+        }
+    }
+    impl nexus::Id for Tid {
+        const BYTE_LEN: usize = 0;
+    }
+
+    fn env(v: u64) -> PendingEnvelope {
+        pending_envelope(Version::new(v).unwrap())
+            .event_type("E")
+            .payload(vec![v as u8])
+            .unwrap()
+            .build()
+    }
+
+    async fn seed(store: &InMemoryStore, id: &Tid, count: u64) {
+        // append one at a time to exercise sequential versions
+        for v in 1..=count {
+            let expected = Version::new(v - 1);
+            store.append(id, expected, &[env(v)]).await.unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn read_yields_all_events_across_refills() {
+        // batch_size 4, 14 events => 4 refills (4+4+4+2)
+        let store = InMemoryStore::with_batch_size(BatchSize::new(4).unwrap());
+        let id = Tid("s".into());
+        seed(&store, &id, 14).await;
+
+        let mut stream = store.read_stream(&id, Version::INITIAL).await.unwrap();
+        let mut seen = Vec::new();
+        while let Some(item) = stream.next().await {
+            seen.push(item.unwrap().version().as_u64());
+        }
+        assert_eq!(seen, (1..=14).collect::<Vec<_>>());
+    }
+
+    #[tokio::test]
+    async fn read_terminates_at_exact_batch_boundary() {
+        // exactly batch_size events: must terminate, not hang or double-yield
+        let store = InMemoryStore::with_batch_size(BatchSize::new(4).unwrap());
+        let id = Tid("s".into());
+        seed(&store, &id, 4).await;
+
+        let mut stream = store.read_stream(&id, Version::INITIAL).await.unwrap();
+        let seen: Vec<u64> = {
+            let mut v = Vec::new();
+            while let Some(item) = stream.next().await {
+                v.push(item.unwrap().version().as_u64());
+            }
+            v
+        };
+        assert_eq!(seen, vec![1, 2, 3, 4]);
+    }
+
+    #[tokio::test]
+    async fn read_empty_stream_yields_nothing() {
+        let store = InMemoryStore::with_batch_size(BatchSize::new(4).unwrap());
+        let id = Tid("missing".into());
+        let mut stream = store.read_stream(&id, Version::INITIAL).await.unwrap();
+        assert!(stream.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn read_from_midpoint_resumes_correctly() {
+        let store = InMemoryStore::with_batch_size(BatchSize::new(3).unwrap());
+        let id = Tid("s".into());
+        seed(&store, &id, 10).await;
+        let mut stream = store.read_stream(&id, Version::new(6).unwrap()).await.unwrap();
+        let mut seen = Vec::new();
+        while let Some(item) = stream.next().await {
+            seen.push(item.unwrap().version().as_u64());
+        }
+        assert_eq!(seen, vec![6, 7, 8, 9, 10]);
+    }
+}
+```
+
+- [ ] **Step 2: Verify it fails**
+
+Run: `nix develop -c cargo nextest run -p nexus-store --features testing,subscription bounded_read`
+Expected: FAIL — `read_yields_all_events_across_refills` returns all 14 today (no bound), but the test will only pass once `InMemoryStream` paginates; before the rewrite it still passes by accident (returns all). To make the test meaningful, it asserts ordering AND the boundary/midpoint cases. The boundary/midpoint tests pass trivially today; the real proof is Task 6's resident-memory assertion. Run and confirm current behavior, then proceed to rewrite.
+
+> Note: these read tests pass against the current all-rows implementation too — they pin the *contract* (all events, in order, across refills). The bound itself is asserted in Task 6. This is intentional: we lock the observable contract here so the rewrite cannot regress it.
+
+- [ ] **Step 3: Write the implementation**
+
+In `crates/nexus-store/src/testing.rs`, add the shared scan helper (place near `frame_to_envelope`):
+
+```rust
+/// Collect up to `batch_size` frames with `version >= from`, in version order.
+///
+/// `rows` is in insertion = version order, so the matching frames are a
+/// contiguous suffix; `take(batch_size)` bounds the materialized slice.
+fn scan_batch(rows: &[StoredFrame], from: u64, batch_size: usize) -> VecDeque<StoredFrame> {
+    rows.iter()
+        .filter(|r| r.version >= from)
+        .take(batch_size)
+        .cloned()
+        .collect()
+}
+```
+
+Add `use std::collections::VecDeque;` to the top imports if not already present (the file uses `std::collections::VecDeque` inline today — add the import and drop the inline paths).
+
+Replace the `InMemoryStream` struct and its `Stream` impl (lines 118-153) with an unfold-backed cursor plus its read state:
+
+```rust
+/// Keyset-paginating read state for a one-shot `read_stream`.
+struct ReadState {
+    streams: Arc<Mutex<HashMap<String, Vec<StoredFrame>>>>,
+    stream_id: String,
+    /// Start version of the *first* batch (used until the first yield).
+    from: Version,
+    last_version: Option<Version>,
+    batch_size: usize,
+    buffer: VecDeque<StoredFrame>,
+    /// Set when a refill returns fewer than `batch_size` rows — no more data.
+    done: bool,
+    #[cfg(debug_assertions)]
+    prev_version: Option<u64>,
+}
+
+impl ReadState {
+    fn next_read_version(&self) -> Result<Version, InMemoryStoreError> {
+        self.last_version.map_or(Ok(self.from), |v| {
+            v.next().ok_or(InMemoryStoreError::VersionOverflow)
+        })
+    }
+
+    async fn refill(&mut self, from: Version) {
+        let batch = {
+            let guard = self.streams.lock().await;
+            guard
+                .get(&self.stream_id)
+                .map(|rows| scan_batch(rows, from.as_u64(), self.batch_size))
+                .unwrap_or_default()
+        };
+        self.done = batch.len() < self.batch_size;
+        self.buffer = batch;
+    }
+}
+
+/// `futures::Stream` of envelopes over an in-memory stream.
+///
+/// Loads at most `batch_size` rows at a time and keyset-resumes
+/// (`last_version + 1`) when the buffer drains, terminating with `None` once a
+/// refill returns a short (or empty) batch.
+pub struct InMemoryStream {
+    inner: core::pin::Pin<
+        Box<dyn futures::Stream<Item = Result<PersistedEnvelope, InMemoryStoreError>> + Send>,
+    >,
+}
+
+impl futures::Stream for InMemoryStream {
+    type Item = Result<PersistedEnvelope, InMemoryStoreError>;
+
+    fn poll_next(
+        mut self: core::pin::Pin<&mut Self>,
+        cx: &mut core::task::Context<'_>,
+    ) -> core::task::Poll<Option<Self::Item>> {
+        self.inner.as_mut().poll_next(cx)
+    }
+}
+```
+
+Replace `read_stream` (lines 315-335) to build the unfold cursor:
+
+```rust
+    async fn read_stream(&self, id: &impl Id, from: Version) -> Result<Self::Stream, Self::Error> {
+        let state = ReadState {
+            streams: Arc::clone(&self.streams),
+            stream_id: id.to_string(),
+            from,
+            last_version: None,
+            batch_size: self.batch_size.get(),
+            buffer: VecDeque::new(),
+            done: false,
+            #[cfg(debug_assertions)]
+            prev_version: None,
+        };
+
+        let unfolded = futures::stream::unfold(state, |mut s| async move {
+            loop {
+                if let Some(row) = s.buffer.pop_front() {
+                    #[cfg(debug_assertions)]
+                    {
+                        if let Some(prev) = s.prev_version {
+                            debug_assert!(
+                                row.version > prev,
+                                "InMemoryStream monotonicity violated: version {} not > previous {}",
+                                row.version,
+                                prev,
+                            );
+                        }
+                        s.prev_version = Some(row.version);
+                    }
+                    return match frame_to_envelope(&row) {
+                        Ok(env) => {
+                            s.last_version = Some(env.version());
+                            Some((Ok(env), s))
+                        }
+                        Err(e) => Some((Err(e), s)),
+                    };
+                }
+                if s.done {
+                    return None;
+                }
+                let from = match s.next_read_version() {
+                    Ok(v) => v,
+                    Err(e) => return Some((Err(e), s)),
+                };
+                s.refill(from).await;
+                if s.buffer.is_empty() {
+                    // refill returned nothing => end of stream
+                    return None;
+                }
+            }
+        });
+
+        Ok(InMemoryStream {
+            inner: Box::pin(unfolded),
+        })
+    }
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `nix develop -c cargo nextest run -p nexus-store --features testing,subscription`
+Expected: PASS — `bounded_read_tests` (4) plus all existing in-memory tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/nexus-store/src/testing.rs
+git commit -m "feat(store): bounded paginating read_stream on InMemoryStore (#176)"
+```
+
+---
+
+## Task 4: In-memory store — bounded subscription refill
+
+Bound the in-memory subscription cursor's refill to `batch_size` and thread the limit through `SubState`.
+
+**Files:**
+- Modify: `crates/nexus-store/src/testing.rs:351-387` (`SubState`), `:417-444` (`subscribe`)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to the test section:
+
+```rust
+#[cfg(test)]
+#[allow(clippy::unwrap_used, reason = "test code")]
+mod bounded_subscription_tests {
+    use super::*;
+    use crate::batch::BatchSize;
+    use crate::envelope::pending_envelope;
+    use crate::subscription::RawSubscription;
+    use futures::StreamExt;
+
+    #[derive(Debug, Clone, Hash, PartialEq, Eq)]
+    struct Tid(String);
+    impl std::fmt::Display for Tid {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.write_str(&self.0)
+        }
+    }
+    impl AsRef<[u8]> for Tid {
+        fn as_ref(&self) -> &[u8] {
+            self.0.as_bytes()
+        }
+    }
+    impl nexus::Id for Tid {
+        const BYTE_LEN: usize = 0;
+    }
+
+    fn env(v: u64) -> PendingEnvelope {
+        pending_envelope(Version::new(v).unwrap())
+            .event_type("E")
+            .payload(vec![v as u8])
+            .unwrap()
+            .build()
+    }
+
+    #[tokio::test]
+    async fn subscription_drains_many_batches_then_sees_new_event() {
+        // batch_size 4; pre-seed 10 (catch-up across 3 refills), then push 1 live.
+        let store = Arc::new(InMemoryStore::with_batch_size(BatchSize::new(4).unwrap()));
+        let id = Tid("s".into());
+        for v in 1..=10 {
+            store.append(&id, Version::new(v - 1), &[env(v)]).await.unwrap();
+        }
+
+        let mut sub = InMemoryStore::subscribe(&store, &id, None).await.unwrap();
+
+        // Drain the 10 catch-up events (bounded internally to 4 at a time).
+        for expected in 1..=10u64 {
+            let got = sub.next().await.unwrap().unwrap();
+            assert_eq!(got.version().as_u64(), expected);
+        }
+
+        // Append a live event; the subscription must surface it after waiting.
+        let store2 = Arc::clone(&store);
+        let id2 = id.clone();
+        tokio::spawn(async move {
+            store2.append(&id2, Version::new(10), &[env(11)]).await.unwrap();
+        });
+        let live = sub.next().await.unwrap().unwrap();
+        assert_eq!(live.version().as_u64(), 11);
+    }
+}
+```
+
+- [ ] **Step 2: Verify it fails (or passes by accident)**
+
+Run: `nix develop -c cargo nextest run -p nexus-store --features testing,subscription bounded_subscription`
+Expected: PASS today (unbounded refill still yields all). As with Task 3, this pins the contract; Task 6 proves the bound. Confirm green, then make the refill bounded so the contract holds under the new limit.
+
+- [ ] **Step 3: Write the implementation**
+
+In `crates/nexus-store/src/testing.rs`, add `batch_size` to `SubState` (lines 351-362):
+
+```rust
+struct SubState {
+    store: Arc<InMemoryStore>,
+    stream_id: String,
+    buffer: std::collections::VecDeque<StoredFrame>,
+    last_version: Option<Version>,
+    batch_size: usize,
+    guard: SubscriptionGuard,
+    #[cfg(debug_assertions)]
+    prev_version: Option<u64>,
+}
+```
+
+Replace `SubState::refill` (lines 365-379) to use the shared bounded scan:
+
+```rust
+    async fn refill(&mut self, from_version: Version) {
+        let buffer = {
+            let guard = self.store.streams.lock().await;
+            guard
+                .get(&self.stream_id)
+                .map(|rows| scan_batch(rows, from_version.as_u64(), self.batch_size))
+                .unwrap_or_default()
+        };
+        self.buffer = buffer;
+    }
+```
+
+In `subscribe` (lines 433-441), set `batch_size` when building `SubState`:
+
+```rust
+        let mut state = SubState {
+            store: Arc::clone(arc),
+            stream_id,
+            buffer: std::collections::VecDeque::new(),
+            last_version: from,
+            batch_size: arc.batch_size.get(),
+            guard,
+            #[cfg(debug_assertions)]
+            prev_version: from.map(Version::as_u64),
+        };
+```
+
+The unfold loop is unchanged: it yields the buffer, refills (now bounded) on empty, and parks on `notified` only when a refill comes back empty. A full bounded batch leaves the buffer non-empty, so the cursor keeps draining without waiting.
+
+- [ ] **Step 4: Run the tests**
+
+Run: `nix develop -c cargo nextest run -p nexus-store --features testing,subscription`
+Expected: PASS — all in-memory + subscription tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/nexus-store/src/testing.rs
+git commit -m "feat(store): bound in-memory subscription refill to batch_size (#176)"
+```
+
+---
+
+## Task 5: fjall — extract `decode_row`, move `reason_label`
+
+Prepare the fjall stream for pagination by extracting the per-row decode (so unit tests don't need a live keyspace) and relocating `reason_label` so both `store.rs` and `stream.rs` can use it.
+
+**Files:**
+- Modify: `crates/nexus-fjall/src/error.rs` (add `pub(crate) reason_label`)
+- Modify: `crates/nexus-fjall/src/store.rs:19-25` (remove local `reason_label`, import it)
+- Modify: `crates/nexus-fjall/src/stream.rs:30-201` (extract `decode_row`, rewrite tests to call it)
+
+- [ ] **Step 1: Write the failing test**
+
+In `crates/nexus-fjall/src/stream.rs`, replace the existing `tests` module's two tests with decode-function tests:
+
+```rust
+#[cfg(test)]
+#[allow(clippy::unwrap_used, reason = "test code")]
+mod tests {
+    use super::*;
+    use crate::encoding::{encode_event_key, encode_event_value};
+
+    fn row(id: &[u8], version: u64, global_seq: u64, et: &str, payload: &[u8]) -> (Slice, Slice) {
+        let key = encode_event_key(id, version).unwrap();
+        let mut val = Vec::new();
+        encode_event_value(&mut val, global_seq, 1, et, None, payload).unwrap();
+        (Slice::from(key), Slice::from(val))
+    }
+
+    #[test]
+    fn decode_row_yields_envelope() {
+        let (k, v) = row(b"user-1", 7, 42, "Created", b"data");
+        let sid = ArrayString::try_from("user-1").unwrap();
+        let env = decode_row(&k, v, sid).unwrap();
+        assert_eq!(env.version(), Version::new(7).unwrap());
+        assert_eq!(env.global_seq(), GlobalSeq::new(42).unwrap());
+        assert_eq!(env.event_type(), "Created");
+        assert_eq!(env.payload(), b"data");
+    }
+
+    #[test]
+    fn decode_row_rejects_truncated_value() {
+        let k = Slice::from(encode_event_key(b"corrupt", 1).unwrap());
+        let v = Slice::from(&[0u8, 1, 2][..]);
+        let sid = ArrayString::try_from("corrupt").unwrap();
+        match decode_row(&k, v, sid).unwrap_err() {
+            FjallError::CorruptValue { stream_id, version } => {
+                assert_eq!(stream_id.as_str(), "corrupt");
+                assert_eq!(version, Some(1));
+            }
+            other => panic!("expected CorruptValue, got {other:?}"),
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Verify it fails**
+
+Run: `nix develop -c cargo nextest run -p nexus-fjall stream::tests::decode_row`
+Expected: FAIL — `cannot find function decode_row`.
+
+- [ ] **Step 3: Write the implementation**
+
+In `crates/nexus-fjall/src/error.rs`, add (after the imports, above the enum):
+
+```rust
+use std::fmt::Write;
+
+/// Format a `Display` value into a stack-allocated reason label,
+/// silently truncating at 128 bytes on a char boundary.
+pub(crate) fn reason_label(value: &impl std::fmt::Display) -> ArrayString<128> {
+    let mut buf = ArrayString::<128>::new();
+    let _ = write!(buf, "{value}");
+    buf
+}
+```
+
+In `crates/nexus-fjall/src/store.rs`, delete the local `reason_label` (lines 19-25) and the now-unused `use std::fmt::Write;` (line 15), and import the shared one — add to the top `use` block:
+
+```rust
+use crate::error::{reason_label, FjallError};
+```
+
+(Replace the existing `use crate::error::FjallError;` line.)
+
+In `crates/nexus-fjall/src/stream.rs`, extract the decode into a free function (place above `impl FjallStream`):
+
+```rust
+/// Decode one stored `(key, value)` row into a [`PersistedEnvelope`].
+///
+/// Pure: no store handle, no cursor state — so unit tests can exercise it
+/// with hand-built rows. Maps every malformed shape to a typed `FjallError`.
+fn decode_row(
+    key: &Slice,
+    value: Slice,
+    stream_id: ArrayString<64>,
+) -> Result<PersistedEnvelope, FjallError> {
+    let (_id_bytes, version) = decode_event_key(key).map_err(|_| FjallError::CorruptValue {
+        stream_id,
+        version: None,
+    })?;
+
+    let bytes_value: Bytes = value.into();
+    let decoded = decode_event_value(&bytes_value).map_err(|_| FjallError::CorruptValue {
+        stream_id,
+        version: Some(version),
+    })?;
+
+    let ver = Version::new(version).ok_or(FjallError::CorruptValue {
+        stream_id,
+        version: Some(version),
+    })?;
+
+    let global_seq = GlobalSeq::new(decoded.global_seq).ok_or(FjallError::CorruptValue {
+        stream_id,
+        version: Some(version),
+    })?;
+
+    PersistedEnvelope::try_new(
+        ver,
+        global_seq,
+        bytes_value,
+        decoded.schema_version,
+        decoded.event_type_range,
+        decoded.payload_range,
+        decoded.metadata_range,
+    )
+    .map_err(|source| FjallError::EnvelopeCorrupt {
+        stream_id,
+        version,
+        source,
+    })
+}
+```
+
+Rewrite the existing `poll_one` (lines 31-101) to delegate to `decode_row`, keeping the poison + debug-monotonicity behavior (the full paginating version lands in Task 6 — for now keep the single-batch behavior so the crate compiles and existing store tests pass):
+
+```rust
+impl FjallStream {
+    pub(crate) fn poll_one(&mut self) -> Option<Result<PersistedEnvelope, FjallError>> {
+        if self.poisoned {
+            return None;
+        }
+        let (key, value) = self.events.pop_front()?;
+        match decode_row(&key, value, self.stream_id) {
+            Ok(env) => {
+                #[cfg(debug_assertions)]
+                {
+                    let v = env.version().as_u64();
+                    if let Some(prev) = self.prev_version {
+                        debug_assert!(
+                            v > prev,
+                            "EventStream monotonicity violated: version {v} is not greater than previous {prev}",
+                        );
+                    }
+                    self.prev_version = Some(v);
+                }
+                Some(Ok(env))
+            }
+            Err(e) => {
+                self.poisoned = true;
+                Some(Err(e))
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `nix develop -c cargo nextest run -p nexus-fjall`
+Expected: PASS — new `decode_row` tests plus all existing store/stream tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/nexus-fjall/src/error.rs crates/nexus-fjall/src/store.rs crates/nexus-fjall/src/stream.rs
+git commit -m "refactor(fjall): extract decode_row, share reason_label (#176)"
+```
+
+---
+
+## Task 6: fjall — paginating `FjallStream` + bounded `read_stream` + builder config
+
+The core change: `FjallStream` holds a cloned `events` keyspace handle and refills itself via `range().take(batch_size)`; `read_stream` builds it bounded; the builder configures the size.
+
+**Files:**
+- Modify: `crates/nexus-fjall/src/stream.rs` (struct fields, constructor, paginating `poll_one`/`refill`)
+- Modify: `crates/nexus-fjall/src/store.rs` (`batch_size` field, simplified bounded `read_stream`)
+- Modify: `crates/nexus-fjall/src/builder.rs` (`batch_size` field + setter, thread into `open`)
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `crates/nexus-fjall/src/store.rs` `tests` module:
+
+```rust
+    use crate::batch_test_helpers::*;
+
+    #[tokio::test]
+    async fn read_yields_all_across_refills() {
+        let (store, _dir) = store_with_batch(4);
+        let id = tid("s");
+        seed(&store, &id, 14).await;
+        let mut stream = store.read_stream(&id, Version::INITIAL).await.unwrap();
+        let mut seen = Vec::new();
+        while let Some(item) = futures::StreamExt::next(&mut stream).await {
+            seen.push(item.unwrap().version().as_u64());
+        }
+        assert_eq!(seen, (1..=14).collect::<Vec<_>>());
+    }
+
+    #[tokio::test]
+    async fn read_terminates_at_exact_batch_boundary() {
+        let (store, _dir) = store_with_batch(4);
+        let id = tid("s");
+        seed(&store, &id, 8).await; // exactly 2 full batches
+        let mut stream = store.read_stream(&id, Version::INITIAL).await.unwrap();
+        let mut count = 0u64;
+        while let Some(item) = futures::StreamExt::next(&mut stream).await {
+            item.unwrap();
+            count += 1;
+        }
+        assert_eq!(count, 8);
+    }
+
+    #[tokio::test]
+    async fn read_reopened_store_recovers_all_across_refills() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("db");
+        let id = tid("s");
+        {
+            let store = FjallStore::builder(&path)
+                .batch_size(nexus_store::batch::BatchSize::new(4).unwrap())
+                .open()
+                .unwrap();
+            seed(&store, &id, 10).await;
+        }
+        let store = FjallStore::builder(&path)
+            .batch_size(nexus_store::batch::BatchSize::new(4).unwrap())
+            .open()
+            .unwrap();
+        let mut stream = store.read_stream(&id, Version::INITIAL).await.unwrap();
+        let mut seen = Vec::new();
+        while let Some(item) = futures::StreamExt::next(&mut stream).await {
+            seen.push(item.unwrap().version().as_u64());
+        }
+        assert_eq!(seen, (1..=10).collect::<Vec<_>>());
+    }
+```
+
+Add a shared test helper module to `crates/nexus-fjall/src/store.rs` (outside the existing `tests` mod, gated on test):
+
+```rust
+#[cfg(test)]
+#[allow(clippy::unwrap_used, reason = "test code")]
+pub(crate) mod batch_test_helpers {
+    use super::*;
+    use nexus_store::batch::BatchSize;
+    use nexus_store::envelope::pending_envelope;
+
+    #[derive(Debug, Clone, Hash, PartialEq, Eq)]
+    pub(crate) struct Tid(pub String);
+    impl std::fmt::Display for Tid {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.write_str(&self.0)
+        }
+    }
+    impl AsRef<[u8]> for Tid {
+        fn as_ref(&self) -> &[u8] {
+            self.0.as_bytes()
+        }
+    }
+    impl nexus::Id for Tid {
+        const BYTE_LEN: usize = 0;
+    }
+
+    pub(crate) fn tid(s: &str) -> Tid {
+        Tid(s.to_owned())
+    }
+
+    pub(crate) fn store_with_batch(n: usize) -> (FjallStore, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = FjallStore::builder(dir.path().join("db"))
+            .batch_size(BatchSize::new(n).unwrap())
+            .open()
+            .unwrap();
+        (store, dir)
+    }
+
+    pub(crate) async fn seed(store: &FjallStore, id: &Tid, count: u64) {
+        for v in 1..=count {
+            let env = pending_envelope(Version::new(v).unwrap())
+                .event_type("E")
+                .payload(vec![v as u8])
+                .unwrap()
+                .build();
+            store.append(id, Version::new(v - 1), &[env]).await.unwrap();
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Verify it fails**
+
+Run: `nix develop -c cargo nextest run -p nexus-fjall read_yields_all_across_refills`
+Expected: FAIL — `no method named batch_size` on the builder.
+
+- [ ] **Step 3: Write the implementation**
+
+**`crates/nexus-fjall/src/builder.rs`** — add the field + setter and thread it into `open`.
+
+Add import at top:
+
+```rust
+use nexus_store::batch::BatchSize;
+```
+
+Add `batch_size: BatchSize` to the struct (after `events_config`):
+
+```rust
+pub struct FjallStoreBuilder<S = (), E = ()> {
+    path: PathBuf,
+    streams_config: S,
+    events_config: E,
+    batch_size: BatchSize,
+}
+```
+
+Set it in `new` (line 29-35) and carry it through the two `streams_config`/`events_config` builders (they reconstruct the struct — add `batch_size: self.batch_size` to each `FjallStoreBuilder { … }` literal at lines 49-53 and 66-70). In `new`:
+
+```rust
+        Self {
+            path: path.as_ref().to_path_buf(),
+            streams_config: (),
+            events_config: (),
+            batch_size: BatchSize::DEFAULT,
+        }
+```
+
+Add the setter in the `impl<S, E> FjallStoreBuilder<S, E>` block:
+
+```rust
+    /// Set the read / refill batch size — the maximum number of event rows
+    /// held in memory at once by a read stream or subscription refill.
+    ///
+    /// Out-of-range values are rejected when constructing the
+    /// [`BatchSize`](nexus_store::batch::BatchSize), so this setter is
+    /// infallible. Defaults to [`BatchSize::DEFAULT`].
+    #[must_use]
+    pub fn batch_size(mut self, batch_size: BatchSize) -> Self {
+        self.batch_size = batch_size;
+        self
+    }
+```
+
+In `open` (line 98-107), pass it into the struct:
+
+```rust
+        Ok(FjallStore {
+            db,
+            streams,
+            events,
+            #[cfg(feature = "snapshot")]
+            snapshots,
+            global,
+            notifiers: StreamNotifiers::new(),
+            batch_size: self.batch_size,
+        })
+```
+
+**`crates/nexus-fjall/src/store.rs`** — add the field and rewrite `read_stream`.
+
+Add imports (top `use` block):
+
+```rust
+use nexus_store::batch::BatchSize;
+```
+
+Add the field to `FjallStore` (after `notifiers`, line 52):
+
+```rust
+    /// Maximum event rows materialized per read batch / refill.
+    pub(crate) batch_size: BatchSize,
+```
+
+Replace `read_stream` (lines 221-278) entirely:
+
+```rust
+    async fn read_stream(&self, id: &impl Id, from: Version) -> Result<Self::Stream, Self::Error> {
+        // A single bounded range scan; a nonexistent stream simply yields an
+        // empty first batch (done), so no separate existence check is needed.
+        FjallStream::new(
+            self.events.clone(),
+            OwnedStreamId::from_id(id),
+            from.as_u64(),
+            self.batch_size.get(),
+            id.to_label(),
+        )
+    }
+```
+
+**`crates/nexus-fjall/src/stream.rs`** — paginating cursor.
+
+Update imports at top:
+
+```rust
+use fjall::{Readable, Slice, SingleWriterTxKeyspace};
+use crate::encoding::{decode_event_key, decode_event_value, encode_event_key};
+use crate::error::{reason_label, FjallError};
+use crate::subscription_stream::OwnedStreamId;
+```
+
+(Keep existing `use` lines for `VecDeque`, `ArrayString`, `Bytes`, `Version`, `GlobalSeq`, `PersistedEnvelope`. `Readable` brings `Keyspace::range` into scope for `self.keyspace.inner().range(...)`.)
+
+Replace the `FjallStream` struct (lines 19-28):
+
+```rust
+pub struct FjallStream {
+    /// Current in-memory batch, drained front-to-back.
+    events: VecDeque<(Slice, Slice)>,
+    /// Cloned `events` partition handle — Arc-backed, cheap to hold; used to
+    /// scan the next batch when `events` drains.
+    keyspace: SingleWriterTxKeyspace,
+    /// Stream key bytes for refill key encoding.
+    id: OwnedStreamId,
+    /// Next version to scan from on the following refill (keyset cursor).
+    next_version: u64,
+    /// Max rows per batch.
+    batch_size: usize,
+    /// Set once a refill returns fewer than `batch_size` rows — no more data.
+    done: bool,
+    stream_id: ArrayString<64>,
+    /// Once an error is yielded, the stream is poisoned — subsequent polls
+    /// return `None` rather than silently skipping corrupt entries.
+    poisoned: bool,
+    #[cfg(debug_assertions)]
+    prev_version: Option<u64>,
+}
+```
+
+Add the constructor + refill, and make `poll_one` paginate (replace the `impl FjallStream` block written in Task 5):
+
+```rust
+impl FjallStream {
+    /// Build a stream and eagerly load the first batch (so the first poll is
+    /// IO-free), scanning from `from`.
+    pub(crate) fn new(
+        keyspace: SingleWriterTxKeyspace,
+        id: OwnedStreamId,
+        from: u64,
+        batch_size: usize,
+        stream_id: ArrayString<64>,
+    ) -> Result<Self, FjallError> {
+        let mut stream = Self {
+            events: VecDeque::new(),
+            keyspace,
+            id,
+            next_version: from,
+            batch_size,
+            done: false,
+            stream_id,
+            poisoned: false,
+            #[cfg(debug_assertions)]
+            prev_version: None,
+        };
+        stream.refill()?;
+        Ok(stream)
+    }
+
+    /// Scan the next `batch_size` rows from `next_version` into `events`.
+    /// A short batch (fewer than `batch_size`) sets `done`.
+    fn refill(&mut self) -> Result<(), FjallError> {
+        let id_bytes = self.id.as_ref();
+        let start = encode_event_key(id_bytes, self.next_version).map_err(|e| {
+            FjallError::InvalidInput {
+                stream_id: self.stream_id,
+                version: self.next_version,
+                reason: reason_label(&e),
+            }
+        })?;
+        let end = encode_event_key(id_bytes, u64::MAX).map_err(|e| FjallError::InvalidInput {
+            stream_id: self.stream_id,
+            version: u64::MAX,
+            reason: reason_label(&e),
+        })?;
+
+        let batch: Vec<(Slice, Slice)> = self
+            .keyspace
+            .inner()
+            .range(start..=end)
+            .take(self.batch_size)
+            .map(fjall::Guard::into_inner)
+            .collect::<Result<_, _>>()?;
+
+        self.done = batch.len() < self.batch_size;
+        self.events = batch.into();
+        Ok(())
+    }
+
+    pub(crate) fn poll_one(&mut self) -> Option<Result<PersistedEnvelope, FjallError>> {
+        if self.poisoned {
+            return None;
+        }
+        loop {
+            if let Some((key, value)) = self.events.pop_front() {
+                return Some(match decode_row(&key, value, self.stream_id) {
+                    Ok(env) => {
+                        let v = env.version().as_u64();
+                        #[cfg(debug_assertions)]
+                        {
+                            if let Some(prev) = self.prev_version {
+                                debug_assert!(
+                                    v > prev,
+                                    "EventStream monotonicity violated: version {v} is not greater than previous {prev}",
+                                );
+                            }
+                            self.prev_version = Some(v);
+                        }
+                        // Advance keyset cursor. No event can follow u64::MAX.
+                        self.next_version = match v.checked_add(1) {
+                            Some(n) => n,
+                            None => {
+                                self.done = true;
+                                v
+                            }
+                        };
+                        Ok(env)
+                    }
+                    Err(e) => {
+                        self.poisoned = true;
+                        Err(e)
+                    }
+                });
+            }
+            if self.done {
+                return None;
+            }
+            if let Err(e) = self.refill() {
+                self.poisoned = true;
+                return Some(Err(e));
+            }
+            if self.events.is_empty() {
+                // refill returned nothing => end of stream
+                return None;
+            }
+        }
+    }
+}
+```
+
+> Note: `poll_one`'s refill is a synchronous fjall range scan — consistent with the pre-existing design (the old `read_stream` also scanned synchronously inside the async fn). Each scan is now bounded to `batch_size`, so no scan blocks longer than one batch.
+
+- [ ] **Step 4: Run the tests**
+
+Run: `nix develop -c cargo nextest run -p nexus-fjall`
+Expected: PASS — the three new read tests, the `decode_row` tests, and all existing append/read/version tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/nexus-fjall/src/stream.rs crates/nexus-fjall/src/store.rs crates/nexus-fjall/src/builder.rs
+git commit -m "feat(fjall): paginating FjallStream + bounded read_stream + batch_size builder (#176)"
+```
+
+---
+
+## Task 7: fjall — subscription bounded across refills (test)
+
+The fjall subscription drives a `FjallStream` (now paginating) and re-reads via `read_stream` (now bounded), so the bound propagates automatically. Prove it.
+
+**Files:**
+- Modify: `crates/nexus-fjall/src/subscription_stream.rs` (add a `tests` module)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `crates/nexus-fjall/src/subscription_stream.rs`:
+
+```rust
+#[cfg(test)]
+#[allow(clippy::unwrap_used, reason = "test code")]
+mod tests {
+    use super::*;
+    use crate::store::batch_test_helpers::{seed, store_with_batch, tid};
+    use futures::StreamExt;
+    use nexus_store::envelope::pending_envelope;
+    use nexus_store::subscription::RawSubscription;
+
+    #[tokio::test]
+    async fn subscription_drains_many_batches_then_sees_live_event() {
+        let (store, _dir) = store_with_batch(4);
+        let store = Arc::new(store);
+        let id = tid("s");
+        seed(&store, &id, 10).await; // 3 bounded catch-up refills (4+4+2)
+
+        let mut sub = FjallStore::subscribe(&store, &id, None).await.unwrap();
+        for expected in 1..=10u64 {
+            let got = sub.next().await.unwrap().unwrap();
+            assert_eq!(got.version().as_u64(), expected);
+        }
+
+        let store2 = Arc::clone(&store);
+        let id2 = id.clone();
+        tokio::spawn(async move {
+            let env = pending_envelope(Version::new(11).unwrap())
+                .event_type("E")
+                .payload(vec![11u8])
+                .unwrap()
+                .build();
+            store2.append(&id2, Version::new(10), &[env]).await.unwrap();
+        });
+        let live = sub.next().await.unwrap().unwrap();
+        assert_eq!(live.version().as_u64(), 11);
+    }
+}
+```
+
+- [ ] **Step 2: Verify it fails or passes**
+
+Run: `nix develop -c cargo nextest run -p nexus-fjall subscription_stream::tests`
+Expected: PASS (bound propagates from Task 6). If it hangs or yields out of order, the pagination/keyset logic in Task 6 is wrong — fix there.
+
+- [ ] **Step 3: (no implementation change expected)**
+
+If Step 2 passes, no code change. If `batch_test_helpers` isn't visible from `subscription_stream.rs`, confirm `pub(crate) mod batch_test_helpers` in `store.rs` (Task 6) and that it's `#[cfg(test)]`.
+
+- [ ] **Step 4: Re-run**
+
+Run: `nix develop -c cargo nextest run -p nexus-fjall`
+Expected: PASS — whole crate.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/nexus-fjall/src/subscription_stream.rs
+git commit -m "test(fjall): subscription stays bounded across catch-up refills (#176)"
+```
+
+---
+
+## Task 8: Linearizability + property tests
+
+Cross-cutting category 4 (concurrent reader/writer) and a property test over random `(stream_len, batch_size)`.
+
+**Files:**
+- Modify: `crates/nexus-fjall/src/store.rs` tests (concurrency)
+- Create: `crates/nexus-store/tests/bounded_batch_proptest.rs` (property)
+
+- [ ] **Step 1: Write the failing tests**
+
+Concurrency test — add to `crates/nexus-fjall/src/store.rs` `tests` module:
+
+```rust
+    #[tokio::test]
+    async fn reader_sees_monotonic_gapfree_while_writer_appends() {
+        use std::sync::Arc as StdArc;
+        let (store, _dir) = store_with_batch(4);
+        let store = StdArc::new(store);
+        let id = tid("s");
+        seed(&store, &id, 4).await;
+
+        let writer = StdArc::clone(&store);
+        let wid = id.clone();
+        let handle = tokio::spawn(async move {
+            for v in 5..=20u64 {
+                let env = nexus_store::envelope::pending_envelope(Version::new(v).unwrap())
+                    .event_type("E")
+                    .payload(vec![v as u8])
+                    .unwrap()
+                    .build();
+                writer.append(&wid, Version::new(v - 1), &[env]).await.unwrap();
+            }
+        });
+
+        // Reader paginates the snapshot it observes; assert strict monotonic,
+        // gap-free version sequence (immutability guarantee).
+        let mut stream = store.read_stream(&id, Version::INITIAL).await.unwrap();
+        let mut prev = 0u64;
+        while let Some(item) = futures::StreamExt::next(&mut stream).await {
+            let v = item.unwrap().version().as_u64();
+            assert_eq!(v, prev + 1, "version gap or reorder: {prev} -> {v}");
+            prev = v;
+        }
+        handle.await.unwrap();
+        assert!(prev >= 4, "reader saw at least the seeded events");
+    }
+```
+
+Property test — create `crates/nexus-store/tests/bounded_batch_proptest.rs`:
+
+```rust
+//! Property: a bounded paginating read yields exactly the stream's events,
+//! in order, regardless of how `batch_size` chunks them.
+#![allow(clippy::unwrap_used)]
+
+use futures::StreamExt;
+use nexus_store::batch::BatchSize;
+use nexus_store::envelope::pending_envelope;
+use nexus_store::store::RawEventStore;
+use nexus_store::testing::InMemoryStore;
+use nexus_store::Version;
+use proptest::prelude::*;
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+struct Tid(String);
+impl std::fmt::Display for Tid {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+impl AsRef<[u8]> for Tid {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_bytes()
+    }
+}
+impl nexus::Id for Tid {
+    const BYTE_LEN: usize = 0;
+}
+
+fn batch_strategy() -> impl Strategy<Value = usize> {
+    prop_oneof![Just(1usize), Just(2), Just(255), Just(256), 1usize..512]
+}
+
+fn len_strategy() -> impl Strategy<Value = u64> {
+    prop_oneof![Just(0u64), Just(1), Just(255), Just(256), Just(257), 0u64..600]
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+    #[test]
+    fn read_yields_all_in_order(batch in batch_strategy(), len in len_strategy()) {
+        let rt = tokio::runtime::Builder::new_current_thread().build().unwrap();
+        rt.block_on(async {
+            let store = InMemoryStore::with_batch_size(BatchSize::new(batch).unwrap());
+            let id = Tid("s".into());
+            for v in 1..=len {
+                let env = pending_envelope(Version::new(v).unwrap())
+                    .event_type("E")
+                    .payload(vec![(v % 256) as u8])
+                    .unwrap()
+                    .build();
+                store.append(&id, Version::new(v - 1), &[env]).await.unwrap();
+            }
+            let mut stream = store.read_stream(&id, Version::INITIAL).await.unwrap();
+            let mut seen = Vec::new();
+            while let Some(item) = stream.next().await {
+                seen.push(item.unwrap().version().as_u64());
+            }
+            prop_assert_eq!(seen, (1..=len).collect::<Vec<_>>());
+            Ok(())
+        })?;
+    }
+}
+```
+
+- [ ] **Step 2: Verify they fail / run**
+
+Run: `nix develop -c cargo nextest run -p nexus-fjall reader_sees_monotonic`
+Run: `nix develop -c cargo nextest run -p nexus-store --features testing,subscription --test bounded_batch_proptest`
+Expected: PASS if Tasks 3 & 6 are correct. A reorder/gap failure points back to the keyset logic.
+
+- [ ] **Step 3: (fix only if red)** Adjust pagination logic in the relevant cursor; do not weaken the assertions.
+
+- [ ] **Step 4: Re-run both**
+
+Run: `nix develop -c cargo nextest run -p nexus-fjall && nix develop -c cargo nextest run -p nexus-store --features testing,subscription`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/nexus-fjall/src/store.rs crates/nexus-store/tests/bounded_batch_proptest.rs
+git commit -m "test: linearizability + property coverage for bounded batches (#176)"
+```
+
+---
+
+## Task 9: Documentation + final verification
+
+**Files:**
+- Modify: `crates/nexus-store/src/store.rs` (`read_stream` doc, lines 159-167)
+- Modify: `crates/nexus-store/src/subscription.rs` (`subscribe` doc, lines 119-129)
+
+- [ ] **Step 1: Document refill chunking on `RawEventStore::read_stream`**
+
+In `crates/nexus-store/src/store.rs`, expand the `read_stream` doc comment (above line 163):
+
+```rust
+    /// Open a stream of events.
+    ///
+    /// Events are yielded one at a time as a `futures::Stream` of owned
+    /// [`PersistedEnvelope`](crate::envelope::PersistedEnvelope)s.
+    ///
+    /// # Batching
+    ///
+    /// The cursor materializes at most `batch_size` rows at a time (see the
+    /// adapter's batch-size configuration) and refills the next batch
+    /// internally as it drains, by keyset resume on the stream version. This
+    /// is invisible to callers: `next()` has the same contract regardless of
+    /// how the events are chunked, and the stream returns `None` once the
+    /// persisted stream is exhausted.
+```
+
+- [ ] **Step 2: Document bounded catch-up on `Subscription::subscribe`**
+
+In `crates/nexus-store/src/subscription.rs`, add to the `subscribe` doc (around line 122):
+
+```rust
+    /// Catch-up reads are bounded: the cursor materializes at most the
+    /// adapter's configured `batch_size` events per refill, paginating by
+    /// keyset resume until caught up, then waits for new events. A slow
+    /// consumer never forces the whole backlog into memory at once.
+```
+
+- [ ] **Step 3: Full check**
+
+Run: `nix develop -c cargo nextest run --workspace --all-features`
+Expected: PASS — whole workspace.
+
+Run: `nix flake check`
+Expected: PASS — clippy (deny), fmt, taplo, audit, deny, nextest, doc.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/nexus-store/src/store.rs crates/nexus-store/src/subscription.rs
+git commit -m "docs(store): document bounded refill on read_stream + subscribe (#176)"
+```
+
+- [ ] **Step 5: Open the PR**
+
+```bash
+git push -u origin feat/bounded-batch-size
+gh pr create --title "feat: bound subscription/read batch size (#176)" \
+  --body "Closes #176. Adds BatchSize (1..=MAX_BATCH=4096, default 256), bounded paginating read_stream + subscription refills on both InMemoryStore and FjallStore. See docs/plans/2026-06-16-bounded-batch-size-{design,implementation}.md."
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- AC "fjall builder API for batch size, compile-time max" → Task 1 (`MAX_BATCH`) + Task 6 (`batch_size` setter). ✓
+- AC "same for `InMemoryStore`" → Task 2 (`with_batch_size`). ✓
+- AC "`FjallStream`/`InMemoryStream` refill when buffer drains" → Task 6 (fjall) + Task 3 (in-memory). ✓
+- AC "bound honored by `read_stream` and both subscription refills" → Tasks 3, 4, 6, 7. ✓
+- AC "subscription falls behind, 10× batch, drains across refills" → Task 4 + Task 7. ✓
+- AC "one-shot read of > batch_size yields all in order" → Tasks 3, 6, 8. ✓
+- AC "batch_size > max rejected at builder" → Task 1 (`BatchSize::new` rejects; builders accept only `BatchSize`). ✓
+- AC "doc on refill semantics" → Task 9. ✓
+- Spec 4 test categories: sequence (3, 6), lifecycle (6 reopen), defensive boundary (1, 3, 6 exact-boundary), linearizability (8). ✓
+
+**Placeholder scan:** No "TBD"/"add error handling"-style gaps; every code step shows full code. (Task 1 Step 1/2 explains the create-then-test ordering explicitly rather than leaving it implicit.)
+
+**Type consistency:** `BatchSize::new` / `BatchSize::DEFAULT` / `BatchSize::get` used consistently; `scan_batch(rows, from: u64, batch_size)` signature identical at all call sites; `decode_row(&Slice, Slice, ArrayString<64>)` consistent between definition (Task 5) and call (Task 6); `FjallStream::new(keyspace, id, from, batch_size, stream_id)` consistent between definition (Task 6) and `read_stream` call (Task 6); `batch_test_helpers` exported `pub(crate)` and consumed in Tasks 6/7/8.


### PR DESCRIPTION
Closes #176.

## Summary

Caps how many event rows `read_stream` and subscription refills hold in memory at once, with a compile-time ceiling and a runtime-configurable batch size, so a slow consumer or large catch-up replay can no longer OOM the process (a real risk on the project's IoT/mobile targets).

- **`BatchSize` newtype** (`nexus_store::batch`, range `1..=MAX_BATCH = 4096`, default `256`) — the single source of the bound. Validated at construction, so an out-of-range value is unrepresentable past `BatchSize::new` and the builders that accept it are structurally infallible.
- **Keyset pagination, not snapshots.** Cursors load at most `batch_size` rows, then resume at `last_version + 1`; a batch shorter than `batch_size` signals end-of-data (one-shot read → `None`; subscription → park on the wake registry). This relies on the store's append-only + gapless-per-stream-version invariant, so no transactional snapshot is held open — preserving the existing "no LSM iterator stays open" / no-GC-pin design.
- **fjall:** `range(start..=end).take(batch_size)` (the lazy `Iter` makes `.take` genuinely bound the scan); `FjallStream` holds a cheap Arc-backed clone of the `events` keyspace and self-refills; `read_stream` is now a single bounded scan (the prior `streams.get()` existence check is dropped — one read instead of two, more atomic).
- **in-memory:** `Arc<Mutex<…>>` map, an unfold cursor, and a shared `scan_batch` helper bound both the read and subscription-refill paths.
- **Builders:** `FjallStore::builder(p).batch_size(BatchSize)` and `InMemoryStore::with_batch_size(BatchSize)`.
- **Docs:** `RawEventStore::read_stream` and `Subscription::subscribe` now document the chunked-refill semantics.

Design + plan: `docs/plans/2026-06-16-bounded-batch-size-{design,implementation}.md`.

## Test Plan

- [x] `nix flake check` (clippy deny / fmt / nextest / doc / deny / hakari) green at HEAD
- [x] One-shot read of `> batch_size` events yields all in order across refills (both adapters)
- [x] Subscription falls behind a 10×-`batch_size` backlog, drains across refills, then sees a live event (both adapters)
- [x] Exact-batch-multiple boundary terminates (no hang / no double-yield); empty stream; from-midpoint resume
- [x] `BatchSize::new(MAX_BATCH + 1)` rejected at construction
- [x] Linearizability: barrier-forced concurrent writer + paginating reader sees a gap-free monotonic prefix, then a deterministic post-join read recovers all events
- [x] Property test over random `(batch_size, len)` incl. boundaries `0,1,255,256,257`
- [x] Lifecycle: close + reopen recovers all events across refills (fjall)

🤖 Generated with [Claude Code](https://claude.com/claude-code)