### PR TITLE
feat(store): default CBOR backup box (export/import Card 3, #145)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,6 +233,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32c"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
+dependencies = [
+ "rustc_version",
+]
+
+[[package]]
 name = "criterion"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -695,6 +704,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "minicbor"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b7a5041e12946f8b7d3f5a9d96383a19d694b9335457c522be7815b9abafb02"
+dependencies = [
+ "minicbor-derive",
+]
+
+[[package]]
+name = "minicbor-derive"
+version = "0.19.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c9303a7d70578b101a21b3043ade4ab825c59063bbcd89af1066729399b79c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -854,10 +883,13 @@ dependencies = [
  "arrayvec",
  "bytemuck",
  "bytes",
+ "crc32c",
  "criterion",
  "foldhash",
  "futures",
  "futures-core",
+ "insta",
+ "minicbor",
  "nexus",
  "nexus-store",
  "nexus-store-testing",
@@ -1220,6 +1252,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1270,6 +1311,12 @@ name = "self_cell"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,12 +20,14 @@ aligned-vec = "=0.6.4"
 arrayvec = { version = "0.7.6", default-features = false }
 bytemuck = { version = "1", features = ["derive"] }
 bytes = "1"
+crc32c = "0.6.8"
 criterion = { version = "0.8", features = ["html_reports"] }
 fjall = { version = "3", features = ["bytes_1"] }
 foldhash = "0.2.0"
 futures = "0.3"
 futures-core = { version = "0.3", default-features = false }
 insta = "1.47.2"
+minicbor = { version = "2.2.2", features = ["alloc"] }
 parking_lot = "0.12.5"
 proptest = "1.11.0"
 proptest-state-machine = "0.8.0"

--- a/crates/nexus-store/Cargo.toml
+++ b/crates/nexus-store/Cargo.toml
@@ -38,15 +38,21 @@ rkyv = ["dep:rkyv"]
 # feature now would emit `unexpected_cfgs` warnings that fail clippy
 # `--deny warnings`. See deviations doc.
 futures-bridge = []
+# Default CBOR backup box (issue #145, Card 3). Implies export+import; the
+# inverse never holds (Agency enables export/import and brings its own CESR box,
+# pulling no CBOR).
+cbor = ["import", "export", "dep:minicbor", "dep:crc32c"]
 
 [dependencies]
 aligned-vec = { workspace = true }
 arrayvec = { workspace = true }
 bytemuck = { workspace = true, optional = true }
 bytes = { workspace = true }
+crc32c = { workspace = true, optional = true }
 foldhash = { workspace = true, optional = true }
 futures = { workspace = true }
 futures-core = { workspace = true }
+minicbor = { workspace = true, features = ["derive"], optional = true }
 nexus = { version = "0.1.0", path = "../nexus" }
 parking_lot = { workspace = true, optional = true }
 rkyv = { workspace = true, optional = true }
@@ -59,7 +65,8 @@ workspace-hack = { version = "0.1", path = "../workspace-hack" }
 [dev-dependencies]
 criterion = { workspace = true }
 futures = { workspace = true }
-nexus-store = { path = ".", features = ["testing", "export", "import"] }
+insta = { workspace = true }
+nexus-store = { path = ".", features = ["testing", "export", "import", "cbor"] }
 nexus-store-testing = { version = "0.1.0", path = "../nexus-store-testing" }
 proptest = { workspace = true }
 serde = { workspace = true }

--- a/crates/nexus-store/src/cbor.rs
+++ b/crates/nexus-store/src/cbor.rs
@@ -684,12 +684,25 @@ mod tests {
                 1u64..1000
             ],
             prop_oneof![Just(1u32), Just(7), Just(u32::MAX), 1u32..100],
-            prop_oneof![Just(String::new()), Just("E".to_owned()), "[A-Za-z]{0,40}"],
+            // event_type spanning CBOR text-string length bands: inline (<24),
+            // 1-byte length (24..=255), 2-byte length (256..).
+            prop_oneof![
+                Just(String::new()),
+                Just("E".to_owned()),
+                "[A-Za-z]{0,40}",
+                Just("z".repeat(300)),
+            ],
+            // metadata: None, the 1-byte band, and the 2-byte band.
             prop_oneof![
                 Just(None),
-                proptest::collection::vec(any::<u8>(), 1..32).prop_map(Some)
+                proptest::collection::vec(any::<u8>(), 1..32).prop_map(Some),
+                proptest::collection::vec(any::<u8>(), 256..400).prop_map(Some),
             ],
-            proptest::collection::vec(any::<u8>(), 0..64),
+            // payload spanning inline / 1-byte / 2-byte length bands.
+            prop_oneof![
+                proptest::collection::vec(any::<u8>(), 0..64),
+                proptest::collection::vec(any::<u8>(), 256..512),
+            ],
         )
     }
 
@@ -918,5 +931,184 @@ mod tests {
                 .collect();
             assert_eq!(got, expected, "stream {sid} round-trips");
         }
+    }
+
+    // ── #2: CBOR length-form boundaries (deterministic) ──────────────────────
+    // CBOR encodes a byte/text-string length with a different prefix per size
+    // band: inline (<24), 1-byte (24..=255), 2-byte (256..=65535), 4-byte
+    // (65536..). A bug mishandling one band is invisible until a value lands in
+    // it; exercise each band explicitly through encode_block → decode.
+
+    #[test]
+    fn box_round_trips_every_payload_length_band() {
+        for size in [0usize, 23, 24, 255, 256, 1024, 65536] {
+            let payload = vec![0xABu8; size];
+            let event = persisted(1, 1, "E", None, &payload);
+            let bytes = encode_block(&event).expect("encode");
+            match decode_one_block(&bytes) {
+                ImportBlock::Event(got) => {
+                    assert_eq!(got.payload().len(), size, "payload size {size} length");
+                    assert_eq!(got.payload(), payload.as_slice(), "payload {size} bytes");
+                }
+                ImportBlock::Corrupt => panic!("payload size {size} must round-trip"),
+            }
+        }
+    }
+
+    #[test]
+    fn box_round_trips_event_type_at_2byte_band_and_max() {
+        for et_len in [256usize, crate::value::MAX_EVENT_TYPE_LEN] {
+            let et = "a".repeat(et_len);
+            let event = persisted(1, 1, &et, Some(b"m"), b"p");
+            let bytes = encode_block(&event).expect("encode");
+            match decode_one_block(&bytes) {
+                ImportBlock::Event(got) => {
+                    assert_eq!(got.event_type().len(), et_len, "event_type len {et_len}");
+                    assert_eq!(got.event_type(), et);
+                    assert_eq!(got.metadata(), Some(b"m".as_slice()));
+                }
+                ImportBlock::Corrupt => panic!("event_type len {et_len} must round-trip"),
+            }
+        }
+    }
+
+    #[test]
+    fn box_round_trips_metadata_at_2byte_band() {
+        let meta = vec![0x07u8; 300];
+        let event = persisted(1, 1, "E", Some(&meta), b"p");
+        match decode_one_block(&encode_block(&event).expect("encode")) {
+            ImportBlock::Event(got) => assert_eq!(got.metadata(), Some(meta.as_slice())),
+            ImportBlock::Corrupt => panic!("metadata 2-byte band must round-trip"),
+        }
+    }
+
+    // ── #3: defensive decode branches, asserted by specific outcome ──────────
+    // These branches were previously exercised only by the never-panic fuzz,
+    // which asserts no crash but not WHICH result. Pin the exact outcomes.
+
+    #[test]
+    fn decode_block_rejects_indefinite_array() {
+        // 0x9f = indefinite-length array. Never emitted; must be rejected, not
+        // hang or panic. (Reached via decode_block directly; decode_chunk peeks
+        // ArrayIndef as a distinct type and rejects it before calling here.)
+        let mut d = Decoder::new(&[0x9fu8]);
+        assert!(matches!(
+            decode_block(&mut d),
+            Err("indefinite-length block array")
+        ));
+    }
+
+    #[test]
+    fn decode_block_rejects_wrong_arity() {
+        // A 3-element array violates the exactly-2 block shape.
+        let mut buf = Vec::new();
+        {
+            let mut e = minicbor::Encoder::new(&mut buf);
+            e.array(3).expect("array header");
+        }
+        let mut d = Decoder::new(&buf);
+        assert!(matches!(
+            decode_block(&mut d),
+            Err("block array must have exactly 2 elements")
+        ));
+    }
+
+    #[test]
+    fn indefinite_array_at_top_level_is_malformed() {
+        // decode_chunk peeks Type::ArrayIndef (not Array) → unexpected item type.
+        let mut chunk = encode_header(None).expect("header").to_vec();
+        chunk.extend_from_slice(&encode_section_heading(b"s").expect("heading"));
+        chunk.push(0x9f); // array(*) indefinite
+        chunk.push(0xff); // break
+        assert!(matches!(
+            decode_chunk(&chunk),
+            Err(ChunkError::Malformed("unexpected item type"))
+        ));
+    }
+
+    #[test]
+    fn torn_mid_heading_stops_at_valid_prefix() {
+        // One complete section, then a heading truncated mid stream-id. The
+        // complete section survives; the torn heading yields no section (it is a
+        // valid-prefix stop, not Malformed).
+        let chunk = encode_chunk(
+            None,
+            &[(b"done".as_slice(), vec![persisted(1, 1, "E", None, b"x")])],
+        );
+        let mut v = chunk.to_vec();
+        let heading = encode_section_heading(b"truncated-stream-id").expect("heading");
+        v.extend_from_slice(&heading[..heading.len() - 4]); // drop 4 id bytes
+        let sections = decode_chunk(&v).expect("valid prefix");
+        assert_eq!(sections.len(), 1, "torn heading produces no section");
+        assert_eq!(sections[0].origin.as_ref(), b"done");
+        assert_eq!(sections[0].blocks.len(), 1);
+    }
+
+    #[test]
+    fn header_missing_magic_key_is_malformed() {
+        // A 1-entry map carrying only format_version (key 1), no magic (key 0):
+        // a missing required field, distinct from a corrupted magic value.
+        let mut bytes = Vec::new();
+        {
+            let mut e = minicbor::Encoder::new(&mut bytes);
+            e.map(1)
+                .expect("map")
+                .u32(1)
+                .expect("k1")
+                .u32(1)
+                .expect("v1");
+        }
+        assert!(matches!(
+            decode_header(&bytes),
+            Err(ChunkError::Malformed(_))
+        ));
+        assert!(matches!(
+            decode_chunk(&bytes),
+            Err(ChunkError::Malformed(_))
+        ));
+    }
+
+    #[test]
+    fn crc_valid_body_with_empty_metadata_is_malformed() {
+        // metadata present but empty violates the Metadata non-empty invariant;
+        // reconstruct → try_new rejects the empty range → Malformed (with a
+        // matching crc, proving the rejection is at reconstruction, not crc).
+        let mut body = Vec::new();
+        {
+            let mut e = minicbor::Encoder::new(&mut body);
+            e.map(5)
+                .expect("map")
+                .u32(0)
+                .expect("k0")
+                .u64(1)
+                .expect("v0")
+                .u32(1)
+                .expect("k1")
+                .u32(1)
+                .expect("v1")
+                .u32(2)
+                .expect("k2")
+                .str("E")
+                .expect("v2")
+                .u32(3)
+                .expect("k3")
+                .bytes(b"")
+                .expect("v3") // empty metadata
+                .u32(4)
+                .expect("k4")
+                .bytes(b"p")
+                .expect("v4");
+        }
+        let block = BlockRepr {
+            crc: crc32c::crc32c(&body),
+            body: &body,
+        };
+        let mut chunk = encode_header(None).expect("header").to_vec();
+        chunk.extend_from_slice(&encode_section_heading(b"s").expect("heading"));
+        chunk.extend_from_slice(&minicbor::to_vec(&block).expect("block"));
+        assert!(matches!(
+            decode_chunk(&chunk),
+            Err(ChunkError::Malformed(_))
+        ));
     }
 }

--- a/crates/nexus-store/src/cbor.rs
+++ b/crates/nexus-store/src/cbor.rs
@@ -502,4 +502,98 @@ mod tests {
         assert_eq!(sections[0].origin.as_ref(), b"empty");
         assert_eq!(sections[1].blocks.len(), 1);
     }
+
+    // ── Task 5: Defensive boundary — Corrupt vs Malformed ──────────────────
+
+    #[test]
+    fn flipped_body_byte_in_chunk_decodes_to_corrupt_block() {
+        let chunk = encode_chunk(
+            None,
+            &[(b"s".as_slice(), vec![persisted(1, 1, "E", None, b"hello")])],
+        );
+        let mut v = chunk.to_vec();
+        let last = v.len() - 1;
+        v[last] ^= 0xFF;
+        let sections = decode_chunk(&v).expect("framing intact");
+        assert_eq!(sections.len(), 1);
+        assert!(matches!(sections[0].blocks[0], ImportBlock::Corrupt));
+    }
+
+    #[test]
+    fn bad_magic_chunk_is_malformed() {
+        let mut v = encode_chunk(
+            None,
+            &[(b"s".as_slice(), vec![persisted(1, 1, "E", None, b"x")])],
+        )
+        .to_vec();
+        let pos = v.iter().position(|&b| b == b'n').expect("magic");
+        v[pos] = b'Z';
+        assert!(matches!(
+            decode_chunk(&v),
+            Err(ChunkError::Malformed("bad magic"))
+        ));
+    }
+
+    #[test]
+    fn unknown_format_version_is_malformed() {
+        let repr = HeaderRepr {
+            magic: MAGIC,
+            format_version: 2,
+            origin: None,
+        };
+        let bytes = minicbor::to_vec(&repr).expect("encode");
+        assert!(matches!(
+            decode_chunk(&bytes),
+            Err(ChunkError::Malformed("unknown format version"))
+        ));
+    }
+
+    #[test]
+    fn unexpected_top_level_item_is_malformed() {
+        let mut v = encode_header(None).expect("header").to_vec();
+        v.push(0x01); // CBOR uint 1 — neither map nor array
+        assert!(matches!(
+            decode_chunk(&v),
+            Err(ChunkError::Malformed("unexpected item type"))
+        ));
+    }
+
+    #[test]
+    fn crc_valid_but_body_invalid_is_malformed() {
+        // Craft a block whose body decodes to version 0 (illegal) with a
+        // MATCHING crc → proves crc-pass-body-fail => Malformed (not Corrupt).
+        let mut body = Vec::new();
+        {
+            let mut e = minicbor::Encoder::new(&mut body);
+            e.map(4)
+                .expect("map")
+                .u32(0)
+                .expect("k0")
+                .u64(0)
+                .expect("v0")
+                .u32(1)
+                .expect("k1")
+                .u32(1)
+                .expect("v1")
+                .u32(2)
+                .expect("k2")
+                .str("E")
+                .expect("v2")
+                .u32(4)
+                .expect("k4")
+                .bytes(b"")
+                .expect("v4");
+        }
+        let block = BlockRepr {
+            crc: crc32c::crc32c(&body),
+            body: &body,
+        };
+        let mut chunk = encode_header(None).expect("header").to_vec();
+        chunk.extend_from_slice(&encode_section_heading(b"s").expect("heading"));
+        chunk.extend_from_slice(&minicbor::to_vec(&block).expect("block"));
+        assert!(matches!(
+            decode_chunk(&chunk),
+            Err(ChunkError::Malformed(_))
+        ));
+    }
 }

--- a/crates/nexus-store/src/cbor.rs
+++ b/crates/nexus-store/src/cbor.rs
@@ -11,6 +11,7 @@ use core::ops::Range;
 
 use bytes::Bytes;
 use minicbor::Decoder;
+use minicbor::data::Type;
 use thiserror::Error;
 
 use crate::envelope::PersistedEnvelope;
@@ -104,14 +105,24 @@ pub fn decode_header(bytes: &[u8]) -> Result<ChunkHeader, ChunkError> {
     })
 }
 
-/// Stub — replaced in Task 3.
+/// Wire shape of a section heading map `{0: stream_id}`.
+#[derive(minicbor::Encode, minicbor::Decode)]
+#[cbor(map)]
+struct HeadingRepr<'a> {
+    #[n(0)]
+    #[cbor(with = "minicbor::bytes")]
+    stream_id: &'a [u8],
+}
+
+/// Encode a per-stream section heading, recording the origin stream id once.
+/// Emit one before the blocks of each stream.
 ///
 /// # Errors
