### PR TITLE
build: pin stable toolchain via rust-toolchain.toml, declare MSRV

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -243,6 +243,7 @@ Every test must satisfy ALL of these:
 ## Key Conventions
 
 - **Rust edition 2024** with `rustfmt` edition 2024
+- **Toolchain & MSRV**: pinned to an exact **stable** release in `rust-toolchain.toml` (`channel`), which is the single source of truth for both `rustup` users and the Nix flake (consumed via fenix `fromToolchainFile`). **No nightly** — the crates carry no `#![feature(...)]` gates and the whole workspace (build, test, clippy, fmt, coverage, examples) runs on the pinned stable. MSRV policy: `rust-version` in `[workspace.package]` **equals** the pinned toolchain; when bumping Rust, bump `rust-toolchain.toml` *and* `rust-version` together (the pin tracks the latest stable we actually build/test against — no separate lower floor is claimed unless a CI job verifies it). All publishable crates opt in via `rust-version.workspace = true`.
 - **Strict clippy**: `all`, `pedantic`, `nursery` denied; `unwrap_used`, `expect_used`, `panic`, `todo`, `as_conversions`, `shadow_*`, `allow_attributes_without_reason` all denied
 - **Workspace dependencies**: all dependency versions declared in root `Cargo.toml` `[workspace.dependencies]`; crate-level Cargo.toml files use `workspace = true`
 - **workspace-hack crate**: managed by `cargo-hakari` for build optimization; run `cargo hakari generate` after dependency changes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,9 @@ tokio-stream = "0.1"
 [workspace.package]
 version = "0.1.0"
 edition = "2024"
+# MSRV == the pinned toolchain (rust-toolchain.toml). Policy: pin tracks the
+# latest stable we build/test against; bump both together. See issue #204.
+rust-version = "1.95.0"
 license = "MIT OR Apache-2.0"
 authors = ["Joel DSouza <joel@devrandom.co>"]
 repository = "https://github.com/devrandom-labs/nexus"

--- a/crates/nexus-fjall/Cargo.toml
+++ b/crates/nexus-fjall/Cargo.toml
@@ -2,6 +2,7 @@
 name = "nexus-fjall"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/nexus-macros/Cargo.toml
+++ b/crates/nexus-macros/Cargo.toml
@@ -2,6 +2,7 @@
 name = "nexus-macros"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/nexus-store-testing/Cargo.toml
+++ b/crates/nexus-store-testing/Cargo.toml
@@ -2,6 +2,7 @@
 name = "nexus-store-testing"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/nexus-store/Cargo.toml
+++ b/crates/nexus-store/Cargo.toml
@@ -2,6 +2,7 @@
 name = "nexus-store"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/nexus/Cargo.toml
+++ b/crates/nexus/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
+rust-version.workspace = true
 repository.workspace = true
 description = "A zero-compromise event-sourcing and CQRS kernel for Rust with maximum compile-time type safety"
 readme = "README.md"

--- a/flake.nix
+++ b/flake.nix
@@ -19,8 +19,16 @@
         pkgs = nixpkgs.legacyPackages.${system};
         inherit (pkgs) lib;
         isLinux = pkgs.stdenv.isLinux;
-        craneLib = (crane.mkLib pkgs).overrideToolchain
-          (fenix.packages.${system}.complete.toolchain);
+        # Pinned stable toolchain, read from rust-toolchain.toml so rustup
+        # users and the flake share one source of truth. No nightly — the
+        # crates are stable-clean (issue #204). The sha256 hashes the global
+        # channel manifest (platform-independent), so one value covers every
+        # system; per-component binaries are fetched per-platform from it.
+        rustToolchain = fenix.packages.${system}.fromToolchainFile {
+          file = ./rust-toolchain.toml;
+          sha256 = "sha256-gh/xTkxKHL4eiRXzWv8KP7vfjSk61Iq48x47BEDFgfk=";
+        };
+        craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
 
         unfilteredSrc = ./.;
 
@@ -132,7 +140,6 @@
             tree
             cloc
             cargo-edit
-            cargo-expand
             gh
           ];
         };

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,9 @@
+# Pinned stable toolchain — the single source of truth for both rustup users
+# and the Nix flake (consumed via fenix `fromToolchainFile`). Bump this in
+# lockstep with `rust-version` in the root Cargo.toml [workspace.package].
+#
+# Stable only: the crates carry no `#![feature(...)]` gates and the workspace
+# builds + tests on stable (verified for 1.0 freeze gate, issue #204).
+[toolchain]
+channel = "1.95.0"
+components = ["cargo", "rustc", "rust-std", "rustfmt", "clippy", "llvm-tools-preview"]


### PR DESCRIPTION
Closes #204 — Tier-0 freeze gate (prove stable-Rust build, pin toolchain, declare MSRV).

## Why
A 1.0 that only builds on an unpinned nightly is not shippable: downstream stable users can't compile it, and an unpinned nightly makes CI non-reproducible (the source of past ICEs). The crates carry **no** `#![feature(...)]` gates, so they were already stable-compatible — this PR proves it and locks it in.

## What
- **`rust-toolchain.toml`** — pins `channel = "1.95.0"` plus the gate components (`clippy`, `rustfmt`, `llvm-tools-preview`). Single source of truth honored by both `rustup` users and the Nix flake.
- **`flake.nix`** — consumes the toml via fenix `fromToolchainFile` (one platform-independent channel-manifest hash, so all systems resolve the same pin) instead of the nightly `complete.toolchain`. Drops `cargo-expand` from the dev shell (the only nightly-dependent tool).
- **`Cargo.toml`** — `rust-version = "1.95.0"` in `[workspace.package]`; all five publishable crates opt in via `rust-version.workspace = true`. **MSRV == pin.**
- **`CLAUDE.md`** — documents the toolchain/MSRV policy under *Key Conventions*.

## Verification
- `cargo build --workspace --all-features` on stable 1.95.0 → exit 0 (all crates + examples).
- `nix flake check` on the new toolchain → **all 8 checks green** (clippy, fmt, taplo, doc, nextest tests **+ examples**, audit, deny, hakari). The nightly→stable clippy swap surfaced **zero** new lints.
- Coverage (`withLlvmCov`) runs on stable, so the issue's "keep nightly for coverage if needed" hedge is moot — the toolchain is now **fully nightly-free**.

Local verification was aarch64-darwin only; CI confirms x86_64-linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)