### PR TITLE
feat(store): adopt ErrorId in StoreError, re-export bytes/futures_core, seal ProjectedIntents::IntoIter (#208, PR 2/4)

### DIFF
--- a/crates/nexus-store/src/error.rs
+++ b/crates/nexus-store/src/error.rs
@@ -1,5 +1,5 @@
 use arrayvec::ArrayString;
-use nexus::{KernelError, Version};
+use nexus::{ErrorId, KernelError, Version};
 use thiserror::Error;
 
 /// Errors from the event store layer.
@@ -26,14 +26,14 @@ pub enum StoreError<A, EncErr, DecErr> {
         "concurrency conflict on stream '{stream_id}': expected version {expected:?}, actual {actual:?}"
     )]
     Conflict {
-        stream_id: ArrayString<64>,
+        stream_id: ErrorId,
         expected: Option<Version>,
         actual: Option<Version>,
     },
 
     /// Stream not found.
     #[error("stream '{stream_id}' not found")]
-    StreamNotFound { stream_id: ArrayString<64> },
+    StreamNotFound { stream_id: ErrorId },
 
     /// Database adapter failure.
     #[error("adapter error: {0}")]

--- a/crates/nexus-store/src/lib.rs
+++ b/crates/nexus-store/src/lib.rs
@@ -118,11 +118,14 @@ pub mod value;
 pub mod wake;
 pub mod wire;
 
-pub use arrayvec::ArrayString;
 pub use batch::{BatchSize, BatchSizeError, DEFAULT_BATCH, MAX_BATCH};
 #[cfg(feature = "snapshot")]
 pub use builder::WithSnapshot;
 pub use builder::{NeedsCodec, NoSnapshot, RepositoryBuilder};
+// Re-export `bytes` so downstreams name `nexus_store::bytes::Bytes` to feed
+// `Encode` / the value newtypes, sharing *our* version rather than coupling to
+// theirs. Additive (non-breaking).
+pub use bytes;
 #[cfg(feature = "cbor")]
 pub use cbor::{
     ChunkError, ChunkHeader, decode_chunk, decode_header, encode_block, encode_header,
@@ -150,7 +153,8 @@ pub use nexus::Version;
 pub use projection::Projector;
 pub use repository::{EventStore, Repository, ZeroCopyEventStore};
 pub use saga::{
-    ConflictPredicate, ProjectedIntent, ProjectedIntents, Reaction, SagaError, SagaRepository,
+    ConflictPredicate, ProjectedIntent, ProjectedIntents, ProjectedIntentsIntoIter, Reaction,
+    SagaError, SagaRepository,
 };
 #[cfg(feature = "snapshot")]
 pub use snapshot::Snapshotting;
@@ -162,6 +166,11 @@ pub use state::{
 };
 pub use store::{GlobalSeq, RawEventStore, Store};
 pub use stream::EventStream;
+// Re-export the `Stream` trait from `futures-core` (the small, near-frozen
+// definitional crate) rather than `futures`. `futures::Stream` *is* this trait,
+// so our public `EventStream` / `subscribe*` surface is married to
+// `futures-core`'s stability, not the churning batteries-included `futures`.
+pub use futures_core::Stream;
 #[cfg(feature = "subscription")]
 pub use subscription::Subscription;
 #[cfg(feature = "testing")]

--- a/crates/nexus-store/src/repository.rs
+++ b/crates/nexus-store/src/repository.rs
@@ -469,7 +469,10 @@ where
                 expected,
                 actual,
             } => StoreError::Conflict {
-                stream_id,
+                // Transitional: `AppendError::stream_id` is still `ArrayString<64>`
+                // (retyped to `ErrorId` in PR 3, atomic with the fjall construction
+                // sites). Re-wrap through the truncation-aware constructor for now.
+                stream_id: nexus::ErrorId::from_display(&stream_id),
                 expected,
                 actual,
             },
@@ -757,7 +760,10 @@ where
                 expected,
                 actual,
             } => StoreError::Conflict {
-                stream_id,
+                // Transitional: `AppendError::stream_id` is still `ArrayString<64>`
+                // (retyped to `ErrorId` in PR 3, atomic with the fjall construction
+                // sites). Re-wrap through the truncation-aware constructor for now.
+                stream_id: nexus::ErrorId::from_display(&stream_id),
                 expected,
                 actual,
             },