-///
-/// Returns [`ChunkError::Encode`] if the CBOR serialization fails (infallible
-/// in practice for the stub path).
-pub const fn encode_section_heading(_stream_id: &[u8]) -> Result<Bytes, ChunkError> {
-    Ok(Bytes::new())
+/// Returns [`ChunkError::Encode`] if minicbor serialization fails (never in
+/// practice).
+pub fn encode_section_heading(stream_id: &[u8]) -> Result<Bytes, ChunkError> {
+    let repr = HeadingRepr { stream_id };
+    Ok(Bytes::from(minicbor::to_vec(&repr)?))
 }
 
 /// Wire shape of a block body map. `global_seq` is deliberately absent —
@@ -172,10 +183,6 @@ pub fn encode_block(event: &PersistedEnvelope) -> Result<Bytes, ChunkError> {
 /// `Ok(Some(block))` = decoded (Event or Corrupt). `Ok(None)` = torn tail
 /// (end-of-input mid-item → caller stops, valid prefix). `Err(hint)` = a
 /// structural violation the caller turns into [`ChunkError::Malformed`].
-#[allow(
-    dead_code,
-    reason = "wired into decode_chunk in Task 4; called from tests now"
-)]
 fn decode_block(d: &mut Decoder<'_>) -> Result<Option<ImportBlock>, &'static str> {
     match d.array() {
         Ok(Some(2)) => {}
@@ -209,10 +216,6 @@ fn decode_block(d: &mut Decoder<'_>) -> Result<Option<ImportBlock>, &'static str
 /// field-level violation (version 0, schema 0, oversize, range overflow); the
 /// caller maps that to `Malformed`. `global_seq` is a placeholder — import
 /// ignores it.
-#[allow(
-    dead_code,
-    reason = "called by decode_block, wired into decode_chunk in Task 4"
-)]
 fn reconstruct(body: &BodyRepr<'_>) -> Option<PersistedEnvelope> {
     let version = Version::new(body.version)?;
     let schema = SchemaVersion::from_u32(body.schema_version).ok()?;
@@ -247,13 +250,51 @@ fn reconstruct(body: &BodyRepr<'_>) -> Option<PersistedEnvelope> {
     .ok()
 }
 
-/// Stub — replaced in Task 4.
+/// Decode a whole chunk into per-stream sections for
+/// [`EventImporter::import`](crate::import::EventImporter::import).
+///
+/// Walks the CBOR sequence: header first, then peek each item — a map starts a
+/// new section, an array is a block for the current section. A torn tail
+/// (end-of-input mid-item) stops cleanly and returns the valid prefix; any
+/// other structural problem is [`ChunkError::Malformed`]. A per-block crc
+/// mismatch is a non-fatal [`ImportBlock::Corrupt`], never an error.
 ///
 /// # Errors
-///
-/// Returns [`ChunkError::Malformed`] if the chunk bytes cannot be decoded.
-pub const fn decode_chunk(_bytes: &[u8]) -> Result<Vec<StreamSection>, ChunkError> {
-    Ok(Vec::new())
+/// Returns [`ChunkError::Malformed`] on a bad/unknown header, a block before
+/// any section heading, an unexpected top-level item, or a crc-valid body that
+/// fails to decode.
+pub fn decode_chunk(bytes: &[u8]) -> Result<Vec<StreamSection>, ChunkError> {
+    let mut d = Decoder::new(bytes);
+    let header: HeaderRepr = d
+        .decode()
+        .map_err(|_| ChunkError::Malformed("unreadable header"))?;
+    validate_header(header.magic, header.format_version)?;
+
+    let mut sections: Vec<StreamSection> = Vec::new();
+    while d.position() < bytes.len() {
+        match d.datatype() {
+            Ok(Type::Map) => match d.decode::<HeadingRepr>() {
+                Ok(heading) => sections.push(StreamSection {
+                    origin: Bytes::copy_from_slice(heading.stream_id),
+                    blocks: Vec::new(),
+                }),
+                Err(e) if e.is_end_of_input() => break,
+                Err(_) => return Err(ChunkError::Malformed("malformed section heading")),
+            },
+            Ok(Type::Array) => match decode_block(&mut d) {
+                Ok(Some(block)) => match sections.last_mut() {
+                    Some(section) => section.blocks.push(block),
+                    None => return Err(ChunkError::Malformed("block before section heading")),
+                },
+                Ok(None) => break,
+                Err(hint) => return Err(ChunkError::Malformed(hint)),
+            },
+            Ok(_) => return Err(ChunkError::Malformed("unexpected item type")),
+            Err(e) if e.is_end_of_input() => break,
+            Err(_) => return Err(ChunkError::Malformed("decode error")),
+        }
+    }
+    Ok(sections)
 }
 
 #[cfg(test)]
@@ -375,5 +416,90 @@ mod tests {
         let bytes = encode_header(Some(b"x")).expect("encode");
         let err = decode_header(&bytes[..bytes.len() / 2]).expect_err("truncated rejected");
         assert!(matches!(err, ChunkError::Malformed(_)));
+    }
+
+    /// Encode a full multi-stream chunk: header + per-stream heading + blocks.
+    fn encode_chunk(origin: Option<&[u8]>, streams: &[(&[u8], Vec<PersistedEnvelope>)]) -> Bytes {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&encode_header(origin).expect("header"));
+        for (stream_id, events) in streams {
+            buf.extend_from_slice(&encode_section_heading(stream_id).expect("heading"));
+            for e in events {
+                buf.extend_from_slice(&encode_block(e).expect("block"));
+            }
+        }
+        Bytes::from(buf)
+    }
+
+    #[test]
+    fn decode_chunk_round_trips_multi_stream() {
+        let a = vec![
+            persisted(1, 1, "E", None, b"a1"),
+            persisted(2, 1, "E", Some(b"m"), b"a2"),
+        ];
+        let b = vec![persisted(1, 2, "E", None, b"b1")];
+        let chunk = encode_chunk(
+            Some(b"dev-1"),
+            &[(b"task-1".as_slice(), a), (b"task-2".as_slice(), b)],
+        );
+
+        let sections = decode_chunk(&chunk).expect("decode");
+        assert_eq!(sections.len(), 2);
+
+        assert_eq!(sections[0].origin.as_ref(), b"task-1");
+        assert_eq!(sections[0].blocks.len(), 2);
+        match (&sections[0].blocks[0], &sections[0].blocks[1]) {
+            (ImportBlock::Event(e1), ImportBlock::Event(e2)) => {
+                assert_eq!(e1.version().as_u64(), 1);
+                assert_eq!(e1.payload(), b"a1");
+                assert_eq!(e2.metadata(), Some(b"m".as_slice()));
+                assert_eq!(e2.payload(), b"a2");
+            }
+            _ => panic!("expected two Event blocks"),
+        }
+
+        assert_eq!(sections[1].origin.as_ref(), b"task-2");
+        match &sections[1].blocks[0] {
+            ImportBlock::Event(e) => {
+                assert_eq!(e.schema_version(), 2);
+                assert_eq!(e.payload(), b"b1");
+            }
+            ImportBlock::Corrupt => panic!("expected Event"),
+        }
+    }
+
+    #[test]
+    fn decode_header_only_chunk_is_empty_vec() {
+        let chunk = encode_header(None).expect("header");
+        let sections = decode_chunk(&chunk).expect("decode");
+        assert!(sections.is_empty());
+    }
+
+    #[test]
+    fn decode_block_before_heading_is_malformed() {
+        let mut chunk = encode_header(None).expect("header").to_vec();
+        let event = persisted(1, 1, "E", None, b"x");
+        chunk.extend_from_slice(&encode_block(&event).expect("block"));
+        let err = decode_chunk(&chunk).expect_err("block before heading");
+        assert!(matches!(
+            err,
+            ChunkError::Malformed("block before section heading")
+        ));
+    }
+
+    #[test]
+    fn decode_empty_section_then_stream() {
+        let chunk = encode_chunk(
+            None,
+            &[
+                (b"empty".as_slice(), vec![]),
+                (b"real".as_slice(), vec![persisted(1, 1, "E", None, b"r")]),
+            ],
+        );
+        let sections = decode_chunk(&chunk).expect("decode");
+        assert_eq!(sections.len(), 2);
+        assert!(sections[0].blocks.is_empty());
+        assert_eq!(sections[0].origin.as_ref(), b"empty");
+        assert_eq!(sections[1].blocks.len(), 1);
     }
 }

--- a/crates/nexus-store/src/cbor.rs
+++ b/crates/nexus-store/src/cbor.rs
@@ -306,6 +306,11 @@ pub fn decode_chunk(bytes: &[u8]) -> Result<Vec<StreamSection>, ChunkError> {
 )]
 mod tests {
     use super::*;
+    use crate::envelope::pending_envelope;
+    use crate::import::{Atomicity, EventImporter};
+    use crate::store::RawEventStore;
+    use crate::testing::InMemoryStore;
+    use futures::StreamExt;
 
     /// Build a `PersistedEnvelope` directly: backing buffer = [`event_type` | metadata? | payload].
     fn persisted(
@@ -639,5 +644,92 @@ mod tests {
     #[test]
     fn empty_input_is_malformed_header() {
         assert!(matches!(decode_chunk(&[]), Err(ChunkError::Malformed(_))));
+    }
+
+    // ── Task 7: Full pipeline — export → box → import ───────────────────────
+
+    #[derive(Debug, Clone, Hash, PartialEq, Eq)]
+    struct Tid(String);
+
+    impl core::fmt::Display for Tid {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            f.write_str(&self.0)
+        }
+    }
+
+    impl AsRef<[u8]> for Tid {
+        fn as_ref(&self) -> &[u8] {
+            self.0.as_bytes()
+        }
+    }
+
+    impl nexus::Id for Tid {
+        const BYTE_LEN: usize = 0;
+    }
+
+    #[cfg(feature = "testing")]
+    #[tokio::test]
+    async fn export_box_import_round_trip_byte_equal_modulo_global_seq() {
+        // Seed a source store with two streams.
+        let src = InMemoryStore::new();
+        for (sid, count) in [("task-1", 3u64), ("task-2", 2)] {
+            for v in 1..=count {
+                let pe = pending_envelope(Version::new(v).expect("nonzero"))
+                    .event_type("E")
+                    .payload(format!("{sid}-{v}").into_bytes())
+                    .expect("valid payload")
+                    .build();
+                src.append(
+                    &Tid(sid.into()),
+                    Version::new(v - 1),
+                    core::slice::from_ref(&pe),
+                )
+                .await
+                .expect("append");
+            }
+        }
+
+        // Export → box-encode into one chunk.
+        let mut chunk = encode_header(Some(b"src")).expect("header").to_vec();
+        for sid in ["task-1", "task-2"] {
+            chunk.extend_from_slice(&encode_section_heading(sid.as_bytes()).expect("heading"));
+            let mut s = src
+                .read_stream(&Tid(sid.into()), Version::INITIAL)
+                .await
+                .expect("read");
+            while let Some(item) = s.next().await {
+                let e = item.expect("no read error");
+                chunk.extend_from_slice(&encode_block(&e).expect("block"));
+            }
+        }
+
+        // Box-decode → import into a fresh store under origin-namespaced ids.
+        let sections = decode_chunk(&chunk).expect("decode");
+        let dst = InMemoryStore::new();
+        let route = |origin: &[u8]| Tid(format!("src:{}", String::from_utf8_lossy(origin)));
+        let report = dst
+            .import(&sections, route, Atomicity::PerStream)
+            .await
+            .expect("import");
+        assert!(report.all_complete());
+
+        // Verify byte-equality of payloads/versions modulo global_seq.
+        for sid in ["task-1", "task-2"] {
+            let target = Tid(format!("src:{sid}"));
+            let got: Vec<(u64, Vec<u8>)> = dst
+                .read_stream(&target, Version::INITIAL)
+                .await
+                .expect("read")
+                .map(|r| {
+                    let e = r.expect("no err");
+                    (e.version().as_u64(), e.payload().to_vec())
+                })
+                .collect()
+                .await;
+            let expected: Vec<(u64, Vec<u8>)> = (1..=if sid == "task-1" { 3u64 } else { 2 })
+                .map(|v| (v, format!("{sid}-{v}").into_bytes()))
+                .collect();
+            assert_eq!(got, expected, "stream {sid} round-trips");
+        }
     }
 }

--- a/crates/nexus-store/src/cbor.rs
+++ b/crates/nexus-store/src/cbor.rs
@@ -764,6 +764,75 @@ mod tests {
         }
     }
 
+    // ── Task 10: Defensive fuzz (never-panic) + forward-compat unknown key ──
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(512))]
+
+        #[test]
+        fn decode_chunk_never_panics_on_arbitrary_bytes(
+            bytes in proptest::collection::vec(any::<u8>(), 0..256),
+        ) {
+            let _ = decode_chunk(&bytes);
+        }
+
+        #[test]
+        fn decode_chunk_never_panics_on_valid_header_plus_garbage(
+            garbage in proptest::collection::vec(any::<u8>(), 0..128),
+        ) {
+            let mut v = encode_header(None).expect("header").to_vec();
+            v.extend_from_slice(&garbage);
+            let _ = decode_chunk(&v);
+        }
+    }
+
+    #[test]
+    fn body_with_unknown_extra_key_still_decodes_to_event() {
+        // Forward-compat: a future encoder adds key 5 without bumping the
+        // format version; this decoder must skip it.
+        let mut body = Vec::new();
+        {
+            let mut e = minicbor::Encoder::new(&mut body);
+            e.map(5)
+                .expect("map")
+                .u32(0)
+                .expect("k0")
+                .u64(3)
+                .expect("v0")
+                .u32(1)
+                .expect("k1")
+                .u32(1)
+                .expect("v1")
+                .u32(2)
+                .expect("k2")
+                .str("E")
+                .expect("v2")
+                .u32(4)
+                .expect("k4")
+                .bytes(b"data")
+                .expect("v4")
+                .u32(5)
+                .expect("k5")
+                .u32(999)
+                .expect("v5"); // unknown key
+        }
+        let block = BlockRepr {
+            crc: crc32c::crc32c(&body),
+            body: &body,
+        };
+        let mut chunk = encode_header(None).expect("header").to_vec();
+        chunk.extend_from_slice(&encode_section_heading(b"s").expect("heading"));
+        chunk.extend_from_slice(&minicbor::to_vec(&block).expect("block"));
+        let sections = decode_chunk(&chunk).expect("decode");
+        match &sections[0].blocks[0] {
+            ImportBlock::Event(e) => {
+                assert_eq!(e.version().as_u64(), 3);
+                assert_eq!(e.payload(), b"data");
+            }
+            ImportBlock::Corrupt => panic!("unknown key must be skipped, not corrupt"),
+        }
+    }
+
     // ── Task 7: Full pipeline — export → box → import ───────────────────────
 
     #[derive(Debug, Clone, Hash, PartialEq, Eq)]

--- a/crates/nexus-store/src/cbor.rs
+++ b/crates/nexus-store/src/cbor.rs
@@ -596,4 +596,48 @@ mod tests {
             Err(ChunkError::Malformed(_))
         ));
     }
+
+    // ── Task 6: Lifecycle — incremental append / truncation / valid prefix ──
+
+    /// The cumulative byte length after the header + heading + first N blocks.
+    fn prefix_len_after_n_blocks(
+        stream_id: &[u8],
+        events: &[PersistedEnvelope],
+        n: usize,
+    ) -> usize {
+        let mut len = encode_header(None).expect("header").len();
+        len += encode_section_heading(stream_id).expect("heading").len();
+        for e in events.iter().take(n) {
+            len += encode_block(e).expect("block").len();
+        }
+        len
+    }
+
+    #[test]
+    fn every_block_boundary_prefix_is_valid() {
+        let events: Vec<_> = (1..=4).map(|v| persisted(v, 1, "E", None, b"p")).collect();
+        let chunk = encode_chunk(None, &[(b"s".as_slice(), events.clone())]);
+        for n in 0..=events.len() {
+            let cut = prefix_len_after_n_blocks(b"s", &events, n);
+            let sections = decode_chunk(&chunk[..cut]).expect("prefix valid");
+            let got = sections.first().map_or(0, |s| s.blocks.len());
+            assert_eq!(got, n, "prefix after {n} blocks must decode to {n} blocks");
+        }
+    }
+
+    #[test]
+    fn torn_final_block_is_dropped_earlier_survive() {
+        let events: Vec<_> = (1..=3)
+            .map(|v| persisted(v, 1, "E", None, b"payload"))
+            .collect();
+        let chunk = encode_chunk(None, &[(b"s".as_slice(), events)]);
+        let sections = decode_chunk(&chunk[..chunk.len() - 1]).expect("valid prefix");
+        assert_eq!(sections[0].blocks.len(), 2, "torn 3rd block dropped");
+        assert!(matches!(sections[0].blocks[0], ImportBlock::Event(_)));
+    }
+
+    #[test]
+    fn empty_input_is_malformed_header() {
+        assert!(matches!(decode_chunk(&[]), Err(ChunkError::Malformed(_))));
+    }
 }

--- a/crates/nexus-store/src/cbor.rs
+++ b/crates/nexus-store/src/cbor.rs
@@ -7,12 +7,17 @@
 //! `docs/plans/2026-06-21-export-import-cbor-box-design.md`.
 
 use core::convert::Infallible;
+use core::ops::Range;
 
 use bytes::Bytes;
+use minicbor::Decoder;
 use thiserror::Error;
 
 use crate::envelope::PersistedEnvelope;
