### PR TITLE
feat(store): add StoreError::is_conflict() retry predicate (#129)

### DIFF
--- a/crates/nexus-store/src/error.rs
+++ b/crates/nexus-store/src/error.rs
@@ -81,6 +81,29 @@ pub enum StoreError<A, EncErr, DecErr> {
     Envelope(#[from] crate::envelope::EnvelopeError),
 }
 
+impl<A, EncErr, DecErr> StoreError<A, EncErr, DecErr> {
+    /// Returns `true` if this is an optimistic-concurrency [`Conflict`].
+    ///
+    /// [`Conflict`] is the one error the store can assert a *semantic* fact
+    /// about that the consumer cannot infer otherwise: the expected version
+    /// was stale, so reloading the aggregate and re-running the (pure,
+    /// side-effect-free) decision will likely succeed. It is the natural
+    /// predicate for a consumer-owned retry loop — e.g. a supervising actor
+    /// retrying load → handle → save, or a `tower::retry::Policy` /
+    /// `backon` `.when(|e| e.is_conflict())`.
+    ///
+    /// nexus deliberately ships no retry machinery: classifying *other*
+    /// errors as retryable (transient adapter I/O, say) needs context only
+    /// the consumer has, and the loop, backoff, and sleep are runtime
+    /// concerns. This predicate is the entire retry-facing surface.
+    ///
+    /// [`Conflict`]: StoreError::Conflict
+    #[must_use]
+    pub const fn is_conflict(&self) -> bool {
+        matches!(self, Self::Conflict { .. })
+    }
+}
+
 /// Errors from the with-upcaster load path.
 ///
 /// Returned by [`EventStore::load_with`](crate::EventStore::load_with) and

--- a/crates/nexus-store/tests/error_tests.rs
+++ b/crates/nexus-store/tests/error_tests.rs
@@ -38,6 +38,33 @@ fn conflict_display_contains_stream_id_and_versions() {
 }
 
 #[test]
+fn is_conflict_true_only_for_conflict_variant() {
+    let conflict: TestStoreError = StoreError::Conflict {
+        stream_id: label("order-42"),
+        expected: Version::new(3),
+        actual: Version::new(5),
+    };
+    assert!(
+        conflict.is_conflict(),
+        "Conflict variant must be a conflict"
+    );
+
+    let not_found: TestStoreError = StoreError::StreamNotFound {
+        stream_id: label("user-99"),
+    };
+    assert!(!not_found.is_conflict(), "StreamNotFound is not a conflict");
+
+    let decode: TestStoreError = StoreError::Decode(std::io::Error::new(
+        std::io::ErrorKind::InvalidData,
+        "bad bytes",
+    ));
+    assert!(!decode.is_conflict(), "Decode is not a conflict");
+
+    let overflow: TestStoreError = StoreError::VersionOverflow;
+    assert!(!overflow.is_conflict(), "VersionOverflow is not a conflict");
+}
+
+#[test]
 fn stream_not_found_display_contains_stream_id() {
     let err: TestStoreError = StoreError::StreamNotFound {
         stream_id: label("user-99"),


### PR DESCRIPTION
## What

Adds `StoreError::is_conflict(&self) -> bool` — a `const fn` predicate that is `true` only for the `Conflict` variant.

## Why

Closes #129 by re-scoping it. Worked through the design with the conclusion that **retry-on-conflict does not belong in nexus** — retry-on-error is error-recovery orchestration, i.e. *supervision*, which Agency's actor owns alongside lifecycle, state, and the mailbox.

**Principle: nexus reports, the actor decides.** The kernel's entire contribution to retry is two things it already provides:

1. A precise, matchable error — `StoreError::Conflict { expected, actual }`.
2. The guarantee that re-deciding is *safe*: `Handle` is `handle(state, cmd) -> events`, pure and side-effect-free, so re-running it on reloaded state can't double-apply.

`is_conflict()` is the one error nexus can assert a *semantic* fact about ("version was stale; reload + re-decide will likely succeed"), and it drops straight into a consumer-owned retry loop:

```rust
something.retry(ExponentialBuilder::default()).when(|e| e.is_conflict()).await   // backon
// or a tower::retry::Policy, or an actor handler's `if err.is_conflict()` branch
```

The proposed `RetryStrategy` trait + `FixedBackoff`/`ExponentialBackoff` are deliberately **not** shipped — they would re-implement established crates (`backon`, `tower`, `tokio-retry`) worse and pull a runtime framework into a `no_std`-targeted kernel, the same reason `nexus-framework` was retired (#193). The retry loop, backoff, and the tower-vs-actor-spine question move to Agency.

## Tests

TDD (red → green): `is_conflict_true_only_for_conflict_variant` asserts `true` for `Conflict` and `false` for `StreamNotFound` / `Decode` / `VersionOverflow`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)