--- a/crates/nexus-store/src/saga.rs
+++ b/crates/nexus-store/src/saga.rs
@@ -210,13 +210,47 @@ impl<'a, S: Saga, const N: usize> IntoIterator for &'a ProjectedIntents<S, N> {
     }
 }
 
+/// Owning iterator over [`ProjectedIntents`], yielding `first` then each
+/// token in `rest`.
+///
+/// A named newtype wrapping the concrete `Chain<option::IntoIter, _>` so the
+/// `arrayvec::IntoIter` type does not appear in the public API as
+/// `ProjectedIntents`' associated `IntoIter` (sealing `arrayvec` out of our
+/// `SemVer`). Mirrors the kernel's `EventsIntoIter`.
+pub struct ProjectedIntentsIntoIter<S: Saga, const N: usize> {
+    inner: Chain<option::IntoIter<ProjectedIntent<S>>, arrayvec::IntoIter<ProjectedIntent<S>, N>>,
+}
+
+impl<S: Saga, const N: usize> Iterator for ProjectedIntentsIntoIter<S, N> {
+    type Item = ProjectedIntent<S>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+}
+
+impl<S: Saga, const N: usize> DoubleEndedIterator for ProjectedIntentsIntoIter<S, N> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.inner.next_back()
+    }
+}
+
+// Sound: both halves of the chain (`option::IntoIter` and `arrayvec::IntoIter`)
+// yield `None` permanently once exhausted, so the chain is fused.
+impl<S: Saga, const N: usize> core::iter::FusedIterator for ProjectedIntentsIntoIter<S, N> {}
+
 impl<S: Saga, const N: usize> IntoIterator for ProjectedIntents<S, N> {
     type Item = ProjectedIntent<S>;
-    type IntoIter =
-        Chain<option::IntoIter<ProjectedIntent<S>>, arrayvec::IntoIter<ProjectedIntent<S>, N>>;
+    type IntoIter = ProjectedIntentsIntoIter<S, N>;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.first.into_iter().chain(self.rest)
+        ProjectedIntentsIntoIter {
+            inner: self.first.into_iter().chain(self.rest),
+        }
     }
 }
 