-use crate::import::StreamSection;
+use crate::import::{ImportBlock, StreamSection};
+use crate::store::GlobalSeq;
+use crate::value::SchemaVersion;
+use nexus::Version;
 
 const MAGIC: &[u8] = b"nxch";
 const FORMAT_VERSION: u32 = 1;
@@ -109,14 +114,137 @@ pub const fn encode_section_heading(_stream_id: &[u8]) -> Result<Bytes, ChunkErr
     Ok(Bytes::new())
 }
 
-/// Stub — replaced in Task 3.
+/// Wire shape of a block body map. `global_seq` is deliberately absent —
+/// store-local, restamped on import.
+#[derive(minicbor::Encode, minicbor::Decode)]
+#[cbor(map)]
+struct BodyRepr<'a> {
+    #[n(0)]
+    version: u64,
+    #[n(1)]
+    schema_version: u32,
+    #[n(2)]
+    event_type: &'a str,
+    #[n(3)]
+    #[cbor(with = "minicbor::bytes")]
+    metadata: Option<&'a [u8]>,
+    #[n(4)]
+    #[cbor(with = "minicbor::bytes")]
+    payload: &'a [u8],
+}
+
+/// Wire shape of a block array `[crc32c, body]`. Encode-only (decode is manual
+/// so the crc is checked before the body is trusted).
+#[derive(minicbor::Encode)]
+#[cbor(array)]
+struct BlockRepr<'a> {
+    #[n(0)]
+    crc: u32,
+    #[n(1)]
+    #[cbor(with = "minicbor::bytes")]
+    body: &'a [u8],
+}
+
+/// Encode one event as a block `[crc32c(body), body]`. The crc covers exactly
+/// the body bstr bytes.
 ///
 /// # Errors
+/// Returns [`ChunkError::Encode`] if minicbor serialization fails (never in
+/// practice).
+pub fn encode_block(event: &PersistedEnvelope) -> Result<Bytes, ChunkError> {
+    let body = BodyRepr {
+        version: event.version().as_u64(),
+        schema_version: event.schema_version(),
+        event_type: event.event_type(),
+        metadata: event.metadata(),
+        payload: event.payload(),
+    };
+    let body_bytes = minicbor::to_vec(&body)?;
+    let block = BlockRepr {
+        crc: crc32c::crc32c(&body_bytes),
+        body: &body_bytes,
+    };
+    Ok(Bytes::from(minicbor::to_vec(&block)?))
+}
+
+/// Decode one block from the decoder's current position.
 ///
-/// Returns [`ChunkError::Encode`] if the CBOR serialization fails (infallible
-/// in practice for the stub path).
-pub const fn encode_block(_event: &PersistedEnvelope) -> Result<Bytes, ChunkError> {
-    Ok(Bytes::new())
+/// `Ok(Some(block))` = decoded (Event or Corrupt). `Ok(None)` = torn tail
+/// (end-of-input mid-item → caller stops, valid prefix). `Err(hint)` = a
+/// structural violation the caller turns into [`ChunkError::Malformed`].
+#[allow(
+    dead_code,
+    reason = "wired into decode_chunk in Task 4; called from tests now"
+)]
+fn decode_block(d: &mut Decoder<'_>) -> Result<Option<ImportBlock>, &'static str> {
+    match d.array() {
+        Ok(Some(2)) => {}
+        Ok(Some(_)) => return Err("block array must have exactly 2 elements"),
+        Ok(None) => return Err("indefinite-length block array"),
+        Err(e) if e.is_end_of_input() => return Ok(None),
+        Err(_) => return Err("malformed block array"),
+    }
+    let crc = match d.u32() {
+        Ok(c) => c,
+        Err(e) if e.is_end_of_input() => return Ok(None),
+        Err(_) => return Err("malformed block crc"),
+    };
+    let body: &[u8] = match d.bytes() {
+        Ok(b) => b,
+        Err(e) if e.is_end_of_input() => return Ok(None),
+        Err(_) => return Err("malformed block body bytes"),
+    };
+    if crc32c::crc32c(body) != crc {
+        // crc failed → bytes untrusted → Corrupt, do NOT decode the body.
+        return Ok(Some(ImportBlock::Corrupt));
+    }
+    // crc passed → body bytes are intact-as-written; any decode failure is a
+    // format violation, not bit-rot → Malformed (caller's job).
+    let parsed: BodyRepr = minicbor::decode(body).map_err(|_| "crc-valid body failed to decode")?;
+    let envelope = reconstruct(&parsed).ok_or("crc-valid body has invalid fields")?;
+    Ok(Some(ImportBlock::Event(envelope)))
+}
+
+/// Rebuild a [`PersistedEnvelope`] from a decoded body. Returns `None` on any
+/// field-level violation (version 0, schema 0, oversize, range overflow); the
+/// caller maps that to `Malformed`. `global_seq` is a placeholder — import
+/// ignores it.
+#[allow(
+    dead_code,
+    reason = "called by decode_block, wired into decode_chunk in Task 4"
+)]
+fn reconstruct(body: &BodyRepr<'_>) -> Option<PersistedEnvelope> {
+    let version = Version::new(body.version)?;
+    let schema = SchemaVersion::from_u32(body.schema_version).ok()?;
+    let event_type = body.event_type.as_bytes();
+    let et_end = u32::try_from(event_type.len()).ok()?;
+    let mut buf = Vec::with_capacity(
+        event_type.len() + body.metadata.map_or(0, <[u8]>::len) + body.payload.len(),
+    );
+    buf.extend_from_slice(event_type);
+    let et_range: Range<u32> = 0..et_end;
+    let meta_range = match body.metadata {
+        Some(m) => {
+            let start = u32::try_from(buf.len()).ok()?;
+            buf.extend_from_slice(m);
+            let end = u32::try_from(buf.len()).ok()?;
+            Some(start..end)
+        }
+        None => None,
+    };
+    let pl_start = u32::try_from(buf.len()).ok()?;
+    buf.extend_from_slice(body.payload);
+    let pl_end = u32::try_from(buf.len()).ok()?;
+    PersistedEnvelope::try_new(
+        version,
+        GlobalSeq::INITIAL,
+        Bytes::from(buf),
+        schema,
+        et_range,
+        pl_start..pl_end,
+        meta_range,
+    )
+    .ok()
 }
 
 /// Stub — replaced in Task 4.
@@ -137,6 +265,85 @@ pub const fn decode_chunk(_bytes: &[u8]) -> Result<Vec<StreamSection>, ChunkErro
 )]
 mod tests {
     use super::*;
+
+    /// Build a `PersistedEnvelope` directly: backing buffer = [`event_type` | metadata? | payload].
+    fn persisted(
+        version: u64,
+        schema: u32,
+        event_type: &str,
+        metadata: Option<&[u8]>,
+        payload: &[u8],
+    ) -> PersistedEnvelope {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(event_type.as_bytes());
+        let et_end = u32::try_from(buf.len()).expect("fits");
+        let meta_range = metadata.map(|m| {
+            let start = u32::try_from(buf.len()).expect("fits");
+            buf.extend_from_slice(m);
+            start..u32::try_from(buf.len()).expect("fits")
+        });
+        let pl_start = u32::try_from(buf.len()).expect("fits");
+        buf.extend_from_slice(payload);
+        let pl_end = u32::try_from(buf.len()).expect("fits");
+        PersistedEnvelope::try_new(
+            Version::new(version).expect("nonzero"),
+            GlobalSeq::new(version).expect("nonzero"),
+            Bytes::from(buf),
+            SchemaVersion::from_u32(schema).expect("nonzero"),
+            0..et_end,
+            pl_start..pl_end,
+            meta_range,
+        )
+        .expect("valid persisted")
+    }
+
+    /// Decode a single block from a freshly-encoded block buffer.
+    fn decode_one_block(bytes: &[u8]) -> ImportBlock {
+        let mut d = Decoder::new(bytes);
+        decode_block(&mut d)
+            .expect("not malformed")
+            .expect("not torn")
+    }
+
+    #[test]
+    fn block_round_trips_all_fields() {
+        let event = persisted(7, 3, "AccountOpened", Some(b"hlc=42"), b"balance:100");
+        let bytes = encode_block(&event).expect("encode");
+        match decode_one_block(&bytes) {
+            ImportBlock::Event(got) => {
+                assert_eq!(got.version().as_u64(), 7);
+                assert_eq!(got.schema_version(), 3);
+                assert_eq!(got.event_type(), "AccountOpened");
+                assert_eq!(got.metadata(), Some(b"hlc=42".as_slice()));
+                assert_eq!(got.payload(), b"balance:100");
+            }
+            ImportBlock::Corrupt => panic!("expected Event, got Corrupt"),
+        }
+    }
+
+    #[test]
+    fn block_round_trips_without_metadata_and_empty_payload() {
+        let event = persisted(1, 1, "E", None, b"");
+        let bytes = encode_block(&event).expect("encode");
+        match decode_one_block(&bytes) {
+            ImportBlock::Event(got) => {
+                assert_eq!(got.metadata(), None);
+                assert_eq!(got.payload(), b"");
+                assert_eq!(got.version().as_u64(), 1);
+            }
+            ImportBlock::Corrupt => panic!("expected Event"),
+        }
+    }
+
+    #[test]
+    fn block_with_flipped_body_byte_is_corrupt() {
+        let event = persisted(2, 1, "E", None, b"hello");
+        let bytes = encode_block(&event).expect("encode");
+        let mut v = bytes.to_vec();
+        let last = v.len() - 1;
+        v[last] ^= 0xFF;
+        assert!(matches!(decode_one_block(&v), ImportBlock::Corrupt));
+    }
 
     #[test]
     fn header_round_trips_without_origin() {

--- a/crates/nexus-store/src/cbor.rs
+++ b/crates/nexus-store/src/cbor.rs
@@ -14,6 +14,9 @@ use thiserror::Error;
 use crate::envelope::PersistedEnvelope;
 use crate::import::StreamSection;
 
+const MAGIC: &[u8] = b"nxch";
+const FORMAT_VERSION: u32 = 1;
+
 /// A box-layer encode/decode failure.
 ///
 /// Not [`ImportError`](crate::import::ImportError) — the box has no store error
@@ -41,24 +44,59 @@ pub struct ChunkHeader {
     pub origin: Option<Bytes>,
 }
 
-/// Stub — replaced in Task 2.
-///
-/// # Errors
-///
-/// Returns [`ChunkError::Encode`] if the CBOR serialization fails (infallible
-/// in practice for the stub path).
-pub const fn encode_header(_origin: Option<&[u8]>) -> Result<Bytes, ChunkError> {
-    Ok(Bytes::new())
+/// Wire shape of the header map `{0: magic, 1: format_version, 2: origin?}`.
+#[derive(minicbor::Encode, minicbor::Decode)]
+#[cbor(map)]
+struct HeaderRepr<'a> {
+    #[n(0)]
+    #[cbor(with = "minicbor::bytes")]
+    magic: &'a [u8],
+    #[n(1)]
+    format_version: u32,
+    #[n(2)]
+    #[cbor(with = "minicbor::bytes")]
+    origin: Option<&'a [u8]>,
 }
 
-/// Stub — replaced in Task 2.
+fn validate_header(magic: &[u8], format_version: u32) -> Result<(), ChunkError> {
+    if magic != MAGIC {
+        return Err(ChunkError::Malformed("bad magic"));
+    }
+    if format_version != FORMAT_VERSION {
+        return Err(ChunkError::Malformed("unknown format version"));
+    }
+    Ok(())
+}
+
+/// Encode the chunk header. Call once, at the start of a chunk. `origin` is an
+/// optional chunk-level producer/device id (omitted from the map when `None`).
 ///
 /// # Errors
+/// Returns [`ChunkError::Encode`] if minicbor serialization fails (never in
+/// practice — the `Vec` writer is infallible).
+pub fn encode_header(origin: Option<&[u8]>) -> Result<Bytes, ChunkError> {
+    let repr = HeaderRepr {
+        magic: MAGIC,
+        format_version: FORMAT_VERSION,
+        origin,
+    };
+    Ok(Bytes::from(minicbor::to_vec(&repr)?))
+}
+
+/// Decode just the header — a cheap peek that validates magic + format version
+/// and returns the chunk-level origin without parsing the body.
 ///
-/// Returns [`ChunkError::Malformed`] if the chunk header bytes cannot be
-/// decoded.
-pub const fn decode_header(_bytes: &[u8]) -> Result<ChunkHeader, ChunkError> {
-    Err(ChunkError::Malformed("unimplemented"))
+/// # Errors
+/// Returns [`ChunkError::Malformed`] on bad magic, unknown format version, or
+/// unreadable header bytes.
+pub fn decode_header(bytes: &[u8]) -> Result<ChunkHeader, ChunkError> {
+    let repr: HeaderRepr =
+        minicbor::decode(bytes).map_err(|_| ChunkError::Malformed("unreadable header"))?;
+    validate_header(repr.magic, repr.format_version)?;
+    Ok(ChunkHeader {
+        format_version: repr.format_version,
+        origin: repr.origin.map(Bytes::copy_from_slice),
+    })
 }
 
 /// Stub — replaced in Task 3.
@@ -88,4 +126,47 @@ pub const fn encode_block(_event: &PersistedEnvelope) -> Result<Bytes, ChunkErro
 /// Returns [`ChunkError::Malformed`] if the chunk bytes cannot be decoded.
 pub const fn decode_chunk(_bytes: &[u8]) -> Result<Vec<StreamSection>, ChunkError> {
     Ok(Vec::new())
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    reason = "test code asserts exact values"
+)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn header_round_trips_without_origin() {
+        let bytes = encode_header(None).expect("encode");
+        let header = decode_header(&bytes).expect("decode");
+        assert_eq!(header.format_version, 1);
+        assert_eq!(header.origin, None);
+    }
+
+    #[test]
+    fn header_round_trips_with_origin() {
+        let bytes = encode_header(Some(b"phone-7")).expect("encode");
+        let header = decode_header(&bytes).expect("decode");
+        assert_eq!(header.format_version, 1);
+        assert_eq!(header.origin.as_deref(), Some(b"phone-7".as_slice()));
+    }
+
+    #[test]
+    fn header_rejects_bad_magic() {
+        let mut v = encode_header(None).expect("encode").to_vec();
+        let pos = v.iter().position(|&b| b == b'n').expect("magic present");
+        v[pos] = b'X';
+        let err = decode_header(&v).expect_err("bad magic rejected");
+        assert!(matches!(err, ChunkError::Malformed("bad magic")));
+    }
+
+    #[test]
+    fn header_rejects_truncated() {
+        let bytes = encode_header(Some(b"x")).expect("encode");
+        let err = decode_header(&bytes[..bytes.len() / 2]).expect_err("truncated rejected");
+        assert!(matches!(err, ChunkError::Malformed(_)));
+    }
 }

--- a/crates/nexus-store/src/cbor.rs
+++ b/crates/nexus-store/src/cbor.rs
@@ -669,6 +669,101 @@ mod tests {
         insta::assert_snapshot!("block_v1_hex", hex_of(&bytes));
     }
 
+    // ── Task 9: VOPR round-trip + crc single-byte-mutation property tests ───
+
+    use proptest::prelude::*;
+
+    /// (version, schema, `event_type`, metadata?, payload) — boundary-inclusive.
+    fn event_strategy() -> impl Strategy<Value = (u64, u32, String, Option<Vec<u8>>, Vec<u8>)> {
+        (
+            prop_oneof![
+                Just(1u64),
+                Just(2),
+                Just(u64::MAX - 1),
+                Just(u64::MAX),
+                1u64..1000
+            ],
+            prop_oneof![Just(1u32), Just(7), Just(u32::MAX), 1u32..100],
+            prop_oneof![Just(String::new()), Just("E".to_owned()), "[A-Za-z]{0,40}"],
+            prop_oneof![
+                Just(None),
+                proptest::collection::vec(any::<u8>(), 1..32).prop_map(Some)
+            ],
+            proptest::collection::vec(any::<u8>(), 0..64),
+        )
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(128))]
+
+        #[test]
+        fn vopr_chunk_round_trips(
+            origin in prop_oneof![
+                Just(None),
+                proptest::collection::vec(any::<u8>(), 1..16).prop_map(Some)
+            ],
+            streams in proptest::collection::vec(
+                (proptest::collection::vec(any::<u8>(), 0..12),
+                 proptest::collection::vec(event_strategy(), 0..5)),
+                0..4,
+            ),
+        ) {
+            let built: Vec<(Vec<u8>, Vec<PersistedEnvelope>)> = streams
+                .iter()
+                .map(|(sid, evs)| {
+                    let events = evs.iter().map(|(v, sc, et, md, pl)| {
+                        persisted(*v, *sc, et, md.as_deref(), pl)
+                    }).collect();
+                    (sid.clone(), events)
+                })
+                .collect();
+
+            let refs: Vec<(&[u8], Vec<PersistedEnvelope>)> =
+                built.iter().map(|(s, e)| (s.as_slice(), e.clone())).collect();
+            let chunk = encode_chunk(origin.as_deref(), &refs);
+            let sections = decode_chunk(&chunk).expect("decode");
+
+            prop_assert_eq!(sections.len(), built.len());
+            for (section, (sid, events)) in sections.iter().zip(built.iter()) {
+                prop_assert_eq!(section.origin.as_ref(), sid.as_slice());
+                prop_assert_eq!(section.blocks.len(), events.len());
+                for (block, original) in section.blocks.iter().zip(events.iter()) {
+                    match block {
+                        ImportBlock::Event(got) => {
+                            prop_assert_eq!(got.version(), original.version());
+                            prop_assert_eq!(got.schema_version(), original.schema_version());
+                            prop_assert_eq!(got.event_type(), original.event_type());
+                            prop_assert_eq!(got.metadata(), original.metadata());
+                            prop_assert_eq!(got.payload(), original.payload());
+                        }
+                        ImportBlock::Corrupt => prop_assert!(false, "unexpected corrupt"),
+                    }
+                }
+            }
+        }
+
+        #[test]
+        fn vopr_single_byte_body_mutation_is_corrupt_never_silently_wrong(
+            (ev_v, ev_sc, ev_et, ev_md, ev_pl) in event_strategy(),
+            flip_pick in any::<prop::sample::Index>(),
+        ) {
+            let event = persisted(ev_v, ev_sc, &ev_et, ev_md.as_deref(), &ev_pl);
+            let block = encode_block(&event).expect("block");
+            let mut v = block.to_vec();
+            let start = v.len() / 2;
+            let idx = start + flip_pick.index(v.len() - start);
+            v[idx] ^= 0xFF;
+            let mut d = Decoder::new(&v);
+            match decode_block(&mut d) {
+                Ok(Some(ImportBlock::Event(got))) => {
+                    prop_assert_eq!(got.payload(), event.payload());
+                    prop_assert_eq!(got.event_type(), event.event_type());
+                }
+                Ok(Some(ImportBlock::Corrupt) | None) | Err(_) => {}
+            }
+        }
+    }
+
     // ── Task 7: Full pipeline — export → box → import ───────────────────────
 
     #[derive(Debug, Clone, Hash, PartialEq, Eq)]

--- a/crates/nexus-store/src/cbor.rs
+++ b/crates/nexus-store/src/cbor.rs
@@ -1,0 +1,91 @@
+//! The default CBOR backup box — the bytes↔sections travel codec.
+//!
+//! Sits between Card 1's raw export (per-stream [`PersistedEnvelope`]s) and
+//! Card 2's [`EventImporter`](crate::import::EventImporter). A chunk is a CBOR
+//! sequence (RFC 8742): a header map, then per-stream section headings each
+//! followed by block arrays `[crc32c, body]`. See
+//! `docs/plans/2026-06-21-export-import-cbor-box-design.md`.
+
+use core::convert::Infallible;
+
+use bytes::Bytes;
+use thiserror::Error;
+
+use crate::envelope::PersistedEnvelope;
+use crate::import::StreamSection;
+
+/// A box-layer encode/decode failure.
+///
+/// Not [`ImportError`](crate::import::ImportError) — the box has no store error
+/// or id type. Two failure domains, two variants (CLAUDE rule 3).
+#[derive(Debug, Error)]
+pub enum ChunkError {
+    /// Decode: the chunk framing is unreadable. The `&'static str` is a debug
+    /// hint. Distinct from a per-block crc failure, which is a non-error
+    /// [`ImportBlock::Corrupt`](crate::import::ImportBlock::Corrupt).
+    #[error("malformed chunk: {0}")]
+    Malformed(&'static str),
+    /// Encode: minicbor serialization failed. Never fires in practice (the
+    /// `Vec` writer is `Infallible`, a `PersistedEnvelope` guarantees every
+    /// field cap) but minicbor's API is fallible, so the type is honest.
+    #[error("chunk encode failed: {0}")]
+    Encode(#[from] minicbor::encode::Error<Infallible>),
+}
+
+/// The decoded chunk header — what [`decode_header`] returns.
+#[derive(Debug, Clone)]
+pub struct ChunkHeader {
+    /// The chunk format version (always `1` for a chunk this build accepts).
+    pub format_version: u32,
+    /// The chunk-level producer/device id, if the encoder recorded one.
+    pub origin: Option<Bytes>,
+}
+
+/// Stub — replaced in Task 2.
+///
+/// # Errors
+///
+/// Returns [`ChunkError::Encode`] if the CBOR serialization fails (infallible
+/// in practice for the stub path).
+pub const fn encode_header(_origin: Option<&[u8]>) -> Result<Bytes, ChunkError> {
+    Ok(Bytes::new())
+}
+
+/// Stub — replaced in Task 2.
+///
+/// # Errors
+///
+/// Returns [`ChunkError::Malformed`] if the chunk header bytes cannot be
+/// decoded.
+pub const fn decode_header(_bytes: &[u8]) -> Result<ChunkHeader, ChunkError> {
+    Err(ChunkError::Malformed("unimplemented"))
+}
+
+/// Stub — replaced in Task 3.
+///
+/// # Errors
+///
+/// Returns [`ChunkError::Encode`] if the CBOR serialization fails (infallible
+/// in practice for the stub path).
+pub const fn encode_section_heading(_stream_id: &[u8]) -> Result<Bytes, ChunkError> {
+    Ok(Bytes::new())
+}
+
+/// Stub — replaced in Task 3.
+///
+/// # Errors
+///
+/// Returns [`ChunkError::Encode`] if the CBOR serialization fails (infallible
+/// in practice for the stub path).
+pub const fn encode_block(_event: &PersistedEnvelope) -> Result<Bytes, ChunkError> {
+    Ok(Bytes::new())
+}
+
+/// Stub — replaced in Task 4.
+///
+/// # Errors
+///
+/// Returns [`ChunkError::Malformed`] if the chunk bytes cannot be decoded.
+pub const fn decode_chunk(_bytes: &[u8]) -> Result<Vec<StreamSection>, ChunkError> {
+    Ok(Vec::new())
+}

--- a/crates/nexus-store/src/cbor.rs
+++ b/crates/nexus-store/src/cbor.rs
@@ -646,6 +646,29 @@ mod tests {
         assert!(matches!(decode_chunk(&[]), Err(ChunkError::Malformed(_))));
     }
 
+    // ── Task 8: Golden-byte insta snapshots ─────────────────────────────────
+
+    fn hex_of(bytes: &[u8]) -> String {
+        bytes
+            .iter()
+            .map(|b| format!("{b:02x}"))
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+
+    #[test]
+    fn golden_header_bytes() {
+        let bytes = encode_header(Some(b"dev")).expect("header");
+        insta::assert_snapshot!("header_with_origin_hex", hex_of(&bytes));
+    }
+
+    #[test]
+    fn golden_block_bytes() {
+        let event = persisted(1, 1, "E", None, b"hi");
+        let bytes = encode_block(&event).expect("block");
+        insta::assert_snapshot!("block_v1_hex", hex_of(&bytes));
+    }
+
     // ── Task 7: Full pipeline — export → box → import ───────────────────────
 
     #[derive(Debug, Clone, Hash, PartialEq, Eq)]

--- a/crates/nexus-store/src/lib.rs
+++ b/crates/nexus-store/src/lib.rs
@@ -83,6 +83,8 @@
 
 pub mod batch;
 pub mod builder;
+#[cfg(feature = "cbor")]
+pub mod cbor;
 pub mod codec;
 pub mod envelope;
 pub mod error;
@@ -113,6 +115,11 @@ pub use batch::{BatchSize, BatchSizeError, DEFAULT_BATCH, MAX_BATCH};
 #[cfg(feature = "snapshot")]
 pub use builder::WithSnapshot;
 pub use builder::{NeedsCodec, NoSnapshot, RepositoryBuilder};
+#[cfg(feature = "cbor")]
+pub use cbor::{
+    ChunkError, ChunkHeader, decode_chunk, decode_header, encode_block, encode_header,
+    encode_section_heading,
+};
 #[cfg(feature = "json")]
 pub use codec::serde::json::{Json, JsonCodec};
 #[cfg(feature = "serde")]

--- a/crates/nexus-store/src/snapshots/nexus_store__cbor__tests__block_v1_hex.snap
+++ b/crates/nexus-store/src/snapshots/nexus_store__cbor__tests__block_v1_hex.snap
@@ -1,0 +1,5 @@
+---
+source: crates/nexus-store/src/cbor.rs
+expression: hex_of(&bytes)
+---
+82 1a cf f9 cc 83 4c a4 00 01 01 01 02 61 45 04 42 68 69

--- a/crates/nexus-store/src/snapshots/nexus_store__cbor__tests__header_with_origin_hex.snap
+++ b/crates/nexus-store/src/snapshots/nexus_store__cbor__tests__header_with_origin_hex.snap
@@ -1,0 +1,5 @@
+---
+source: crates/nexus-store/src/cbor.rs
+expression: hex_of(&bytes)
+---
+a3 00 44 6e 78 63 68 01 01 02 43 64 65 76

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -27,7 +27,7 @@ once_cell = { version = "1" }
 proc-macro2 = { version = "1", features = ["span-locations"] }
 serde = { version = "1", features = ["alloc", "derive", "rc"] }
 serde_core = { version = "1", default-features = false, features = ["alloc", "rc", "result", "std"] }
-syn = { version = "2", features = ["extra-traits", "full"] }
+syn = { version = "2", features = ["extra-traits", "full", "visit"] }
 trybuild = { version = "1", default-features = false, features = ["diff"] }
 zerocopy = { version = "0.8", default-features = false, features = ["derive", "simd"] }
 

--- a/deny.toml
+++ b/deny.toml
@@ -7,7 +7,8 @@ allow = [
     "Unicode-3.0",  # For Unicode data
     "MPL-2.0", # Mozilla Public License
     "Zlib",
-    "BSL-1.0"
+    "BSL-1.0",
+    "BlueOak-1.0.0", # Blue Oak Model License — permissive, required by crc32c
 ]
 private = { ignore = true }
 

--- a/docs/plans/2026-06-21-export-import-cbor-box-design.md
+++ b/docs/plans/2026-06-21-export-import-cbor-box-design.md
@@ -1,0 +1,294 @@
+# Export/Import Card 3 — the default CBOR backup box (design)
+
+Issue #145, milestone 1 (Feature-Complete, pre-freeze). Branch
+`feat/export-import-cbor-box`, stacked on `feat/export-import-traits` (PR #218,
+Cards 0–2). This is the **last nexus-side card** for #145; the sync runtime
+(per-device layout, iCloud transport, CRDT merge, the forever
+export→upload→download→import loop) is Agency's (devrandom-labs/agency#147).
+
+## What this card is
+
+The bytes↔sections codec that sits between Card 1's raw export and Card 2's
+`EventImporter`. It is the **default backup box** — the travel format. It does
+two things:
+
+- **Encode** (write side): turn a header + per-stream `PersistedEnvelope`s into
+  appendable `Bytes` the caller writes to a chunk file incrementally.
+- **Decode** (read side): turn chunk bytes back into `Vec<StreamSection>` for
+  `EventImporter::import`, plus a cheap header peek.
+
+It lives in a new `cbor.rs`, gated `#[cfg(feature = "cbor")]`, where
+`cbor = ["import", "export", "dep:minicbor", "dep:crc32c"]`. `cbor` implies
+export+import; export/import never imply `cbor` (Agency enables export/import and
+brings its own CESR box, pulling no CBOR).
+
+## Glossary (pinned — easy to blur)
+
+- **frame** — one event as stored locally (`wire::encode_frame`, unchanged by
+  this card). A book on the shelf. NOT what we build here.
+- **block** — one event wrapped for the trip: `[crc32c, body]`. A mailed book
+  with a fragile sticker.
+- **section** — one origin stream's blocks, introduced by a heading that names
+  the stream once.
+- **chunk** — the travel box: one byte buffer holding a header + many sections.
+- **box** — the codec in this card that turns events ↔ chunk bytes.
+
+## Two layers, kept separate
+
+Layer 1 = the on-disk wire frame (`wire.rs`), unchanged. Layer 2 = the export
+**chunk** (this card). The label and per-block checksum go on the box, not in
+every book. The chunk copies on decode — it carries **no** 16-byte alignment
+guarantee (that is a frame-only concern for zero-copy local reads). Import is
+not a hot path, so a copy/parse on decode is acceptable.
+
+## The CBOR sequence layout (re-spec of §6 for per-stream sections)
+
+The pre-pivot §6 put `stream_id` in every block body. The Card-2 pivot moved
+`stream_id` to a per-stream **section heading**, emitted once, and dropped it
+from block bodies. This is the re-spec.
+
+A chunk is a **CBOR sequence** (RFC 8742) — a bare concatenation of CBOR data
+items, no outer array. Definite-length encoding only; unsigned-integer map keys.
+
+```
+item[0]  HEADER   map   {0: magic bstr h'6e786368' ("nxch"),
+                         1: format_version uint = 1,
+                         2: origin bstr OPTIONAL}              ← chunk-level producer id
+item[1]  HEADING  map   {0: stream_id bstr}                   ← starts a StreamSection
+item[2]  BLOCK    array [crc32c uint, body bstr]              ← a block for the current section
+item[3]  BLOCK    array [crc32c uint, body bstr]
+item[4]  HEADING  map   {0: stream_id bstr}                   ← next StreamSection
+item[5]  BLOCK    array [...]
+...
+
+body bstr = CBOR map {0: version uint ≥ 1,
+                      1: schema_version uint ≥ 1,
+                      2: event_type tstr (≤ MAX_EVENT_TYPE_LEN),
+                      3: metadata bstr OPTIONAL (≤ MAX_METADATA_LEN, omitted when None),
+                      4: payload bstr}
+crc32c = CRC32C(body bstr bytes)   ; Castagnoli poly 0x1EDC6F41, the `crc32c` crate
+```
+
+### Why these shapes
+
+- **Header / heading both maps; block an array.** The decoder distinguishes
+  heading from block by peeking the next CBOR major type: **Map ⇒ heading**,
+  **Array ⇒ block**. The header is also a map but is resolved positionally
+  (always `item[0]`, read first and unconditionally). A map heading
+  (`{0: stream_id}`) rather than a bare byte-string is chosen for
+  forward-compatibility: integer keys are append-only, so a future per-section
+  field can be added without a format break.
+- **crc is element[0]** of the block array, so the reader has the expected
+  checksum before reading the body. crc covers **exactly** the body bstr span —
+  not the array, not itself.
+- **`global_seq` is never written.** It is store-local; import restamps a fresh
+  one on append (Card 2 confirmed import ignores it). Writing it would be work
+  import redoes for free.
+- **Block body keys renumbered 0–4** (was 0–5 with `stream_id` at 0). Allowed
+  now, pre-freeze. After this card ships the keys are **append-only**: decoders
+  skip unknown keys (forward-compat), and an incompatible change bumps
+  `format_version` (an unknown version ⇒ `Malformed`).
+- **No event-count, no end-marker.** Either would break incremental/live append.
+  A chunk is "the valid blocks you can read"; truncation = fewer blocks.
+
+## Trust model and the decode walk
+
+Two trust levels, one clean rule: **bit-rot is localized (Corrupt);
+structural violations reject the chunk (Malformed).** The only thing that
+produces a `Corrupt` block is a crc mismatch. A passing crc means the body bytes
+are intact-as-written, so any failure to interpret them is a format violation,
+not corruption.
+
+`decode_chunk(&[u8]) -> Result<Vec<StreamSection>, ChunkError>`:
+
+| Situation | Outcome |
+|---|---|
+| header: bad magic / unknown `format_version` / not-a-map / truncated | `Malformed` |
+| peek = end-of-input | **stop**, return accumulated sections (valid prefix) |
+| peek = Map → heading `{0: stream_id}` decodes | start a new `StreamSection` |
+| heading torn mid-item (end-of-input) | **stop** (valid prefix) |
+| heading present but malformed (not the expected map) | `Malformed` |
+| peek = Array → block `[crc, body]` torn mid-item (end-of-input) | **stop** (valid prefix) |
+| block fully read, **crc mismatch** | `ImportBlock::Corrupt`, **continue** |
+| block fully read, **crc match, body decodes** | `ImportBlock::Event`, continue (unknown body keys skipped) |
+| block fully read, **crc match, body fails** (v0, schema 0, bad utf8, oversize, missing required key, not-a-map) | `Malformed` |
+| block before any heading | `Malformed` |
+| peek = any other major type | `Malformed` |
+
+**Why end-of-input is the only "stop":** CBOR sequences are not
+self-synchronizing — a corrupted length prefix makes the next item boundary
+unfindable. End-of-input (truncation / torn tail) is the one non-clean
+termination we can recover from, because everything before it is intact and
+crc-checked per block. Any other parse failure past the header means the framing
+is damaged in a way we cannot walk; returning a "valid prefix" there would risk
+silently dropping present-but-unreachable data. `Malformed` is the honest
+answer — the consumer re-fetches the chunk.
+
+This never panics on arbitrary input: every failure is either a `Malformed`
+result or a clean stop.
+
+## Reconstructing `PersistedEnvelope` on decode
+
+For each `Event` block, rebuild a `PersistedEnvelope` via
+`PersistedEnvelope::try_new`:
+
+- synthesize a backing `Bytes` buffer laid out `[event_type | metadata? | payload]`,
+- compute the `event_type` / `metadata?` / `payload` `Range<u32>` offsets into it,
+- `version` from body key 0, `schema_version` from body key 1,
+- `global_seq = GlobalSeq::INITIAL` (a placeholder — import ignores it).
+
+`try_new` re-validates ranges, UTF-8, and per-field caps at the box boundary
+(each crate defends itself — CLAUDE rule). The box copies; no alignment needed.
+
+## API surface
+
+All in `cbor.rs`, behind `#[cfg(feature = "cbor")]`, re-exported at the crate
+root.
+
+**Encode — three free functions** (stateless, each returns a small `Bytes` the
+caller appends; the encoder never owns a buffer or file IO, so an all-day
+incremental append stays bounded in memory):
+
+```rust
+pub fn encode_header(origin: Option<&[u8]>) -> Result<Bytes, ChunkError>;
+pub fn encode_section_heading(stream_id: &[u8]) -> Result<Bytes, ChunkError>;
+pub fn encode_block(event: &PersistedEnvelope) -> Result<Bytes, ChunkError>;
+```
+
+**Resolved (from minicbor 2.2.2 source):** encode is fallible at the type level.
+`minicbor::to_vec` returns `Result<Vec<u8>, encode::Error<Infallible>>`, and
+`encode::Error` carries `Message` / `Custom` variants beyond the (uninhabited)
+`Write(Infallible)` — so the compiler will not let us treat encoding as
+infallible without `unwrap`/`expect`/`panic`, all of which strict clippy bans in
+production code. The encode functions therefore return `Result<Bytes,
+ChunkError>`, propagating the minicbor error via `?`. This also matches the
+crate's existing fallible builder `wire::build_row`. In practice the error never
+fires (a `PersistedEnvelope` guarantees every field cap, and the `Vec` writer is
+`Infallible`), but the type is honest.
+
+The caller's loop (Agency): `encode_header` once, then per stream
+`encode_section_heading` followed by one `encode_block` per exported event,
+appending each `Bytes` to the chunk file. Resume = re-open `export_stream(id,
+from)` and continue.
+
+**Decode:**
+
+```rust
+pub fn decode_chunk(bytes: &[u8]) -> Result<Vec<StreamSection>, ChunkError>;
+pub fn decode_header(bytes: &[u8]) -> Result<ChunkHeader, ChunkError>;
+
+pub struct ChunkHeader {
+    pub format_version: u32,
+    pub origin: Option<Bytes>,
+}
+```
+
+`decode_header` is the cheap peek: validate magic + `format_version`, return the
+chunk-level `origin` (device id) without parsing the body. It exists so the
+chunk-level `origin` we encode is actually readable (a write-only field would
+violate "justify every type") and so Agency can attribute a chunk to a device
+before deciding the `route` closure. `decode_chunk` returns `Vec<StreamSection>`
+to match `EventImporter::import(&[StreamSection], …)` — materialized because
+import takes a slice and is not the hot path; a lazy streaming decoder is a
+possible follow-up, out of scope here.
+
+**The decode/encode asymmetry is intentional:** encode is incremental
+(bounded-memory all-day append on the write side), decode is whole-buffer
+(import consumes a slice anyway). Two sides, two constraints.
+
+## Error type
+
+```rust
+#[derive(Debug, thiserror::Error)]
+pub enum ChunkError {
+    /// Decode: the chunk's framing is unreadable (bad magic, unknown
+    /// format_version, block before heading, unexpected item type, a
+    /// crc-passing body that fails to decode, …).
+    #[error("malformed chunk: {0}")]
+    Malformed(&'static str),
+    /// Encode: minicbor failed to serialize (never fires in practice — the
+    /// `Vec` writer is `Infallible` and a `PersistedEnvelope` guarantees every
+    /// field cap — but the type is honest about minicbor's fallible API).
+    #[error("chunk encode failed: {0}")]
+    Encode(#[from] minicbor::encode::Error<core::convert::Infallible>),
+}
+```
+
+A dedicated box-layer error, not `ImportError<E, I>` — the box has no store error
+`E` and no id type `I`. Two variants for two failure domains (CLAUDE rule 3):
+`Malformed` is the decode-side framing rejection (mirrors the reserved
+`ImportError::Malformed` slot but at the box layer); `Encode` preserves the
+minicbor source via `#[from]` so encode can use `?` without discarding the error.
+`Malformed`'s `&'static str` carries a debug hint ("bad magic", "unknown format
+version", "block before section heading", "unexpected item type", "body decode
+failed", …). `ChunkError` does **not** derive `PartialEq` (minicbor's error type
+is not `PartialEq`); decode tests match on `ChunkError::Malformed(_)` via
+`matches!` and assert the hint string separately.
+
+## Feature wiring
+
+`crates/nexus-store/Cargo.toml`:
+
+```toml
+cbor = ["import", "export", "dep:minicbor", "dep:crc32c"]
+```
+
+- `minicbor` locked over ciborium: no_std / no-serde, so the box stays decoupled
+  from serde (rkyv/bytemuck users export without pulling serde). Pin via
+  `cargo add` (2.2.2 verified for the layout). `#[cbor(with =
+  "minicbor::bytes")]` on **every** bstr field (magic, origin, stream_id,
+  metadata, payload, block body) — without it minicbor encodes `&[u8]` as a
+  CBOR array-of-integers (wrong major type, ~4× bloat). `event_type` stays plain
+  `&str` (tstr).
+- `crc32c` crate for the Castagnoli per-block checksum. Pin via `cargo add`.
+
+Add `cbor` to the `nexus-store` self dev-dependency feature list so the box
+tests run under `nix flake check` (the gate runs default features only).
+
+`lib.rs`: `#[cfg(feature = "cbor")] pub mod cbor;` + re-export
+`encode_header`, `encode_section_heading`, `encode_block`, `decode_chunk`,
+`decode_header`, `ChunkHeader`, `ChunkError`.
+
+## Test plan (TDD, 4 cross-cutting categories first, then golden + VOPR)
+
+1. **Sequence/protocol** — encode a multi-stream chunk (header + 2 headings +
+   their blocks) → `decode_chunk` → exact `Vec<StreamSection>` back (origins +
+   per-block version / event_type / payload / metadata / schema). Full pipeline:
+   Card-1 export → box encode → `decode_chunk` → Card-2 `import` into a fresh
+   `InMemoryStore` → streams byte-equal modulo `global_seq`.
+2. **Lifecycle (incremental/append)** — a chunk is valid at every block-boundary
+   prefix; truncating after N complete blocks decodes to those N (valid prefix);
+   a torn final block is dropped, earlier blocks survive; header-only chunk →
+   empty `Vec`.
+3. **Defensive boundary** — flip a byte inside a block body → crc mismatch →
+   that block decodes to `ImportBlock::Corrupt` (and the importer halts that
+   stream); bad magic / unknown `format_version` → `Malformed`; block-before-
+   heading → `Malformed`; oversize event_type/metadata or version 0 with a
+   matching crc → `Malformed`; unexpected major type → `Malformed`; arbitrary
+   garbage bytes → never panics, returns `Malformed` or a valid-prefix `Vec`.
+4. **Linearizability/isolation** — encode is pure/stateless free functions and
+   decode is pure, so there is no shared mutable state to race; the
+   concurrency story is covered by Card 2's import tests. We assert the
+   functions are `Send`-friendly (`Bytes` / owned outputs) and that
+   encode→decode is deterministic across threads.
+5. **insta golden bytes** — snapshot the encoded header and a known block's hex
+   so any accidental format drift must consciously update the snapshot.
+6. **VOPR / round-trip property test (proptest)** — for arbitrary valid
+   `(origin, [streams of [events]])`, `decode_chunk(encode(x)) == x` modulo
+   `global_seq`; and crc rejects any single-byte mutation of a body (decodes to
+   `Corrupt`, never silently wrong). Boundary-inclusive strategies: empty
+   payload, max event_type, empty/Some metadata, version/schema at 1 and
+   near-max.
+7. **Forward-compat** — a body carrying an unknown extra integer key still
+   decodes to `Event` (decoders skip unknown keys).
+
+Test modules carry a scoped
+`#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, reason = "...")]`.
+
+## Out of scope
+
+- Live/continuous export loop, per-device file layout, iCloud transport, CRDT
+  merge — all Agency (agency#147).
+- A lazy streaming decoder (materialized `decode_chunk` suffices for import).
+- Any change to the wire frame, `PersistedEnvelope`, or Cards 0–2.
+- Signing / authenticity (consumer's CESR/KERI layer) and content-addressing.

--- a/docs/plans/2026-06-21-export-import-cbor-box-plan.md
+++ b/docs/plans/2026-06-21-export-import-cbor-box-plan.md
@@ -1,0 +1,1364 @@
+# Export/Import Card 3 — CBOR backup box Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the default CBOR backup box — the bytes↔sections codec between Card 1's raw export and Card 2's `EventImporter` — in `crates/nexus-store/src/cbor.rs` behind a new `cbor` feature.
+
+**Architecture:** A chunk is a CBOR sequence (RFC 8742): a header map, then per-stream section headings (maps) each followed by block arrays `[crc32c, body]`. Encode = three stateless free functions returning appendable `Bytes`. Decode = a whole-buffer walk that peeks each item's CBOR major type (map ⇒ heading, array ⇒ block) and rebuilds `PersistedEnvelope`s, classifying failures as `Corrupt` (crc mismatch, localized) or `Malformed` (structural, whole-chunk). See `docs/plans/2026-06-21-export-import-cbor-box-design.md`.
+
+**Tech Stack:** Rust 2024, `minicbor` 2.2.2 (derive, no_std/no-serde) for CBOR, `crc32c` for the Castagnoli per-block checksum, `bytes::Bytes`, `thiserror`, `insta` for golden bytes, `proptest` for VOPR.
+
+---
+
+## File structure
+
+- **Create** `crates/nexus-store/src/cbor.rs` — the entire box: constants, `ChunkError`, `ChunkHeader`, the `minicbor::Encode`/`Decode` repr structs (`HeaderRepr`, `HeadingRepr`, `BodyRepr`, `BlockRepr`), the public `encode_header` / `encode_section_heading` / `encode_block` / `decode_header` / `decode_chunk`, the private `validate_header` / `decode_block` / `reconstruct`, and `#[cfg(test)] mod tests`.
+- **Modify** `crates/nexus-store/Cargo.toml` — add the `cbor` feature, `minicbor` + `crc32c` optional deps, and `cbor` to the self dev-dependency feature list. Add `insta` dev-dep if absent.
+- **Modify** `crates/nexus-store/src/lib.rs` — `#[cfg(feature = "cbor")] pub mod cbor;` + re-exports.
+- **Modify** root `Cargo.toml` — `[workspace.dependencies]` entries for `minicbor`, `crc32c` (and `insta` if absent).
+
+Everything box-related is one file. It is small, cohesive, and gated — no reason to split.
+
+---
+
+## Task 1: Dependencies, feature wiring, and module skeleton
+
+**Files:**
+- Modify: root `Cargo.toml` (`[workspace.dependencies]`)
+- Modify: `crates/nexus-store/Cargo.toml`
+- Create: `crates/nexus-store/src/cbor.rs`
+- Modify: `crates/nexus-store/src/lib.rs`
+
+- [ ] **Step 1: Add the dependencies via `cargo add` (never hand-write versions).**
+
+```bash
+cd /Users/joel/Code/devrandom/nexus
+nix develop -c cargo add minicbor --features derive,alloc -p nexus-store --optional
+nix develop -c cargo add crc32c -p nexus-store --optional
+# insta is dev-only; check first, add only if missing:
+nix develop -c cargo add insta --dev -p nexus-store
+nix develop -c cargo hakari generate
+```
+
+Expected: `minicbor`, `crc32c` land in `[workspace.dependencies]` and as `optional = true` under `nexus-store` `[dependencies]`; `insta` under `[dev-dependencies]`. If `cargo add` places versions only in the crate manifest, move the version to `[workspace.dependencies]` and set `workspace = true` in the crate manifest to match the repo convention (then re-run `cargo hakari generate`).
+
+- [ ] **Step 2: Add the `cbor` feature and extend the self dev-dependency.**
+
+In `crates/nexus-store/Cargo.toml` `[features]`, add:
+
+```toml
+# Default CBOR backup box (issue #145, Card 3). Implies export+import; the
+# inverse never holds (Agency enables export/import and brings its own CESR box,
+# pulling no CBOR).
+cbor = ["import", "export", "dep:minicbor", "dep:crc32c"]
+```
+
+In `[dev-dependencies]`, extend the self dep so box tests run under `nix flake check` (the gate runs default features only):
+
+```toml
+nexus-store = { path = ".", features = ["testing", "export", "import", "cbor"] }
+```
+
+- [ ] **Step 3: Create the module skeleton `crates/nexus-store/src/cbor.rs`.**
+
+```rust
+//! The default CBOR backup box — the bytes↔sections travel codec.
+//!
+//! Sits between Card 1's raw export (per-stream [`PersistedEnvelope`]s) and
+//! Card 2's [`EventImporter`](crate::import::EventImporter). A chunk is a CBOR
+//! sequence (RFC 8742): a header map, then per-stream section headings each
+//! followed by block arrays `[crc32c, body]`. See
+//! `docs/plans/2026-06-21-export-import-cbor-box-design.md`.
+
+use core::convert::Infallible;
+use core::ops::Range;
+
+use bytes::Bytes;
+use minicbor::data::Type;
+use minicbor::Decoder;
+use nexus::Version;
+use thiserror::Error;
+
+use crate::envelope::PersistedEnvelope;
+use crate::import::{ImportBlock, StreamSection};
+use crate::store::GlobalSeq;
+use crate::value::SchemaVersion;
+
+/// Chunk magic — `"nxch"` (h'6e786368').
+const MAGIC: &[u8] = b"nxch";
+/// The only format version this build emits and accepts.
+const FORMAT_VERSION: u32 = 1;
+
+/// A box-layer encode/decode failure.
+///
+/// Not [`ImportError`](crate::import::ImportError) — the box has no store error
+/// or id type. Two failure domains, two variants (CLAUDE rule 3).
+#[derive(Debug, Error)]
+pub enum ChunkError {
+    /// Decode: the chunk framing is unreadable. The `&'static str` is a debug
+    /// hint. Distinct from a per-block crc failure, which is a non-error
+    /// [`ImportBlock::Corrupt`](crate::import::ImportBlock::Corrupt).
+    #[error("malformed chunk: {0}")]
+    Malformed(&'static str),
+    /// Encode: minicbor serialization failed. Never fires in practice (the
+    /// `Vec` writer is `Infallible`, a `PersistedEnvelope` guarantees every
+    /// field cap) but minicbor's API is fallible, so the type is honest.
+    #[error("chunk encode failed: {0}")]
+    Encode(#[from] minicbor::encode::Error<Infallible>),
+}
+
+/// The decoded chunk header — what [`decode_header`] returns.
+#[derive(Debug, Clone)]
+pub struct ChunkHeader {
+    /// The chunk format version (always [`FORMAT_VERSION`] for a chunk this
+    /// build accepts).
+    pub format_version: u32,
+    /// The chunk-level producer/device id, if the encoder recorded one.
+    pub origin: Option<Bytes>,
+}
+```
+
+- [ ] **Step 4: Wire `lib.rs`.**
+
+After the `import` module gate (line ~92) add:
+
+```rust
+#[cfg(feature = "cbor")]
+pub mod cbor;
+```
+
+In the re-export block, after the `import` re-exports (line ~132) add:
+
+```rust
+#[cfg(feature = "cbor")]
+pub use cbor::{
+    decode_chunk, decode_header, encode_block, encode_header, encode_section_heading, ChunkError,
+    ChunkHeader,
+};
+```
+
+(The free functions don't exist yet — Step 5 adds temporary stubs so this compiles, or comment the function names out of the re-export until Task 2. Prefer stubs.)
+
+- [ ] **Step 5: Add temporary stubs so the crate compiles.**
+
+Append to `cbor.rs` (these are replaced in later tasks):
+
+```rust
+/// Stub — replaced in Task 2.
+pub fn encode_header(_origin: Option<&[u8]>) -> Result<Bytes, ChunkError> {
+    Ok(Bytes::new())
+}
+/// Stub — replaced in Task 2.
+pub fn decode_header(_bytes: &[u8]) -> Result<ChunkHeader, ChunkError> {
+    Err(ChunkError::Malformed("unimplemented"))
+}
+/// Stub — replaced in Task 3.
+pub fn encode_section_heading(_stream_id: &[u8]) -> Result<Bytes, ChunkError> {
+    Ok(Bytes::new())
+}
+/// Stub — replaced in Task 3.
+pub fn encode_block(_event: &PersistedEnvelope) -> Result<Bytes, ChunkError> {
+    Ok(Bytes::new())
+}
+/// Stub — replaced in Task 4.
+pub fn decode_chunk(_bytes: &[u8]) -> Result<Vec<StreamSection>, ChunkError> {
+    Ok(Vec::new())
+}
+```
+
+- [ ] **Step 6: Verify it compiles (and unused imports are tolerated for now).**
+
+Run: `nix develop -c cargo build -p nexus-store --features cbor,testing`
+Expected: builds. Warnings about unused imports/items are acceptable at this checkpoint (they're consumed in Tasks 2–4). If clippy `--deny warnings` complains, add a temporary `#[allow(unused_imports, dead_code)]` on the module and remove it in Task 4's final step.
+
+- [ ] **Step 7: Commit.**
+
+```bash
+cd /Users/joel/Code/devrandom/nexus
+nix develop -c cargo fmt --all
+git add crates/nexus-store/Cargo.toml crates/nexus-store/src/cbor.rs crates/nexus-store/src/lib.rs Cargo.toml crates/workspace-hack/
+git commit -m "$(cat <<'EOF'
+feat(store): scaffold cbor backup box feature + module skeleton
+
+Card 3 of export/import (#145): the default CBOR travel codec. Adds the
+`cbor` feature (implies export+import; never the reverse), pins minicbor +
+crc32c, and lands ChunkError/ChunkHeader plus stubbed public functions.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Wait for the pre-commit hook (`nix flake check`) to pass; confirm HEAD changed (`git log -1 --oneline`).
+
+---
+
+## Task 2: Header — `encode_header` + `decode_header` round-trip
+
+**Files:**
+- Modify: `crates/nexus-store/src/cbor.rs`
+
+- [ ] **Step 1: Write the failing tests.** Add to (or create) `#[cfg(test)] mod tests` at the bottom of `cbor.rs`:
+
+```rust
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    reason = "test code asserts exact values"
+)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn header_round_trips_without_origin() {
+        let bytes = encode_header(None).expect("encode");
+        let header = decode_header(&bytes).expect("decode");
+        assert_eq!(header.format_version, 1);
+        assert_eq!(header.origin, None);
+    }
+
+    #[test]
+    fn header_round_trips_with_origin() {
+        let bytes = encode_header(Some(b"phone-7")).expect("encode");
+        let header = decode_header(&bytes).expect("decode");
+        assert_eq!(header.format_version, 1);
+        assert_eq!(header.origin.as_deref(), Some(b"phone-7".as_slice()));
+    }
+
+    #[test]
+    fn header_rejects_bad_magic() {
+        // A valid CBOR map with a wrong magic value.
+        let mut wrong = encode_header(None).expect("encode");
+        // Flip a magic byte: locate 'n' (0x6e) of "nxch" and corrupt it.
+        let mut v = wrong.to_vec();
+        let pos = v.iter().position(|&b| b == b'n').expect("magic present");
+        v[pos] = b'X';
+        wrong = Bytes::from(v);
+        let err = decode_header(&wrong).expect_err("bad magic rejected");
+        assert!(matches!(err, ChunkError::Malformed("bad magic")));
+    }
+
+    #[test]
+    fn header_rejects_truncated() {
+        let bytes = encode_header(Some(b"x")).expect("encode");
+        let err = decode_header(&bytes[..bytes.len() / 2]).expect_err("truncated rejected");
+        assert!(matches!(err, ChunkError::Malformed(_)));
+    }
+}
+```
+
+- [ ] **Step 2: Run, verify failure.**
+
+Run: `nix develop -c cargo test -p nexus-store --features cbor,testing cbor::tests::header_ -- --nocapture`
+Expected: FAIL (stubs return empty / unimplemented).
+
+- [ ] **Step 3: Implement the header repr + functions.** Add near the top of `cbor.rs` (after `ChunkHeader`):
+
+```rust
+/// Wire shape of the header map `{0: magic, 1: format_version, 2: origin?}`.
+#[derive(minicbor::Encode, minicbor::Decode)]
+#[cbor(map)]
+struct HeaderRepr<'a> {
+    #[n(0)]
+    #[cbor(with = "minicbor::bytes")]
+    magic: &'a [u8],
+    #[n(1)]
+    format_version: u32,
+    #[n(2)]
+    #[cbor(with = "minicbor::bytes")]
+    origin: Option<&'a [u8]>,
+}
+
+fn validate_header(magic: &[u8], format_version: u32) -> Result<(), ChunkError> {
+    if magic != MAGIC {
+        return Err(ChunkError::Malformed("bad magic"));
+    }
+    if format_version != FORMAT_VERSION {
+        return Err(ChunkError::Malformed("unknown format version"));
+    }
+    Ok(())
+}
+```
+
+Replace the `encode_header` / `decode_header` stubs:
+
+```rust
+/// Encode the chunk header. Call once, at the start of a chunk. `origin` is an
+/// optional chunk-level producer/device id (omitted from the map when `None`).
+pub fn encode_header(origin: Option<&[u8]>) -> Result<Bytes, ChunkError> {
+    let repr = HeaderRepr {
+        magic: MAGIC,
+        format_version: FORMAT_VERSION,
+        origin,
+    };
+    Ok(Bytes::from(minicbor::to_vec(&repr)?))
+}
+
+/// Decode just the header — a cheap peek that validates magic + format version
+/// and returns the chunk-level origin without parsing the body.
+pub fn decode_header(bytes: &[u8]) -> Result<ChunkHeader, ChunkError> {
+    let repr: HeaderRepr =
+        minicbor::decode(bytes).map_err(|_| ChunkError::Malformed("unreadable header"))?;
+    validate_header(repr.magic, repr.format_version)?;
+    Ok(ChunkHeader {
+        format_version: repr.format_version,
+        origin: repr.origin.map(Bytes::copy_from_slice),
+    })
+}
+```
+
+**Verification note (minicbor `with` on `Option`):** if `#[cbor(with = "minicbor::bytes")]` on `origin: Option<&[u8]>` fails to compile, change the field to `Option<&'a minicbor::bytes::ByteSlice>` (drop the `with`), set `origin: origin.map(<&minicbor::bytes::ByteSlice>::from)` in `encode_header`, and read it back with `repr.origin.map(|b| Bytes::copy_from_slice(b.as_ref()))`.
+
+- [ ] **Step 4: Run, verify pass.**
+
+Run: `nix develop -c cargo test -p nexus-store --features cbor,testing cbor::tests::header_`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit.**
+
+```bash
+nix develop -c cargo fmt --all
+git add crates/nexus-store/src/cbor.rs
+git commit -m "$(cat <<'EOF'
+feat(store): cbor box header encode/decode + validation
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Wait for the hook; confirm HEAD changed.
+
+---
+
+## Task 3: Block body — `encode_block` + private `decode_block`/`reconstruct` round-trip
+
+**Files:**
+- Modify: `crates/nexus-store/src/cbor.rs`
+
+- [ ] **Step 1: Write the failing tests.** Add to `mod tests`:
+
+```rust
+    use crate::envelope::{pending_envelope, PersistedEnvelope};
+    use crate::store::GlobalSeq;
+    use crate::value::SchemaVersion;
+
+    /// Build a PersistedEnvelope directly (mirrors import.rs's test helper):
+    /// backing buffer = [event_type | metadata? | payload].
+    fn persisted(
+        version: u64,
+        schema: u32,
+        event_type: &str,
+        metadata: Option<&[u8]>,
+        payload: &[u8],
+    ) -> PersistedEnvelope {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(event_type.as_bytes());
+        let et_end = u32::try_from(buf.len()).expect("fits");
+        let meta_range = metadata.map(|m| {
+            let start = u32::try_from(buf.len()).expect("fits");
+            buf.extend_from_slice(m);
+            start..u32::try_from(buf.len()).expect("fits")
+        });
+        let pl_start = u32::try_from(buf.len()).expect("fits");
+        buf.extend_from_slice(payload);
+        let pl_end = u32::try_from(buf.len()).expect("fits");
+        PersistedEnvelope::try_new(
+            Version::new(version).expect("nonzero"),
+            GlobalSeq::new(version).expect("nonzero"),
+            Bytes::from(buf),
+            SchemaVersion::from_u32(schema).expect("nonzero"),
+            0..et_end,
+            pl_start..pl_end,
+            meta_range,
+        )
+        .expect("valid persisted")
+    }
+
+    /// Decode a single block from a freshly-encoded block buffer.
+    fn decode_one_block(bytes: &[u8]) -> ImportBlock {
+        let mut d = Decoder::new(bytes);
+        decode_block(&mut d)
+            .expect("not malformed")
+            .expect("not torn")
+    }
+
+    #[test]
+    fn block_round_trips_all_fields() {
+        let event = persisted(7, 3, "AccountOpened", Some(b"hlc=42"), b"balance:100");
+        let bytes = encode_block(&event).expect("encode");
+        match decode_one_block(&bytes) {
+            ImportBlock::Event(got) => {
+                assert_eq!(got.version().as_u64(), 7);
+                assert_eq!(got.schema_version(), 3);
+                assert_eq!(got.event_type(), "AccountOpened");
+                assert_eq!(got.metadata(), Some(b"hlc=42".as_slice()));
+                assert_eq!(got.payload(), b"balance:100");
+            }
+            ImportBlock::Corrupt => panic!("expected Event, got Corrupt"),
+        }
+    }
+
+    #[test]
+    fn block_round_trips_without_metadata_and_empty_payload() {
+        let event = persisted(1, 1, "E", None, b"");
+        let bytes = encode_block(&event).expect("encode");
+        match decode_one_block(&bytes) {
+            ImportBlock::Event(got) => {
+                assert_eq!(got.metadata(), None);
+                assert_eq!(got.payload(), b"");
+                assert_eq!(got.version().as_u64(), 1);
+            }
+            ImportBlock::Corrupt => panic!("expected Event"),
+        }
+    }
+
+    #[test]
+    fn block_with_flipped_body_byte_is_corrupt() {
+        let event = persisted(2, 1, "E", None, b"hello");
+        let bytes = encode_block(&event).expect("encode");
+        // Flip the last byte (inside the body bstr → crc mismatch).
+        let mut v = bytes.to_vec();
+        let last = v.len() - 1;
+        v[last] ^= 0xFF;
+        assert!(matches!(decode_one_block(&v), ImportBlock::Corrupt));
+    }
+```
+
+- [ ] **Step 2: Run, verify failure.**
+
+Run: `nix develop -c cargo test -p nexus-store --features cbor,testing cbor::tests::block_`
+Expected: FAIL (`decode_block` / real `encode_block` not defined).
+
+- [ ] **Step 3: Implement the body/block reprs, `encode_block`, `decode_block`, `reconstruct`.** Add to `cbor.rs`:
+
+```rust
+/// Wire shape of a block body map. `global_seq` is deliberately absent —
+/// store-local, restamped on import.
+#[derive(minicbor::Encode, minicbor::Decode)]
+#[cbor(map)]
+struct BodyRepr<'a> {
+    #[n(0)]
+    version: u64,
+    #[n(1)]
+    schema_version: u32,
+    #[n(2)]
+    event_type: &'a str,
+    #[n(3)]
+    #[cbor(with = "minicbor::bytes")]
+    metadata: Option<&'a [u8]>,
+    #[n(4)]
+    #[cbor(with = "minicbor::bytes")]
+    payload: &'a [u8],
+}
+
+/// Wire shape of a block array `[crc32c, body]`. Encode-only (decode is manual
+/// so the crc is checked before the body is trusted).
+#[derive(minicbor::Encode)]
+#[cbor(array)]
+struct BlockRepr<'a> {
+    #[n(0)]
+    crc: u32,
+    #[n(1)]
+    #[cbor(with = "minicbor::bytes")]
+    body: &'a [u8],
+}
+
+/// Encode one event as a block `[crc32c(body), body]`. The crc covers exactly
+/// the body bstr bytes.
+pub fn encode_block(event: &PersistedEnvelope) -> Result<Bytes, ChunkError> {
+    let body = BodyRepr {
+        version: event.version().as_u64(),
+        schema_version: event.schema_version(),
+        event_type: event.event_type(),
+        metadata: event.metadata(),
+        payload: event.payload(),
+    };
+    let body_bytes = minicbor::to_vec(&body)?;
+    let block = BlockRepr {
+        crc: crc32c::crc32c(&body_bytes),
+        body: &body_bytes,
+    };
+    Ok(Bytes::from(minicbor::to_vec(&block)?))
+}
+
+/// Decode one block from the decoder's current position.
+///
+/// `Ok(Some(block))` = decoded (Event or Corrupt). `Ok(None)` = torn tail
+/// (end-of-input mid-item → caller stops, valid prefix). `Err(hint)` = a
+/// structural violation the caller turns into [`ChunkError::Malformed`].
+fn decode_block(d: &mut Decoder<'_>) -> Result<Option<ImportBlock>, &'static str> {
+    match d.array() {
+        Ok(Some(2)) => {}
+        Ok(Some(_)) => return Err("block array must have exactly 2 elements"),
+        Ok(None) => return Err("indefinite-length block array"),
+        Err(e) if e.is_end_of_input() => return Ok(None),
+        Err(_) => return Err("malformed block array"),
+    }
+    let crc = match d.u32() {
+        Ok(c) => c,
+        Err(e) if e.is_end_of_input() => return Ok(None),
+        Err(_) => return Err("malformed block crc"),
+    };
+    let body: &[u8] = match d.bytes() {
+        Ok(b) => b,
+        Err(e) if e.is_end_of_input() => return Ok(None),
+        Err(_) => return Err("malformed block body bytes"),
+    };
+    if crc32c::crc32c(body) != crc {
+        // crc failed → header untrusted → Corrupt, do NOT decode the body.
+        return Ok(Some(ImportBlock::Corrupt));
+    }
+    // crc passed → body bytes are intact-as-written; any decode failure is a
+    // format violation, not bit-rot → Malformed (caller's job).
+    let parsed: BodyRepr =
+        minicbor::decode(body).map_err(|_| "crc-valid body failed to decode")?;
+    let envelope = reconstruct(&parsed).ok_or("crc-valid body has invalid fields")?;
+    Ok(Some(ImportBlock::Event(envelope)))
+}
+
+/// Rebuild a [`PersistedEnvelope`] from a decoded body. Returns `None` on any
+/// field-level violation (version 0, schema 0, oversize, range overflow); the
+/// caller maps that to `Malformed`. `global_seq` is a placeholder — import
+/// ignores it.
+fn reconstruct(body: &BodyRepr<'_>) -> Option<PersistedEnvelope> {
+    let version = Version::new(body.version)?;
+    let schema = SchemaVersion::from_u32(body.schema_version).ok()?;
+    let event_type = body.event_type.as_bytes();
+    let et_end = u32::try_from(event_type.len()).ok()?;
+    let mut buf =
+        Vec::with_capacity(event_type.len() + body.metadata.map_or(0, <[u8]>::len) + body.payload.len());
+    buf.extend_from_slice(event_type);
+    let et_range: Range<u32> = 0..et_end;
+    let meta_range = match body.metadata {
+        Some(m) => {
+            let start = u32::try_from(buf.len()).ok()?;
+            buf.extend_from_slice(m);
+            let end = u32::try_from(buf.len()).ok()?;
+            Some(start..end)
+        }
+        None => None,
+    };
+    let pl_start = u32::try_from(buf.len()).ok()?;
+    buf.extend_from_slice(body.payload);
+    let pl_end = u32::try_from(buf.len()).ok()?;
+    PersistedEnvelope::try_new(
+        version,
+        GlobalSeq::INITIAL,
+        Bytes::from(buf),
+        schema,
+        et_range,
+        pl_start..pl_end,
+        meta_range,
+    )
+    .ok()
+}
+```
+
+- [ ] **Step 4: Run, verify pass.**
+
+Run: `nix develop -c cargo test -p nexus-store --features cbor,testing cbor::tests::block_`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit.**
+
+```bash
+nix develop -c cargo fmt --all
+git add crates/nexus-store/src/cbor.rs
+git commit -m "$(cat <<'EOF'
+feat(store): cbor box block encode + crc-checked block decode
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Wait for the hook; confirm HEAD changed.
+
+---
+
+## Task 4: `encode_section_heading` + `decode_chunk` (the integrator)
+
+**Files:**
+- Modify: `crates/nexus-store/src/cbor.rs`
+
+- [ ] **Step 1: Write the failing test (Category 1 — sequence/protocol).** Add to `mod tests`:
+
+```rust
+    /// Encode a full multi-stream chunk: header + per-stream heading + blocks.
+    fn encode_chunk(origin: Option<&[u8]>, streams: &[(&[u8], Vec<PersistedEnvelope>)]) -> Bytes {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&encode_header(origin).expect("header"));
+        for (stream_id, events) in streams {
+            buf.extend_from_slice(&encode_section_heading(stream_id).expect("heading"));
+            for e in events {
+                buf.extend_from_slice(&encode_block(e).expect("block"));
+            }
+        }
+        Bytes::from(buf)
+    }
+
+    #[test]
+    fn decode_chunk_round_trips_multi_stream() {
+        let a = vec![
+            persisted(1, 1, "E", None, b"a1"),
+            persisted(2, 1, "E", Some(b"m"), b"a2"),
+        ];
+        let b = vec![persisted(1, 2, "E", None, b"b1")];
+        let chunk = encode_chunk(
+            Some(b"dev-1"),
+            &[(b"task-1".as_slice(), a), (b"task-2".as_slice(), b)],
+        );
+
+        let sections = decode_chunk(&chunk).expect("decode");
+        assert_eq!(sections.len(), 2);
+
+        assert_eq!(sections[0].origin.as_ref(), b"task-1");
+        assert_eq!(sections[0].blocks.len(), 2);
+        match (&sections[0].blocks[0], &sections[0].blocks[1]) {
+            (ImportBlock::Event(e1), ImportBlock::Event(e2)) => {
+                assert_eq!(e1.version().as_u64(), 1);
+                assert_eq!(e1.payload(), b"a1");
+                assert_eq!(e2.metadata(), Some(b"m".as_slice()));
+                assert_eq!(e2.payload(), b"a2");
+            }
+            _ => panic!("expected two Event blocks"),
+        }
+
+        assert_eq!(sections[1].origin.as_ref(), b"task-2");
+        match &sections[1].blocks[0] {
+            ImportBlock::Event(e) => {
+                assert_eq!(e.schema_version(), 2);
+                assert_eq!(e.payload(), b"b1");
+            }
+            ImportBlock::Corrupt => panic!("expected Event"),
+        }
+    }
+
+    #[test]
+    fn decode_header_only_chunk_is_empty_vec() {
+        let chunk = encode_header(None).expect("header");
+        let sections = decode_chunk(&chunk).expect("decode");
+        assert!(sections.is_empty());
+    }
+
+    #[test]
+    fn decode_block_before_heading_is_malformed() {
+        // header immediately followed by a block (no heading).
+        let mut chunk = encode_header(None).expect("header").to_vec();
+        let event = persisted(1, 1, "E", None, b"x");
+        chunk.extend_from_slice(&encode_block(&event).expect("block"));
+        let err = decode_chunk(&chunk).expect_err("block before heading");
+        assert!(matches!(err, ChunkError::Malformed("block before section heading")));
+    }
+
+    #[test]
+    fn decode_empty_section_then_stream() {
+        // A heading with no blocks, then a real stream.
+        let chunk = encode_chunk(
+            None,
+            &[
+                (b"empty".as_slice(), vec![]),
+                (b"real".as_slice(), vec![persisted(1, 1, "E", None, b"r")]),
+            ],
+        );
+        let sections = decode_chunk(&chunk).expect("decode");
+        assert_eq!(sections.len(), 2);
+        assert!(sections[0].blocks.is_empty());
+        assert_eq!(sections[0].origin.as_ref(), b"empty");
+        assert_eq!(sections[1].blocks.len(), 1);
+    }
+```
+
+- [ ] **Step 2: Run, verify failure.**
+
+Run: `nix develop -c cargo test -p nexus-store --features cbor,testing cbor::tests::decode_`
+Expected: FAIL (stub `decode_chunk` returns empty; `encode_section_heading` is a stub).
+
+- [ ] **Step 3: Implement `HeadingRepr`, `encode_section_heading`, `decode_chunk`.** Replace the stubs:
+
+```rust
+/// Wire shape of a section heading map `{0: stream_id}`.
+#[derive(minicbor::Encode, minicbor::Decode)]
+#[cbor(map)]
+struct HeadingRepr<'a> {
+    #[n(0)]
+    #[cbor(with = "minicbor::bytes")]
+    stream_id: &'a [u8],
+}
+
+/// Encode a per-stream section heading, recording the origin stream id once.
+/// Emit one before the blocks of each stream.
+pub fn encode_section_heading(stream_id: &[u8]) -> Result<Bytes, ChunkError> {
+    let repr = HeadingRepr { stream_id };
+    Ok(Bytes::from(minicbor::to_vec(&repr)?))
+}
+
+/// Decode a whole chunk into per-stream sections for
+/// [`EventImporter::import`](crate::import::EventImporter::import).
+///
+/// Walks the CBOR sequence: header first, then peek each item — a map starts a
+/// new section, an array is a block for the current section. A torn tail
+/// (end-of-input mid-item) stops cleanly and returns the valid prefix; any
+/// other structural problem is [`ChunkError::Malformed`]. A per-block crc
+/// mismatch is a non-fatal [`ImportBlock::Corrupt`], never an error.
+pub fn decode_chunk(bytes: &[u8]) -> Result<Vec<StreamSection>, ChunkError> {
+    let mut d = Decoder::new(bytes);
+    let header: HeaderRepr =
+        d.decode().map_err(|_| ChunkError::Malformed("unreadable header"))?;
+    validate_header(header.magic, header.format_version)?;
+
+    let mut sections: Vec<StreamSection> = Vec::new();
+    while d.position() < bytes.len() {
+        match d.datatype() {
+            Ok(Type::Map) => match d.decode::<HeadingRepr>() {
+                Ok(heading) => sections.push(StreamSection {
+                    origin: Bytes::copy_from_slice(heading.stream_id),
+                    blocks: Vec::new(),
+                }),
+                Err(e) if e.is_end_of_input() => break,
+                Err(_) => return Err(ChunkError::Malformed("malformed section heading")),
+            },
+            Ok(Type::Array) => match decode_block(&mut d) {
+                Ok(Some(block)) => match sections.last_mut() {
+                    Some(section) => section.blocks.push(block),
+                    None => return Err(ChunkError::Malformed("block before section heading")),
+                },
+                Ok(None) => break, // torn block tail → valid prefix
+                Err(hint) => return Err(ChunkError::Malformed(hint)),
+            },
+            Ok(_) => return Err(ChunkError::Malformed("unexpected item type")),
+            Err(e) if e.is_end_of_input() => break,
+            Err(_) => return Err(ChunkError::Malformed("decode error")),
+        }
+    }
+    Ok(sections)
+}
+```
+
+Remove any temporary `#[allow(unused_imports, dead_code)]` added in Task 1.
+
+- [ ] **Step 4: Run, verify pass.**
+
+Run: `nix develop -c cargo test -p nexus-store --features cbor,testing cbor::tests::decode_`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit.**
+
+```bash
+nix develop -c cargo fmt --all
+git add crates/nexus-store/src/cbor.rs
+git commit -m "$(cat <<'EOF'
+feat(store): cbor box section heading + decode_chunk sequence walk
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Wait for the hook; confirm HEAD changed.
+
+---
+
+## Task 5: Defensive boundary — Corrupt vs Malformed classification (Category 3)
+
+**Files:**
+- Modify: `crates/nexus-store/src/cbor.rs`
+
+- [ ] **Step 1: Write the failing tests.** Add to `mod tests`:
+
+```rust
+    #[test]
+    fn flipped_body_byte_in_chunk_decodes_to_corrupt_block() {
+        let chunk = encode_chunk(None, &[(b"s".as_slice(), vec![persisted(1, 1, "E", None, b"hello")])]);
+        let mut v = chunk.to_vec();
+        // Corrupt the very last byte (inside the only block's body).
+        let last = v.len() - 1;
+        v[last] ^= 0xFF;
+        let sections = decode_chunk(&v).expect("framing intact");
+        assert_eq!(sections.len(), 1);
+        assert!(matches!(sections[0].blocks[0], ImportBlock::Corrupt));
+    }
+
+    #[test]
+    fn bad_magic_chunk_is_malformed() {
+        let mut v = encode_chunk(None, &[(b"s".as_slice(), vec![persisted(1, 1, "E", None, b"x")])]).to_vec();
+        let pos = v.iter().position(|&b| b == b'n').expect("magic");
+        v[pos] = b'Z';
+        assert!(matches!(decode_chunk(&v), Err(ChunkError::Malformed("bad magic"))));
+    }
+
+    #[test]
+    fn unknown_format_version_is_malformed() {
+        // Hand-build a header map with format_version = 2.
+        let repr = HeaderRepr { magic: MAGIC, format_version: 2, origin: None };
+        let bytes = minicbor::to_vec(&repr).expect("encode");
+        assert!(matches!(
+            decode_chunk(&bytes),
+            Err(ChunkError::Malformed("unknown format version"))
+        ));
+    }
+
+    #[test]
+    fn unexpected_top_level_item_is_malformed() {
+        // header followed by a bare uint (neither map nor array).
+        let mut v = encode_header(None).expect("header").to_vec();
+        v.push(0x01); // CBOR uint 1
+        assert!(matches!(
+            decode_chunk(&v),
+            Err(ChunkError::Malformed("unexpected item type"))
+        ));
+    }
+
+    #[test]
+    fn crc_valid_but_body_invalid_is_malformed() {
+        // Craft a block whose body decodes to version 0 (illegal), with a
+        // MATCHING crc, proving crc-pass-body-fail => Malformed (not Corrupt).
+        let mut body = Vec::new();
+        {
+            // body map {0: 0u64, 1: 1u32, 2: "E", 4: ""} — version 0 is illegal.
+            let mut e = minicbor::Encoder::new(&mut body);
+            e.map(4).expect("map")
+                .u32(0).expect("k0").u64(0).expect("v0")
+                .u32(1).expect("k1").u32(1).expect("v1")
+                .u32(2).expect("k2").str("E").expect("v2")
+                .u32(4).expect("k4").bytes(b"").expect("v4");
+        }
+        let block = BlockRepr { crc: crc32c::crc32c(&body), body: &body };
+        let mut chunk = encode_header(None).expect("header").to_vec();
+        chunk.extend_from_slice(&encode_section_heading(b"s").expect("heading"));
+        chunk.extend_from_slice(&minicbor::to_vec(&block).expect("block"));
+        assert!(matches!(decode_chunk(&chunk), Err(ChunkError::Malformed(_))));
+    }
+```
+
+- [ ] **Step 2: Run.**
+
+Run: `nix develop -c cargo test -p nexus-store --features cbor,testing cbor::tests`
+Expected: these new tests PASS already if Tasks 2–4 are correct (this task is verification-by-test of the trust model). If `crc_valid_but_body_invalid_is_malformed` fails, the `reconstruct` version check is wrong — fix it.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+nix develop -c cargo fmt --all
+git add crates/nexus-store/src/cbor.rs
+git commit -m "$(cat <<'EOF'
+test(store): cbor box defensive boundary — corrupt vs malformed
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Wait for the hook; confirm HEAD changed.
+
+---
+
+## Task 6: Lifecycle — incremental append / truncation / valid prefix (Category 2)
+
+**Files:**
+- Modify: `crates/nexus-store/src/cbor.rs`
+
+- [ ] **Step 1: Write the tests.** Add to `mod tests`:
+
+```rust
+    /// The cumulative byte length after the header + heading + first N blocks.
+    fn prefix_len_after_n_blocks(stream_id: &[u8], events: &[PersistedEnvelope], n: usize) -> usize {
+        let mut len = encode_header(None).expect("header").len();
+        len += encode_section_heading(stream_id).expect("heading").len();
+        for e in events.iter().take(n) {
+            len += encode_block(e).expect("block").len();
+        }
+        len
+    }
+
+    #[test]
+    fn every_block_boundary_prefix_is_valid() {
+        let events: Vec<_> = (1..=4).map(|v| persisted(v, 1, "E", None, b"p")).collect();
+        let chunk = encode_chunk(None, &[(b"s".as_slice(), events.clone())]);
+        for n in 0..=events.len() {
+            let cut = prefix_len_after_n_blocks(b"s", &events, n);
+            let sections = decode_chunk(&chunk[..cut]).expect("prefix valid");
+            let got = sections.first().map_or(0, |s| s.blocks.len());
+            assert_eq!(got, n, "prefix after {n} blocks must decode to {n} blocks");
+        }
+    }
+
+    #[test]
+    fn torn_final_block_is_dropped_earlier_survive() {
+        let events: Vec<_> = (1..=3).map(|v| persisted(v, 1, "E", None, b"payload")).collect();
+        let chunk = encode_chunk(None, &[(b"s".as_slice(), events.clone())]);
+        // Cut one byte short of the end → the last block is torn.
+        let sections = decode_chunk(&chunk[..chunk.len() - 1]).expect("valid prefix");
+        assert_eq!(sections[0].blocks.len(), 2, "torn 3rd block dropped");
+        assert!(matches!(sections[0].blocks[0], ImportBlock::Event(_)));
+    }
+
+    #[test]
+    fn empty_input_is_malformed_header() {
+        assert!(matches!(decode_chunk(&[]), Err(ChunkError::Malformed(_))));
+    }
+```
+
+- [ ] **Step 2: Run, verify pass.**
+
+Run: `nix develop -c cargo test -p nexus-store --features cbor,testing cbor::tests`
+Expected: PASS. If `every_block_boundary_prefix_is_valid` fails at `n=0` (header only) the clean-end check is wrong; if it fails mid-way the torn detection in `decode_block` is wrong.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+nix develop -c cargo fmt --all
+git add crates/nexus-store/src/cbor.rs
+git commit -m "$(cat <<'EOF'
+test(store): cbor box lifecycle — valid-at-every-prefix + torn tail
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Wait for the hook; confirm HEAD changed.
+
+---
+
+## Task 7: Full pipeline — export → box → import (Category 1, end-to-end)
+
+**Files:**
+- Modify: `crates/nexus-store/src/cbor.rs`
+
+- [ ] **Step 1: Write the test.** Add to `mod tests`:
+
+```rust
+    use crate::import::{Atomicity, EventImporter};
+    use crate::store::RawEventStore;
+    use crate::testing::InMemoryStore;
+    use futures::StreamExt;
+
+    #[derive(Debug, Clone, Hash, PartialEq, Eq)]
+    struct Tid(String);
+    impl core::fmt::Display for Tid {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            f.write_str(&self.0)
+        }
+    }
+    impl AsRef<[u8]> for Tid {
+        fn as_ref(&self) -> &[u8] {
+            self.0.as_bytes()
+        }
+    }
+    impl nexus::Id for Tid {
+        const BYTE_LEN: usize = 0;
+    }
+
+    #[tokio::test]
+    async fn export_box_import_round_trip_byte_equal_modulo_global_seq() {
+        use crate::envelope::pending_envelope;
+        // Seed a source store with two streams.
+        let src = InMemoryStore::new();
+        for (sid, count) in [("task-1", 3u64), ("task-2", 2)] {
+            for v in 1..=count {
+                let pe = pending_envelope(Version::new(v).expect("nz"))
+                    .event_type("E")
+                    .payload(format!("{sid}-{v}").into_bytes())
+                    .expect("payload")
+                    .build();
+                src.append(&Tid(sid.into()), Version::new(v - 1), &[pe])
+                    .await
+                    .expect("append");
+            }
+        }
+
+        // Export → box-encode into one chunk.
+        let mut chunk = encode_header(Some(b"src")).expect("header").to_vec();
+        for sid in ["task-1", "task-2"] {
+            chunk.extend_from_slice(&encode_section_heading(sid.as_bytes()).expect("heading"));
+            let mut s = src.read_stream(&Tid(sid.into()), Version::INITIAL).await.expect("read");
+            while let Some(item) = s.next().await {
+                let e = item.expect("no read error");
+                chunk.extend_from_slice(&encode_block(&e).expect("block"));
+            }
+        }
+
+        // Box-decode → import into a fresh store under origin-namespaced ids.
+        let sections = decode_chunk(&chunk).expect("decode");
+        let dst = InMemoryStore::new();
+        let route = |origin: &[u8]| Tid(format!("src:{}", String::from_utf8_lossy(origin)));
+        let report = dst.import(&sections, route, Atomicity::PerStream).await.expect("import");
+        assert!(report.all_complete());
+
+        // Verify byte-equality of payloads/versions modulo global_seq.
+        for sid in ["task-1", "task-2"] {
+            let target = Tid(format!("src:{sid}"));
+            let got: Vec<(u64, Vec<u8>)> = dst
+                .read_stream(&target, Version::INITIAL)
+                .await
+                .expect("read")
+                .map(|r| {
+                    let e = r.expect("no err");
+                    (e.version().as_u64(), e.payload().to_vec())
+                })
+                .collect()
+                .await;
+            let expected: Vec<(u64, Vec<u8>)> = (1..=if sid == "task-1" { 3 } else { 2 })
+                .map(|v| (v, format!("{sid}-{v}").into_bytes()))
+                .collect();
+            assert_eq!(got, expected, "stream {sid} round-trips");
+        }
+    }
+```
+
+- [ ] **Step 2: Run, verify pass.**
+
+Run: `nix develop -c cargo test -p nexus-store --features cbor,testing cbor::tests::export_box_import_round_trip`
+Expected: PASS.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+nix develop -c cargo fmt --all
+git add crates/nexus-store/src/cbor.rs
+git commit -m "$(cat <<'EOF'
+test(store): cbor box full pipeline export -> box -> import round-trip
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Wait for the hook; confirm HEAD changed.
+
+---
+
+## Task 8: insta golden bytes (format drift guard)
+
+**Files:**
+- Modify: `crates/nexus-store/src/cbor.rs`
+
+- [ ] **Step 1: Write the snapshot tests.** Add to `mod tests`:
+
+```rust
+    #[test]
+    fn golden_header_bytes() {
+        let bytes = encode_header(Some(b"dev")).expect("header");
+        insta::assert_snapshot!("header_with_origin_hex", hex_of(&bytes));
+    }
+
+    #[test]
+    fn golden_block_bytes() {
+        let event = persisted(1, 1, "E", None, b"hi");
+        let bytes = encode_block(&event).expect("block");
+        insta::assert_snapshot!("block_v1_hex", hex_of(&bytes));
+    }
+
+    fn hex_of(bytes: &[u8]) -> String {
+        bytes.iter().map(|b| format!("{b:02x}")).collect::<Vec<_>>().join(" ")
+    }
+```
+
+- [ ] **Step 2: Generate and review the snapshots.**
+
+Run: `nix develop -c cargo test -p nexus-store --features cbor,testing cbor::tests::golden_`
+Expected: FAIL (snapshots not yet accepted). Inspect the pending `.snap.new` files under `crates/nexus-store/src/snapshots/` and **manually verify the hex against the spec**: header must start `a3` (3-entry map) then `00 44 6e786368` (key 0, bstr len 4, "nxch"), `01 01` (key 1 = 1), `02 43 646576` (key 2, bstr len 3, "dev"). Block must be `82` (array 2) then `1a XXXXXXXX` (uint crc) then `58 LL ..body..`. Then accept:
+
+```bash
+nix develop -c cargo insta accept
+```
+
+If `cargo insta` is not on PATH, accept by renaming each `*.snap.new` → `*.snap` after manual verification.
+
+- [ ] **Step 3: Re-run, verify pass.**
+
+Run: `nix develop -c cargo test -p nexus-store --features cbor,testing cbor::tests::golden_`
+Expected: PASS.
+
+- [ ] **Step 4: Commit (include the snapshot files).**
+
+```bash
+nix develop -c cargo fmt --all
+git add crates/nexus-store/src/cbor.rs crates/nexus-store/src/snapshots/
+git commit -m "$(cat <<'EOF'
+test(store): cbor box insta golden bytes for header + block
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Wait for the hook; confirm HEAD changed.
+
+---
+
+## Task 9: VOPR round-trip + crc-mutation property tests (proptest)
+
+**Files:**
+- Modify: `crates/nexus-store/src/cbor.rs`
+
+- [ ] **Step 1: Write the property tests.** Add to `mod tests`:
+
+```rust
+    use proptest::prelude::*;
+
+    /// (version, schema, event_type, metadata?, payload) — boundary-inclusive.
+    fn event_strategy() -> impl Strategy<Value = (u64, u32, String, Option<Vec<u8>>, Vec<u8>)> {
+        (
+            prop_oneof![Just(1u64), Just(2), Just(u64::MAX - 1), Just(u64::MAX), 1u64..1000],
+            prop_oneof![Just(1u32), Just(7), Just(u32::MAX), 1u32..100],
+            prop_oneof![Just(String::new()), Just("E".to_owned()), "[A-Za-z]{0,40}"],
+            prop_oneof![Just(None), proptest::collection::vec(any::<u8>(), 1..32).prop_map(Some)],
+            proptest::collection::vec(any::<u8>(), 0..64),
+        )
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(128))]
+
+        #[test]
+        fn vopr_chunk_round_trips(
+            origin in prop_oneof![Just(None), proptest::collection::vec(any::<u8>(), 1..16).prop_map(Some)],
+            streams in proptest::collection::vec(
+                (proptest::collection::vec(any::<u8>(), 0..12),
+                 proptest::collection::vec(event_strategy(), 0..5)),
+                0..4,
+            ),
+        ) {
+            // Build sequential versions per stream (import requires contiguity);
+            // but VOPR here checks the BOX (encode/decode), not import — so use
+            // each tuple's version verbatim and assert decode mirrors encode.
+            let built: Vec<(Vec<u8>, Vec<PersistedEnvelope>)> = streams
+                .iter()
+                .map(|(sid, evs)| {
+                    let events = evs.iter().map(|(v, sc, et, md, pl)| {
+                        persisted(*v, *sc, et, md.as_deref(), pl)
+                    }).collect();
+                    (sid.clone(), events)
+                })
+                .collect();
+
+            let refs: Vec<(&[u8], Vec<PersistedEnvelope>)> =
+                built.iter().map(|(s, e)| (s.as_slice(), e.clone())).collect();
+            let chunk = encode_chunk(origin.as_deref(), &refs);
+            let sections = decode_chunk(&chunk).expect("decode");
+
+            prop_assert_eq!(sections.len(), built.len());
+            for (section, (sid, events)) in sections.iter().zip(built.iter()) {
+                prop_assert_eq!(section.origin.as_ref(), sid.as_slice());
+                prop_assert_eq!(section.blocks.len(), events.len());
+                for (block, original) in section.blocks.iter().zip(events.iter()) {
+                    match block {
+                        ImportBlock::Event(got) => {
+                            prop_assert_eq!(got.version(), original.version());
+                            prop_assert_eq!(got.schema_version(), original.schema_version());
+                            prop_assert_eq!(got.event_type(), original.event_type());
+                            prop_assert_eq!(got.metadata(), original.metadata());
+                            prop_assert_eq!(got.payload(), original.payload());
+                        }
+                        ImportBlock::Corrupt => prop_assert!(false, "unexpected corrupt"),
+                    }
+                }
+            }
+        }
+
+        #[test]
+        fn vopr_single_byte_body_mutation_is_corrupt_never_silently_wrong(
+            (v, sc, et, md, pl) in event_strategy(),
+            flip_pick in any::<prop::sample::Index>(),
+        ) {
+            let event = persisted(v, sc, &et, md.as_deref(), &pl);
+            let block = encode_block(&event).expect("block");
+            // Locate the body bstr span and flip one byte inside it.
+            let mut v = block.to_vec();
+            // The body is the trailing bstr; flipping any byte from the array's
+            // 2nd element onward lands in crc or body — both detectable. Pick a
+            // byte in the back half (overwhelmingly body) to assert Corrupt.
+            let start = v.len() / 2;
+            let idx = start + flip_pick.index(v.len() - start);
+            v[idx] ^= 0xFF;
+            let mut d = Decoder::new(&v);
+            match decode_block(&mut d) {
+                Ok(Some(ImportBlock::Event(got))) => {
+                    // If it still decodes as Event, it MUST be byte-identical to
+                    // the original (the flip hit padding/length that re-decodes
+                    // the same) — never silently different content.
+                    prop_assert_eq!(got.payload(), event.payload());
+                    prop_assert_eq!(got.event_type(), event.event_type());
+                }
+                Ok(Some(ImportBlock::Corrupt)) | Ok(None) | Err(_) => {} // all acceptable
+            }
+        }
+    }
+```
+
+- [ ] **Step 2: Run, verify pass.**
+
+Run: `nix develop -c cargo test -p nexus-store --features cbor,testing cbor::tests::vopr_`
+Expected: PASS. If `vopr_chunk_round_trips` finds a shrinking counterexample, the round-trip is broken for that boundary (e.g. empty event_type, `u64::MAX` version) — fix `encode_block`/`reconstruct`, do not weaken the strategy.
+
+- [ ] **Step 3: Commit (include any proptest regression seed).**
+
+```bash
+nix develop -c cargo fmt --all
+git add crates/nexus-store/src/cbor.rs crates/nexus-store/src/cbor.proptest-regressions 2>/dev/null
+git add crates/nexus-store/
+git commit -m "$(cat <<'EOF'
+test(store): cbor box VOPR round-trip + crc single-byte-mutation property
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Wait for the hook; confirm HEAD changed.
+
+---
+
+## Task 10: Defensive fuzz (never-panic) + forward-compat unknown key
+
+**Files:**
+- Modify: `crates/nexus-store/src/cbor.rs`
+
+- [ ] **Step 1: Write the tests.** Add to `mod tests`:
+
+```rust
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(512))]
+
+        #[test]
+        fn decode_chunk_never_panics_on_arbitrary_bytes(bytes in proptest::collection::vec(any::<u8>(), 0..256)) {
+            // Untrusted input: must return Ok(valid prefix) or Err(Malformed),
+            // never panic.
+            let _ = decode_chunk(&bytes);
+        }
+
+        #[test]
+        fn decode_chunk_never_panics_on_valid_header_plus_garbage(
+            garbage in proptest::collection::vec(any::<u8>(), 0..128),
+        ) {
+            let mut v = encode_header(None).expect("header").to_vec();
+            v.extend_from_slice(&garbage);
+            let _ = decode_chunk(&v);
+        }
+    }
+
+    #[test]
+    fn body_with_unknown_extra_key_still_decodes_to_event() {
+        // Forward-compat: a future encoder adds key 5 without bumping the
+        // format version; this decoder must skip it.
+        let mut body = Vec::new();
+        {
+            let mut e = minicbor::Encoder::new(&mut body);
+            e.map(5).expect("map")
+                .u32(0).expect("k0").u64(3).expect("v0")
+                .u32(1).expect("k1").u32(1).expect("v1")
+                .u32(2).expect("k2").str("E").expect("v2")
+                .u32(4).expect("k4").bytes(b"data").expect("v4")
+                .u32(5).expect("k5").u32(999).expect("v5"); // unknown key
+        }
+        let block = BlockRepr { crc: crc32c::crc32c(&body), body: &body };
+        let mut chunk = encode_header(None).expect("header").to_vec();
+        chunk.extend_from_slice(&encode_section_heading(b"s").expect("heading"));
+        chunk.extend_from_slice(&minicbor::to_vec(&block).expect("block"));
+        let sections = decode_chunk(&chunk).expect("decode");
+        match &sections[0].blocks[0] {
+            ImportBlock::Event(e) => {
+                assert_eq!(e.version().as_u64(), 3);
+                assert_eq!(e.payload(), b"data");
+            }
+            ImportBlock::Corrupt => panic!("unknown key must be skipped, not corrupt"),
+        }
+    }
+```
+
+- [ ] **Step 2: Run, verify pass.**
+
+Run: `nix develop -c cargo test -p nexus-store --features cbor,testing cbor::tests`
+Expected: PASS. If `body_with_unknown_extra_key_still_decodes_to_event` fails, minicbor's derived `Decode` is not skipping unknown keys — confirm the `#[cbor(map)]` derive (not `#[cbor(array)]`) is on `BodyRepr`.
+
+- [ ] **Step 3: Run the full crate test + clippy gate locally.**
+
+```bash
+nix develop -c cargo nextest run -p nexus-store --features cbor,testing
+nix develop -c cargo clippy -p nexus-store --features cbor,testing --all-targets
+```
+
+Expected: all green, zero clippy warnings. Fix any lint in non-test code (test modules carry the scoped `#[allow]`).
+
+- [ ] **Step 4: Commit.**
+
+```bash
+nix develop -c cargo fmt --all
+git add crates/nexus-store/
+git commit -m "$(cat <<'EOF'
+test(store): cbor box defensive fuzz (never-panic) + forward-compat key skip
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Wait for the hook; confirm HEAD changed.
+
+---
+
+## Task 11: Open the PR
+
+- [ ] **Step 1: Push and open the PR (stacked on Cards 0–2).**
+
+```bash
+git push -u origin feat/export-import-cbor-box
+gh pr create --base feat/export-import-traits \
+  --title "feat(store): default CBOR backup box (export/import Card 3, #145)" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Card 3 of export/import (#145): the default CBOR backup box — the bytes↔sections
+travel codec between Card 1's raw export and Card 2's `EventImporter`. Stacked on
+#218 (Cards 0–2); base will retarget to `main` once #218 merges.
+
+- New `cbor` feature: `cbor = ["import", "export", "dep:minicbor", "dep:crc32c"]`
+  (implies export+import; never the reverse — Agency brings its own CESR box).
+- CBOR sequence (RFC 8742): header map → per-stream section heading map → block
+  arrays `[crc32c, body]`. `stream_id` recorded once per section; `global_seq`
+  never written (restamped on import).
+- Encode = 3 stateless free functions returning appendable `Bytes`
+  (`encode_header`/`encode_section_heading`/`encode_block`).
+- Decode = `decode_chunk` (→ `Vec<StreamSection>`) + `decode_header` peek.
+  Trust model: crc mismatch ⇒ `ImportBlock::Corrupt` (localized); truncation ⇒
+  valid-prefix stop; any other structural violation ⇒ `ChunkError::Malformed`.
+
+Design + plan: `docs/plans/2026-06-21-export-import-cbor-box-{design,plan}.md`.
+
+## Tests
+
+4 cross-cutting categories first (sequence/protocol, lifecycle/incremental,
+defensive boundary, isolation), then insta golden bytes, a VOPR round-trip
+proptest, a crc single-byte-mutation proptest, and never-panic fuzz +
+forward-compat unknown-key skip.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 2: Confirm the PR is open and CI is running.**
+
+```bash
+gh pr view --json number,baseRefName,state
+```
+
+---
+
+## Self-review against the spec
+
+- **CBOR layout (header map / heading map / block array; body keys 0–4; no `stream_id`; no `global_seq`):** Tasks 2 (`HeaderRepr`), 4 (`HeadingRepr`), 3 (`BodyRepr` keys 0–4, `BlockRepr` array). Golden bytes in Task 8 pin them.
+- **Decode trust table (Corrupt only from crc mismatch; truncation ⇒ valid prefix; else Malformed):** `decode_block` + `decode_chunk` in Tasks 3–4; verified in Tasks 5 (Malformed/Corrupt), 6 (truncation), 10 (never-panic).
+- **`encode_block` infallible → resolved to `Result`:** Task 3, error via `ChunkError::Encode(#[from] ...)` from Task 1.
+- **API trio + `decode_chunk`/`decode_header`/`ChunkHeader`/`ChunkError`:** Tasks 1–4; re-exported in Task 1 Step 4.
+- **`PersistedEnvelope` reconstruction via `try_new`, `global_seq = GlobalSeq::INITIAL`:** `reconstruct` in Task 3.
+- **Feature wiring + self dev-dep + `cargo add`:** Task 1.
+- **Forward-compat unknown-key skip:** Task 10.
+- **Full pipeline export→box→import:** Task 7.
+
+No placeholders; every code step shows full code; types/signatures are consistent across tasks (`ChunkError`, `ChunkHeader`, `HeaderRepr`/`HeadingRepr`/`BodyRepr`/`BlockRepr`, `decode_block`/`reconstruct`).


### PR DESCRIPTION
## Summary

Card 3 of export/import (#145): the default **CBOR backup box** — the bytes↔sections travel codec between Card 1's raw export and Card 2's `EventImporter`. Stacked on #218 (Cards 0–2); retarget the base to `main` once #218 merges. This is the last nexus-side card for #145 (the sync runtime is Agency's, agency#147).

- New `cbor` feature: `cbor = ["import", "export", "dep:minicbor", "dep:crc32c"]` — implies export+import; the reverse never holds (Agency enables export/import and brings its own CESR box, pulling no CBOR).
- **Layout** (re-spec of §6 for per-stream sections): a CBOR sequence (RFC 8742) — header map → per-stream section heading map `{0: stream_id}` → block arrays `[crc32c, body]`. The origin stream id is recorded **once per section**, never per block; `global_seq` is never written (import restamps it).
- **Encode** = 3 stateless free functions returning appendable `Bytes` (`encode_header` / `encode_section_heading` / `encode_block`) — the caller appends to a chunk file incrementally over any timespan, bounded memory.
- **Decode** = `decode_chunk` (→ `Vec<StreamSection>`) + a cheap `decode_header` peek. Trust model: a per-block **crc mismatch ⇒ `ImportBlock::Corrupt`** (localized, body never decoded); **truncation ⇒ valid-prefix stop**; any other structural violation ⇒ **`ChunkError::Malformed`**.

Design + plan: `docs/plans/2026-06-21-export-import-cbor-box-{design,plan}.md`.

## Test Plan

- [x] 4 cross-cutting categories first: sequence/protocol (multi-stream round-trip), lifecycle (valid-at-every-block-prefix + torn-tail drop), defensive boundary (Corrupt vs Malformed classification), isolation (full export→box→import round-trip, byte-equal modulo `global_seq`).
- [x] insta golden bytes for header + block (format-drift guard).
- [x] VOPR round-trip proptest (boundary-inclusive: version/schema 1·MAX, empty/max event_type, None/Some metadata, empty/large payload) + crc single-byte-mutation property.
- [x] Never-panic fuzz on arbitrary bytes + forward-compat unknown-key skip.
- [x] `nix flake check` green on every commit; 423 crate tests pass; strict clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)