@@ -360,8 +394,7 @@ impl<S: Saga, R: Repository<S>> SagaRepository<S> for R {}
 mod error_tests {
     use super::SagaError;
     use crate::error::StoreError;
-    use arrayvec::ArrayString;
-    use nexus::Version;
+    use nexus::{ErrorId, Version};
 
     type TestStoreError =
         StoreError<std::io::Error, std::convert::Infallible, std::convert::Infallible>;
@@ -370,7 +403,7 @@ mod error_tests {
     #[test]
     fn conflict_store_error_is_conflict() {
         let e: TestSagaError = SagaError::Store(StoreError::Conflict {
-            stream_id: ArrayString::from("s").expect("fits"),
+            stream_id: ErrorId::from_display(&"s"),
             expected: Some(Version::INITIAL),
             actual: None,
         });
@@ -392,7 +425,7 @@ mod error_tests {
 
 #[cfg(test)]
 mod projected_intents_tests {
-    use super::{ProjectedIntent, ProjectedIntents};
+    use super::{ProjectedIntent, ProjectedIntents, ProjectedIntentsIntoIter};
     use nexus::{
         Aggregate, AggregateState, DomainEvent, Events, Id, Message, React, Saga, Version,
     };
@@ -496,5 +529,34 @@ mod projected_intents_tests {
         assert_eq!(versions, vec![1, 2, 3]);
         let owned: Vec<u8> = intents.into_iter().map(|p| p.into_intent().0).collect();
         assert_eq!(owned, vec![1, 2, 3]);
+    }
+
+    // PR2 (#208): the owning `IntoIter` is the named, sealed
+    // `ProjectedIntentsIntoIter` (no `arrayvec::IntoIter` in the public API),
+    // preserving the underlying `Chain`'s capabilities.
+    #[test]
+    fn into_iter_is_named_sealed_type_double_ended_fused_and_sized() {
+        let mut intents = ProjectedIntents::<M, 2>::new();
+        for v in 1u64..=3 {
+            let version = Version::new(v).expect("non-zero");
+            let tag = u8::try_from(v).expect("fits u8");
+            intents.push(ProjectedIntent::new(Sid(9), version, Cmd(tag)));
+        }
+
+        // The associated `IntoIter` is the named type, not an arrayvec type.
+        let it: ProjectedIntentsIntoIter<M, 2> = intents.into_iter();
+        // `size_hint` counts first + rest exactly.
+        assert_eq!(it.size_hint(), (3, Some(3)));
+        // Double-ended: reversed yields last-to-first.
+        let reversed: Vec<u8> = it.rev().map(|p| p.into_intent().0).collect();
+        assert_eq!(reversed, vec![3, 2, 1]);
+
+        // Fused: once exhausted it keeps yielding `None`.
+        let mut single = ProjectedIntents::<M, 0>::new();
+        single.push(ProjectedIntent::new(Sid(1), Version::INITIAL, Cmd(7)));
+        let mut single_it = single.into_iter();
+        assert_eq!(single_it.next().map(|p| p.into_intent().0), Some(7));
+        assert!(single_it.next().is_none());
+        assert!(single_it.next().is_none());
     }
 }

--- a/crates/nexus-store/src/stream.rs
+++ b/crates/nexus-store/src/stream.rs
@@ -1,29 +1,31 @@
-//! Marker trait identifying a [`futures::Stream`] of decoded
+//! Marker trait identifying a [`futures_core::Stream`] of decoded
 //! [`PersistedEnvelope`]s.
 //!
-//! Combinators come from [`futures::StreamExt`](https://docs.rs/futures/latest/futures/stream/trait.StreamExt.html)
+//! The public trait surface is bound to **`futures-core`** (the small,
+//! near-frozen definitional crate) rather than `futures`; the two name the
+//! same `Stream` trait, so this marries our `SemVer` to the stabler crate.
+//! Combinators still come from [`futures::StreamExt`](https://docs.rs/futures/latest/futures/stream/trait.StreamExt.html)
 //! and [`futures::TryStreamExt`](https://docs.rs/futures/latest/futures/stream/trait.TryStreamExt.html).
 //!
 //! This module replaced the previous GAT-lending `EventStream` trait
 //! family (cursor, combinators, progress, futures-bridge). The owned-
 //! `Bytes` envelope from PR1 removed the per-record lifetime cliff that
 //! motivated the GAT — the new shape is a marker over
-//! `futures::Stream<Item = Result<PersistedEnvelope, _>>` and combinators
-//! come from the futures crate.
+//! `futures_core::Stream<Item = Result<PersistedEnvelope, _>>`.
 
 use crate::envelope::PersistedEnvelope;
 
 /// A futures-stream of persisted envelopes.
 ///
 /// Marker trait — auto-implemented for every matching
-/// `futures::Stream<Item = Result<PersistedEnvelope, E>> + Send`.
+/// `futures_core::Stream<Item = Result<PersistedEnvelope, E>> + Send`.
 /// The associated `Error` type is recovered from the stream's `Item`
 /// so call sites can bound on `S: EventStream<Error = MyErr>`.
 ///
-/// # Why a marker (and not just `futures::Stream`)
+/// # Why a marker (and not just `futures_core::Stream`)
 ///
 /// The `Error` associated type. Bounding on the bare
-/// `futures::Stream<Item = Result<PersistedEnvelope, E>>` shape requires
+/// `futures_core::Stream<Item = Result<PersistedEnvelope, E>>` shape requires
 /// an extra generic `E` at every consumer; the marker hides it behind a
 /// projection, so call sites name `S::Error` instead of carrying an
 /// extra type parameter. The marker has no methods of its own — every
@@ -37,7 +39,7 @@ use crate::envelope::PersistedEnvelope;
 /// Violating this invariant breaks aggregate rehydration; the trait
 /// does not enforce it structurally.
 pub trait EventStream:
-    futures::Stream<Item = Result<PersistedEnvelope, <Self as EventStream>::Error>> + Send
+    futures_core::Stream<Item = Result<PersistedEnvelope, <Self as EventStream>::Error>> + Send
 {
     /// The error type yielded by the stream's `Result` items.
     type Error: std::error::Error + Send + Sync + 'static;
@@ -45,7 +47,7 @@ pub trait EventStream:
 
 impl<S, E> EventStream for S
 where
-    S: futures::Stream<Item = Result<PersistedEnvelope, E>> + Send,
+    S: futures_core::Stream<Item = Result<PersistedEnvelope, E>> + Send,
     E: std::error::Error + Send + Sync + 'static,
 {
     type Error = E;

--- a/crates/nexus-store/src/subscription.rs
+++ b/crates/nexus-store/src/subscription.rs
@@ -88,7 +88,7 @@ impl<S: RawEventStore + WakeSource> Subscription<S> {
         id: &I,
         from: Option<Version>,
     ) -> Result<
-        impl futures::Stream<Item = Result<PersistedEnvelope, <S as RawEventStore>::Error>>
+        impl futures_core::Stream<Item = Result<PersistedEnvelope, <S as RawEventStore>::Error>>
         + Send
         + use<S, I>,
         <S as WakeSource>::Error,
@@ -116,7 +116,7 @@ impl<S: RawEventStore + WakeSource> Subscription<S> {
         &self,
         from: Option<GlobalSeq>,
     ) -> Result<
-        impl futures::Stream<Item = Result<PersistedEnvelope, <S as RawEventStore>::Error>>
+        impl futures_core::Stream<Item = Result<PersistedEnvelope, <S as RawEventStore>::Error>>
         + Send
         + use<S>,
         <S as WakeSource>::Error,

--- a/crates/nexus-store/tests/adversarial_property_tests.rs
+++ b/crates/nexus-store/tests/adversarial_property_tests.rs
@@ -65,10 +65,9 @@ use std::convert::Infallible;
 use std::fmt;
 use std::sync::Arc;
 
-use arrayvec::ArrayString;
 use bytes::Bytes;
 use futures::StreamExt;
-use nexus::Version;
+use nexus::{ErrorId, Version};
 use nexus_store::InMemoryStoreError;
 use nexus_store::Repository;
 use nexus_store::Store;
@@ -114,8 +113,8 @@ fn build_persisted(
 /// Concrete `StoreError` for tests using `InMemoryStore` + `JsonCodec` + no upcaster.
 type TestStoreError = StoreError<InMemoryStoreError, JsonCodecError, JsonCodecError>;
 
-fn label(s: &str) -> ArrayString<64> {
-    ArrayString::try_from(s).unwrap()
+fn label(s: &str) -> ErrorId {
+    ErrorId::from_display(&s)
 }
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]

--- a/crates/nexus-store/tests/bug_hunt_tests.rs
+++ b/crates/nexus-store/tests/bug_hunt_tests.rs
@@ -27,8 +27,7 @@
     reason = "clarity over brevity in test assertions"
 )]
 
-use arrayvec::ArrayString;
-use nexus::Version;
+use nexus::{ErrorId, Version};
 use nexus_store::AppendError;
 use nexus_store::InMemoryStoreError;
 use nexus_store::envelope::{PendingEnvelope, PersistedEnvelope};
@@ -66,8 +65,8 @@ fn build_persisted(
 /// Concrete `StoreError` for tests using `InMemoryStore` with no codec/upcaster.
 type TestStoreError = StoreError<InMemoryStoreError, std::io::Error, std::io::Error>;
 
-fn label(s: &str) -> ArrayString<64> {
-    ArrayString::try_from(s).unwrap()
+fn label(s: &str) -> ErrorId {
+    ErrorId::from_display(&s)
 }
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]

--- a/crates/nexus-store/tests/error_tests.rs
+++ b/crates/nexus-store/tests/error_tests.rs
@@ -2,8 +2,7 @@
 
 #![allow(clippy::unwrap_used, reason = "tests")]
 
-use arrayvec::ArrayString;
-use nexus::{KernelError, Version};
+use nexus::{ErrorId, KernelError, Version};
 use nexus_store::{LoadWithError, StoreError};
 
 /// Concrete `StoreError` for tests: adapter = `std::io::Error`, codec = `std::io::Error`.
@@ -14,8 +13,8 @@ type TestStoreError = StoreError<std::io::Error, std::io::Error, std::io::Error>
 type TestLoadWithError =
     LoadWithError<std::io::Error, std::io::Error, std::io::Error, std::io::Error>;
 
-fn label(s: &str) -> ArrayString<64> {
-    ArrayString::try_from(s).unwrap()
+fn label(s: &str) -> ErrorId {
+    ErrorId::from_display(&s)
 }
 
 #[test]
@@ -163,6 +162,58 @@ fn load_with_upcast_display_contains_inner_message() {
     );
     let source = std::error::Error::source(&err);
     assert!(source.is_some(), "Upcast variant should have a source");
+}
+
+// ── Defensive boundary (PR2 #208): over-long stream ids are truncated and
+//    visually signalled with a trailing `…` in error Display output. The
+//    `stream_id` field is now `nexus::ErrorId`, whose `from_display`
+//    constructor caps at 64 bytes on a char boundary and appends the marker.
+
+#[test]
+fn conflict_display_truncates_overlong_stream_id_with_ellipsis() {
+    // 100 bytes of input against ErrorId's 64-byte cap.
+    let long = "s".repeat(100);
+    let err: TestStoreError = StoreError::Conflict {
+        stream_id: ErrorId::from_display(&long),
+        expected: Version::new(3),
+        actual: Version::new(5),
+    };
+    let msg = format!("{err}");
+    // The full over-long id must NOT appear verbatim …
+    assert!(
+        !msg.contains(&long),
+        "the untruncated stream id must not be rendered"
+    );
+    // … the loss is signalled with the ellipsis marker …
+    assert!(
+        msg.contains('…'),
+        "truncation must be visually signalled with '…'"
+    );
+    // … and the surviving 61-byte prefix (64 cap − 3-byte '…') renders.
+    assert!(
+        msg.contains(&"s".repeat(61)),
+        "the truncated prefix should still be present"
+    );
+    // Versions still render.
+    assert!(msg.contains('3') && msg.contains('5'));
+}
+
+#[test]
+fn stream_not_found_display_truncates_overlong_stream_id_with_ellipsis() {
+    let long = "u".repeat(200);
+    let err: TestStoreError = StoreError::StreamNotFound {
+        stream_id: ErrorId::from_display(&long),
+    };
+    let msg = format!("{err}");
+    assert!(
+        !msg.contains(&long),
+        "the untruncated stream id must not be rendered"
+    );
+    assert!(
+        msg.contains('…'),
+        "truncation must be visually signalled with '…'"
+    );
+    assert!(msg.contains("not found"), "should mention 'not found'");
 }
 
 #[test]

--- a/crates/nexus-store/tests/security_tests.rs
+++ b/crates/nexus-store/tests/security_tests.rs
@@ -26,9 +26,8 @@
 )]
 #![allow(clippy::str_to_string, reason = "tests use to_string/to_owned freely")]
 
-use arrayvec::ArrayString;
 use futures::StreamExt;
-use nexus::{Id, Version};
+use nexus::{ErrorId, Id, Version};
 use nexus_store::InMemoryStoreError;
 use nexus_store::error::StoreError;
 use nexus_store::pending_envelope;
@@ -38,8 +37,8 @@ use nexus_store::testing::InMemoryStore;
 /// Concrete `StoreError` for tests using `InMemoryStore` with no codec/upcaster.
 type TestStoreError = StoreError<InMemoryStoreError, std::io::Error, std::io::Error>;
 
-fn label(s: &str) -> ArrayString<64> {
-    ArrayString::try_from(s).unwrap()
+fn label(s: &str) -> ErrorId {
+    ErrorId::from_display(&s)
 }
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]

--- a/crates/nexus-store/tests/static_assertions.rs
+++ b/crates/nexus-store/tests/static_assertions.rs
@@ -13,3 +13,19 @@ assert_impl_all!(PersistedEnvelope: Send, Sync, std::fmt::Debug);
 
 #[test]
 fn static_assertions_compile() {}
+
+// PR2 (#208): `bytes` and the `Stream` trait are re-exported from `nexus_store`
+// so downstreams share *our* version of each. These references fail to compile
+// if either re-export is removed.
+#[test]
+fn reexports_resolve() {
+    // `nexus_store::Stream` resolves and is the same trait `futures` streams
+    // implement (it is `futures_core::Stream`, which `futures::Stream` re-exports).
+    fn takes_stream<T: nexus_store::Stream>(_: T) {}
+
+    // `nexus_store::bytes::Bytes` resolves (the `pub use bytes;` re-export).
+    let bytes: nexus_store::bytes::Bytes = nexus_store::bytes::Bytes::new();
+    assert!(bytes.is_empty());
+
+    takes_stream(futures::stream::empty::<u8>());
+}

--- a/crates/nexus-store/tests/subscription_tests.rs
+++ b/crates/nexus-store/tests/subscription_tests.rs
@@ -59,6 +59,24 @@ async fn append_one(
 /// Timeout duration for operations that should complete quickly.
 const TIMEOUT: Duration = Duration::from_secs(2);
 
+// PR2 (#208): the public `subscribe` / `subscribe_all` return types are bound
+// to the re-exported `Stream` trait (`futures_core::Stream`), not the churning
+// `futures` umbrella crate. This compiles only if the returned cursors satisfy
+// that trait — a static guard on the public stream surface.
+#[tokio::test]
+async fn subscribe_returns_a_reexported_stream() {
+    fn assert_stream<T: nexus_store::Stream>(_: &T) {}
+
+    let store = Store::new(InMemoryStore::new());
+    let id = TestId::new("stream-static");
+
+    let per_stream = Subscription::new(&store).subscribe(&id, None).unwrap();
+    assert_stream(&per_stream);
+
+    let all = Subscription::new(&store).subscribe_all(None).unwrap();
+    assert_stream(&all);
+}
+
 // ═══════════════════════════════════════════════════════════════════════════
 // 1. Sequence/Protocol Tests
 // ═══════════════════════════════════════════════════════════════════════════

--- a/docs/plans/2026-06-26-seal-public-dependency-leaks-design.md
+++ b/docs/plans/2026-06-26-seal-public-dependency-leaks-design.md
@@ -124,9 +124,17 @@ constructing `ErrorId` directly via `ErrorId::from_display`.
 - Purely additive; workspace compiles unchanged.
 
 ### PR 2 — store (`nexus-store`) — depends on PR 1
-- Adopt `ErrorId` in `StoreError::{Conflict,StreamNotFound}` and
-  `AppendError::Conflict` `stream_id` fields; construct via
-  `ErrorId::from_display(&id)` (not `to_label`).
+- Adopt `ErrorId` in `StoreError::{Conflict,StreamNotFound}` `stream_id` fields
+  **only**; construct via `ErrorId::from_display(&id)` (not `to_label`).
+  - **Scope correction (vs. the inventory):** `AppendError::Conflict`'s
+    `stream_id` is **not** retyped here. `AppendError::Conflict` is *constructed
+    by `nexus-fjall`* (`crates/nexus-fjall/src/store.rs`), so retyping its field
+    can't land in a store-only PR without breaking the fjall build — the same
+    cross-crate binding that defers `to_label` to PR 4. It moves to **PR 3**
+    (atomic with fjall). The store-side facade arms that map
+    `AppendError::Conflict → StoreError::Conflict` (`repository.rs`) therefore
+    do a transitional `ErrorId::from_display(&stream_id)` conversion, removed in
+    PR 3 once `AppendError` is also `ErrorId`.
 - **Delete** `pub use arrayvec::ArrayString;`.
 - Seal `ProjectedIntents::IntoIter` via `ProjectedIntentsIntoIter` newtype.
 - `pub use bytes;`.
@@ -135,6 +143,9 @@ constructing `ErrorId` directly via `ErrorId::from_display`.
 
 ### PR 3 — fjall (`nexus-fjall`) — depends on PR 1, independent of PR 2
 - Adopt `ErrorId<64>` for `stream_id` fields; `ErrorId<128>` for `reason`.
+- **Also retype `AppendError::Conflict`'s `stream_id`** to `ErrorId` (deferred
+  from PR 2): atomic with the fjall construction sites that build it, and drop
+  the transitional `ErrorId::from_display` conversion in the store facade arms.
 - Replace the `id.to_label()` sites and `reason_label`/`ArrayString::new()`
   sites with `ErrorId::from_display(&id)` / `ErrorId::default()`.
 


### PR DESCRIPTION
Part of #208 (seal public dependency leaks before the 1.0 freeze). Second of four PRs; builds on PR 1 (#231, `nexus::ErrorId` + `EventsIntoIter`, now merged).

## What changed (`nexus-store`)

- **Adopt `nexus::ErrorId` in `StoreError`.** `StoreError::{Conflict,StreamNotFound}.stream_id` changes from `arrayvec::ArrayString<64>` to `nexus::ErrorId` (truncation-aware, `…`-signalled per CLAUDE.md). Construction goes through `ErrorId::from_display(&id)`.
- **Delete `pub use arrayvec::ArrayString;`.** Intended breaking change; no internal users.
- **Seal `ProjectedIntents::IntoIter`.** New named `ProjectedIntentsIntoIter<S, N>` newtype wraps the concrete `Chain<option::IntoIter, arrayvec::IntoIter>` and delegates `Iterator` (`next` + `size_hint`) + `DoubleEndedIterator` + a manual `FusedIterator`, so `arrayvec::IntoIter` no longer appears in the public API. Mirrors PR 1's `EventsIntoIter`. Re-exported from the crate root.
- **`pub use bytes;`** (additive) so downstreams write `nexus_store::bytes::Bytes` and share *our* `bytes` version.
- **Rebind the stream surface to `futures-core`.** The `EventStream` supertrait and the `subscribe`/`subscribe_all` return types move from `futures::Stream` to `futures_core::Stream`, plus `pub use futures_core::Stream`. `futures::Stream` *is* `futures_core::Stream` (same trait identity), so this is **not** an API break — it marries our contract to the small, near-frozen definitional crate. `futures` stays an internal/dev dependency (`StreamExt`/`TryStreamExt` are still used internally).

## Scope correction (design doc updated in this PR)

The inventory listed retyping **both** `StoreError` and `AppendError`. But `AppendError::Conflict` is *constructed by `nexus-fjall`* (`crates/nexus-fjall/src/store.rs`), so retyping its field can't land in a store-only PR without breaking the fjall build — the same cross-crate binding that defers `to_label` to PR 4. Therefore:

- **PR 2 retypes only `StoreError`.** The store facade arms that map `AppendError::Conflict → StoreError::Conflict` (`repository.rs`) do a transitional `ErrorId::from_display(&stream_id)` conversion.
- **`AppendError::Conflict`'s retype moves to PR 3** (atomic with fjall), which also drops that transitional conversion. The design doc's PR 2 / PR 3 sections are updated to record this.
- `Id::to_label -> ErrorId` remains **PR 4**.

## Breaking changes (intentional, pre-freeze)

- Removed `nexus_store::ArrayString` re-export.
- `StoreError::{Conflict,StreamNotFound}.stream_id` field type changed (`ArrayString<64>` → `ErrorId`).
- `ProjectedIntents`' associated `IntoIter` renamed to `ProjectedIntentsIntoIter`.

Additive / non-breaking: `pub use bytes`, `pub use futures_core::Stream`, and the `futures_core` rebind (same trait identity).

## Tests (CLAUDE.md rule 7)

- **Defensive boundary:** `StoreError::Conflict` / `StreamNotFound` built from an over-long stream id render a truncated, `…`-suffixed `stream_id` in `Display` (`error_tests.rs`).
- **Sequence:** `ProjectedIntentsIntoIter` is the named associated `IntoIter`, yields first-then-rest, is double-ended, fused-after-exhaustion, and reports the correct `size_hint` (`saga.rs` inline tests).
- **Static/compile:** `nexus_store::bytes` and `nexus_store::Stream` resolve (`static_assertions.rs`); `subscribe`/`subscribe_all` return a `nexus_store::Stream` (= `futures_core::Stream`) (`subscription_tests.rs`).
- Updated the `label` helpers in `error_tests` / `security_tests` / `bug_hunt_tests` / `adversarial_property_tests` to return `ErrorId`.

Full `nix flake check` gate green (clippy, nextest, doc, fmt, deny, audit, hakari).

🤖 Generated with [Claude Code](https://claude.com/claude-code)