### PR TITLE
feat(fjall)!: adopt ErrorId in FjallError + AppendError, drop store transitional conversion (#208, PR 3/4)

### DIFF
--- a/crates/nexus-fjall/src/error.rs
+++ b/crates/nexus-fjall/src/error.rs
@@ -1,20 +1,18 @@
-use arrayvec::ArrayString;
+use nexus::ErrorId;
 use nexus_store::envelope::EnvelopeError;
-use std::fmt::Write;
 use thiserror::Error;
 
-/// Format a `Display` value into a stack-allocated reason label,
-/// silently truncating at 128 bytes on a char boundary.
-pub(crate) fn reason_label(value: &impl std::fmt::Display) -> ArrayString<128> {
-    let mut buf = ArrayString::<128>::new();
-    let _ = write!(buf, "{value}");
-    buf
+/// Format a `Display` value into a stack-allocated reason label, truncating
+/// at 128 bytes on a char boundary with a trailing `…` if it overflows
+/// (truncation is visually signalled, per CLAUDE.md).
+pub(crate) fn reason_label(value: &impl std::fmt::Display) -> ErrorId<128> {
+    ErrorId::from_display(value)
 }
 
 /// Errors produced by the fjall event store adapter.
 ///
 /// Intentionally stack-allocated (~208 bytes) for IoT/embedded targets.
-/// All diagnostic fields use `ArrayString` — no heap allocation on error paths.
+/// All diagnostic fields use [`ErrorId`] — no heap allocation on error paths.
 #[derive(Debug, Error)]
 pub enum FjallError {
     /// Fjall I/O or internal database error.
@@ -24,7 +22,7 @@ pub enum FjallError {
     /// Stored value has corrupt or unrecognizable byte layout.
     #[error("corrupt value in stream '{stream_id}' at version {version:?}")]
     CorruptValue {
-        stream_id: ArrayString<64>,
+        stream_id: ErrorId,
         version: Option<u64>,
     },
 
@@ -34,7 +32,7 @@ pub enum FjallError {
     /// from wire-format-level corruption (`CorruptValue`).
     #[error("envelope integrity error in stream '{stream_id}' at version {version}")]
     EnvelopeCorrupt {
-        stream_id: ArrayString<64>,
+        stream_id: ErrorId,
         version: u64,
         #[source]
         source: EnvelopeError,
@@ -42,7 +40,7 @@ pub enum FjallError {
 
     /// Stream metadata has wrong byte size.
     #[error("corrupt metadata for stream '{stream_id}'")]
-    CorruptMeta { stream_id: ArrayString<64> },
+    CorruptMeta { stream_id: ErrorId },
 
     /// Invalid input on the write path (e.g. event type name too long).
     ///
@@ -50,9 +48,9 @@ pub enum FjallError {
     /// is unreadable. This error fires before any data is written.
     #[error("invalid input for stream '{stream_id}' at version {version}: {reason}")]
     InvalidInput {
-        stream_id: ArrayString<64>,
+        stream_id: ErrorId,
         version: u64,
-        reason: ArrayString<128>,
+        reason: ErrorId<128>,
     },
 
     /// Event version would overflow `u64::MAX`.
@@ -82,5 +80,45 @@ mod tests {
     fn satisfies_error_send_sync_static() {
         fn assert_bounds<T: std::error::Error + Send + Sync + 'static>() {}
         assert_bounds::<FjallError>();
+    }
+
+    /// Defensive boundary: an over-long stream id in the `ErrorId<64>` field
+    /// renders truncated and `…`-suffixed through the error's `Display`.
+    #[test]
+    fn corrupt_value_display_truncates_overlong_stream_id() {
+        let err = FjallError::CorruptValue {
+            stream_id: ErrorId::from_display(&"s".repeat(200)),
+            version: Some(7),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains('…'), "display must signal truncation: {msg}");
+        // The 64-byte label plus the surrounding format text — never the full
+        // 200-byte id.
+        assert!(!msg.contains(&"s".repeat(100)));
+    }
+
+    /// Defensive boundary: the `reason` field is `ErrorId<128>` (a wider cap
+    /// than the 64-byte stream-id labels); an over-long reason truncates at
+    /// 128 bytes with a trailing `…`, surfaced via `reason_label`.
+    #[test]
+    fn invalid_input_display_truncates_overlong_reason() {
+        let reason = reason_label(&"r".repeat(400));
+        assert!(reason.as_str().len() <= 128);
+        assert!(reason.as_str().ends_with('…'));
+
+        let err = FjallError::InvalidInput {
+            stream_id: ErrorId::from_display(&"stream-1"),
+            version: 3,
+            reason,
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("stream-1"),
+            "display must carry stream id: {msg}"
+        );
+        assert!(
+            msg.contains('…'),
+            "display must signal reason truncation: {msg}"
+        );
     }
 }

--- a/crates/nexus-fjall/src/scan.rs
+++ b/crates/nexus-fjall/src/scan.rs
@@ -4,10 +4,9 @@
 //! [`PersistedEnvelope`]. NOT exported; no other adapter shares fjall's on-disk
 //! key layout, so this stays inside `nexus-fjall`.
 
-use arrayvec::ArrayString;
 use bytes::Bytes;
 use fjall::Slice;
-use nexus::Version;
+use nexus::{ErrorId, Version};
 use nexus_store::{GlobalSeq, PersistedEnvelope};
 
 use crate::error::{FjallError, reason_label};
@@ -33,7 +32,7 @@ pub trait ScanStrategy: Send {
 /// Per-stream scan: keyed by `[id_len][id_bytes][version]`, opens from a [`Version`].
 pub struct StreamScan {
     pub id: OwnedStreamId,
-    pub label: ArrayString<64>,
+    pub label: ErrorId,
 }
 
 /// `$all` scan: keyed by `[global_seq][version]`, opens from a [`GlobalSeq`].
@@ -43,14 +42,14 @@ pub struct GlobalScan;
 /// envelope, mapping the two terminal failures identically for both strategies.
 ///
 /// `stream_id` is the diagnostic label stamped into every error: the per-stream
-/// label for [`StreamScan`], an empty [`ArrayString`] for [`GlobalScan`] (a
+/// label for [`StreamScan`], an empty [`ErrorId`] for [`GlobalScan`] (a
 /// global key carries no stream id). `raw_version` is the version decoded from
 /// the key; it appears verbatim in the error fields.
 fn build_envelope(
     bytes_value: Bytes,
     decoded: DecodedEvent,
     raw_version: u64,
-    stream_id: ArrayString<64>,
+    stream_id: ErrorId,
 ) -> Result<PersistedEnvelope, FjallError> {
     let version = Version::new(raw_version).ok_or(FjallError::CorruptValue {
         stream_id,
@@ -126,13 +125,13 @@ impl ScanStrategy for GlobalScan {
     fn decode(&self, key: &Slice, value: Slice) -> Result<PersistedEnvelope, FjallError> {
         let (key_global_seq, version_raw) =
             decode_global_key(key).map_err(|_| FjallError::CorruptValue {
-                stream_id: ArrayString::new(),
+                stream_id: ErrorId::default(),
                 version: None,
             })?;
 
         let bytes_value: Bytes = value.into();
         let decoded = decode_event_value(&bytes_value).map_err(|_| FjallError::CorruptValue {
-            stream_id: ArrayString::new(),
+            stream_id: ErrorId::default(),
             version: Some(version_raw),
         })?;
 
@@ -140,12 +139,12 @@ impl ScanStrategy for GlobalScan {
         // (CLAUDE.md rule 4 — redundant data must be validated).
         if decoded.global_seq != key_global_seq {
             return Err(FjallError::CorruptValue {
-                stream_id: ArrayString::new(),
+                stream_id: ErrorId::default(),
                 version: Some(version_raw),
             });
         }
 
-        build_envelope(bytes_value, decoded, version_raw, ArrayString::new())
+        build_envelope(bytes_value, decoded, version_raw, ErrorId::default())
     }
 }
 
@@ -232,7 +231,6 @@ mod tests {
     use crate::store::FjallStore;
     use crate::store::read_test_helpers::{Tid, temp_store, tid};
     use futures::StreamExt;
-    use nexus::Id;
     use nexus_store::envelope::pending_envelope;
     use nexus_store::store::RawEventStore;
     use nexus_store::value::{EventType, Payload, SchemaVersion};
@@ -277,7 +275,7 @@ mod tests {
             &store.events,
             StreamScan {
                 id: OwnedStreamId::from_id(&id),
-                label: id.to_label(),
+                label: ErrorId::from_display(&id),
             },
             Version::INITIAL,
         )
@@ -300,7 +298,7 @@ mod tests {
             &store.events,
             StreamScan {
                 id: OwnedStreamId::from_id(&id),
-                label: id.to_label(),
+                label: ErrorId::from_display(&id),
             },
             Version::new(3).unwrap(),
         )
@@ -339,7 +337,7 @@ mod tests {
     fn stream_scan(id_bytes: &[u8], label: &str) -> StreamScan {
         StreamScan {
             id: OwnedStreamId::from_id(&label_id(id_bytes)),
-            label: ArrayString::try_from(label).unwrap(),
+            label: ErrorId::from_display(&label),
         }
     }
 

--- a/crates/nexus-fjall/src/store.rs
+++ b/crates/nexus-fjall/src/store.rs
@@ -6,7 +6,7 @@ use crate::wire_key::{
     decode_stream_version, encode_event_key, encode_global_key, encode_stream_version,
 };
 use fjall::{Readable, Slice};
-use nexus::{Id, Version};
+use nexus::{ErrorId, Id, Version};
 use nexus_store::PendingEnvelope;
 use nexus_store::error::AppendError;
 use nexus_store::notify::{NotifyError, StreamNotifiers, WakeReg};
@@ -67,7 +67,7 @@ impl FjallStore {
             .map_or(Ok(0), |version_bytes| {
                 decode_stream_version(&version_bytes).map_err(|_| {
                     AppendError::Store(FjallError::CorruptMeta {
-                        stream_id: id.to_label(),
+                        stream_id: ErrorId::from_display(id),
                     })
                 })
             })
@@ -85,7 +85,7 @@ impl FjallStore {
             // New stream: expected_version must be None.
             return if expected.is_some() {
                 Err(AppendError::Conflict {
-                    stream_id: id.to_label(),
+                    stream_id: ErrorId::from_display(id),
                     expected,
                     actual: None,
                 })
@@ -95,7 +95,7 @@ impl FjallStore {
         }
         if current != expected.map_or(0, Version::as_u64) {
             return Err(AppendError::Conflict {
-                stream_id: id.to_label(),
+                stream_id: ErrorId::from_display(id),
                 expected,
                 actual: Version::new(current),
             });
@@ -115,7 +115,7 @@ impl FjallStore {
             .map_or(Ok(0), |bytes| {
                 let raw: [u8; 8] = bytes.as_ref().try_into().map_err(|_| {
                     AppendError::Store(FjallError::CorruptMeta {
-                        stream_id: id.to_label(),
+                        stream_id: ErrorId::from_display(id),
                     })
                 })?;
                 Ok(u64::from_le_bytes(raw))
@@ -160,14 +160,14 @@ impl RawEventStore for FjallStore {
             current_version
                 .checked_add(1)
                 .ok_or_else(|| AppendError::Conflict {
-                    stream_id: id.to_label(),
+                    stream_id: ErrorId::from_display(id),
                     expected: Version::new(current_version),
                     actual: Some(envelopes[0].version()),
                 })?;
         for env in envelopes {
             if env.version().as_u64() != expected_version_seq {
                 return Err(AppendError::Conflict {
-                    stream_id: id.to_label(),
+                    stream_id: ErrorId::from_display(id),
                     expected: Version::new(expected_version_seq),
                     actual: Some(env.version()),
                 });
@@ -176,7 +176,7 @@ impl RawEventStore for FjallStore {
                 expected_version_seq
                     .checked_add(1)
                     .ok_or_else(|| AppendError::Conflict {
-                        stream_id: id.to_label(),
+                        stream_id: ErrorId::from_display(id),
                         expected: Version::new(current_version),
                         actual: Some(env.version()),
                     })?;
@@ -196,7 +196,7 @@ impl RawEventStore for FjallStore {
 
             let key = encode_event_key(id_bytes, env.version().as_u64()).map_err(|e| {
                 AppendError::Store(FjallError::InvalidInput {
-                    stream_id: id.to_label(),
+                    stream_id: ErrorId::from_display(id),
                     version: env.version().as_u64(),
                     reason: reason_label(&e),
                 })
@@ -210,7 +210,7 @@ impl RawEventStore for FjallStore {
             )
             .map_err(|e| {
                 AppendError::Store(FjallError::InvalidInput {
-                    stream_id: id.to_label(),
+                    stream_id: ErrorId::from_display(id),
                     version: env.version().as_u64(),
                     reason: reason_label(&e),
                 })
@@ -254,7 +254,7 @@ impl RawEventStore for FjallStore {
             &self.events,
             StreamScan {
                 id: OwnedStreamId::from_id(id),
-                label: id.to_label(),
+                label: ErrorId::from_display(id),
             },
             from,
         )
@@ -271,7 +271,7 @@ impl RawEventStore for FjallStore {
 
 #[cfg(feature = "snapshot")]
 mod snapshot_impl {
-    use super::{FjallError, FjallStore, Id, Version};
+    use super::{ErrorId, FjallError, FjallStore, Id, Version};
     use crate::snapshot::{decode_snapshot_value, encode_snapshot_value};
     use nexus_store::state::SnapshotStore;
     use std::num::NonZeroU32;
@@ -291,7 +291,7 @@ mod snapshot_impl {
 
             let (schema_version_raw, version_raw, payload) = decode_snapshot_value(&bytes)
                 .map_err(|_| FjallError::CorruptValue {
-                    stream_id: id.to_label(),
+                    stream_id: ErrorId::from_display(id),
                     version: None,
                 })?;
 
@@ -301,7 +301,7 @@ mod snapshot_impl {
             }
 
             let version = Version::new(version_raw).ok_or_else(|| FjallError::CorruptValue {
-                stream_id: id.to_label(),
+                stream_id: ErrorId::from_display(id),
                 version: None,
             })?;
 
@@ -478,6 +478,31 @@ mod tests {
             } => {
                 assert_eq!(expected, None);
                 assert_eq!(actual, Version::new(1));
+            }
+            other @ AppendError::Store(_) => panic!("expected Conflict, got: {other}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn conflict_truncates_overlong_stream_id_with_ellipsis() {
+        let (store, _dir) = temp_store();
+        // A >64-byte id forces the ErrorId<64> stream-id label to truncate;
+        // truncation must be visually signalled with a trailing ellipsis
+        // (CLAUDE.md "truncation must be visually signalled").
+        let long = "x".repeat(200);
+        let env = make_envelope(1, "E", b"p");
+        // New stream + Some(expected) → immediate optimistic-concurrency conflict.
+        let err = store
+            .append(&tid(&long), Version::new(1), &[env])
+            .await
+            .unwrap_err();
+        match err {
+            AppendError::Conflict { stream_id, .. } => {
+                assert!(stream_id.as_str().len() <= 64);
+                assert!(
+                    stream_id.as_str().ends_with('…'),
+                    "overlong stream id must be truncated with an ellipsis, got {stream_id:?}"
+                );
             }
             other @ AppendError::Store(_) => panic!("expected Conflict, got: {other}"),
         }

--- a/crates/nexus-store/src/error.rs
+++ b/crates/nexus-store/src/error.rs
@@ -1,4 +1,3 @@
-use arrayvec::ArrayString;
 use nexus::{ErrorId, KernelError, Version};
 use thiserror::Error;
 
@@ -147,7 +146,7 @@ pub enum AppendError<E> {
         "concurrency conflict on '{stream_id}': expected version {expected:?}, actual {actual:?}"
     )]
     Conflict {
-        stream_id: ArrayString<64>,
+        stream_id: ErrorId,
         expected: Option<Version>,
         actual: Option<Version>,
     },

--- a/crates/nexus-store/src/repository.rs
+++ b/crates/nexus-store/src/repository.rs
@@ -469,10 +469,7 @@ where
                 expected,
                 actual,
             } => StoreError::Conflict {
-                // Transitional: `AppendError::stream_id` is still `ArrayString<64>`
-                // (retyped to `ErrorId` in PR 3, atomic with the fjall construction
-                // sites). Re-wrap through the truncation-aware constructor for now.
-                stream_id: nexus::ErrorId::from_display(&stream_id),
+                stream_id,
                 expected,
                 actual,
             },
@@ -760,10 +757,7 @@ where
                 expected,
                 actual,
             } => StoreError::Conflict {
-                // Transitional: `AppendError::stream_id` is still `ArrayString<64>`
-                // (retyped to `ErrorId` in PR 3, atomic with the fjall construction
-                // sites). Re-wrap through the truncation-aware constructor for now.
-                stream_id: nexus::ErrorId::from_display(&stream_id),
+                stream_id,
                 expected,
                 actual,
             },

--- a/crates/nexus-store/src/testing.rs
+++ b/crates/nexus-store/src/testing.rs
@@ -8,6 +8,7 @@ use crate::store::{GlobalSeq, RawEventStore};
 use crate::wake::WakeSource;
 use crate::wire::{self, FrameOffsets};
 use bytes::Bytes;
+use nexus::ErrorId;
 use nexus::Id;
 use nexus::Version;
 use std::collections::BTreeMap;
@@ -332,7 +333,7 @@ impl RawEventStore for InMemoryStore {
         let expected_raw = expected_version.map_or(0, nexus::Version::as_u64);
         if actual_version_raw != expected_raw {
             return Err(AppendError::Conflict {
-                stream_id: id.to_label(),
+                stream_id: ErrorId::from_display(id),
                 expected: expected_version,
                 actual: Version::new(actual_version_raw),
             });
@@ -347,13 +348,13 @@ impl RawEventStore for InMemoryStore {
                 .checked_add(1)
                 .and_then(|v| v.checked_add(i_u64))
                 .ok_or_else(|| AppendError::Conflict {
-                    stream_id: id.to_label(),
+                    stream_id: ErrorId::from_display(id),
                     expected: expected_version,
                     actual: Some(env.version()),
                 })?;
             if env.version().as_u64() != expected_env_version {
                 return Err(AppendError::Conflict {
-                    stream_id: id.to_label(),
+                    stream_id: ErrorId::from_display(id),
                     expected: Version::new(expected_env_version),
                     actual: Some(env.version()),
                 });

--- a/crates/nexus-store/tests/inmemory_store_tests.rs
+++ b/crates/nexus-store/tests/inmemory_store_tests.rs
@@ -1,8 +1,10 @@
 #![cfg(feature = "testing")]
 #![allow(clippy::unwrap_used, reason = "tests")]
+#![allow(clippy::panic, reason = "tests")]
 
 use futures::StreamExt;
 use nexus::{Id, Version};
+use nexus_store::AppendError;
 use nexus_store::pending_envelope;
 use nexus_store::store::{GlobalSeq, RawEventStore};
 use nexus_store::testing::InMemoryStore;
@@ -21,6 +23,50 @@ impl AsRef<[u8]> for TestId {
 }
 impl Id for TestId {
     const BYTE_LEN: usize = 0;
+}
+
+/// An owned-`String` id so tests can build labels longer than the 64-byte
+/// `ErrorId` cap (the static-str [`TestId`] above can't carry a 200-byte id).
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+struct LongId(String);
+impl std::fmt::Display for LongId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+impl AsRef<[u8]> for LongId {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_bytes()
+    }
+}
+impl Id for LongId {
+    const BYTE_LEN: usize = 0;
+}
+
+#[tokio::test]
+async fn append_conflict_truncates_overlong_stream_id_with_ellipsis() {
+    let store = InMemoryStore::new();
+    let long = LongId("y".repeat(200));
+    let env = pending_envelope(Version::new(1).unwrap())
+        .event_type("E")
+        .payload(b"p".to_vec())
+        .unwrap()
+        .build();
+    // New stream + Some(expected) → conflict carrying the truncated id label.
+    let err = store
+        .append(&long, Version::new(1), &[env])
+        .await
+        .unwrap_err();
+    match err {
+        AppendError::Conflict { stream_id, .. } => {
+            assert!(stream_id.as_str().len() <= 64);
+            assert!(
+                stream_id.as_str().ends_with('…'),
+                "overlong stream id must be truncated with an ellipsis, got {stream_id:?}"
+            );
+        }
+        AppendError::Store(e) => panic!("expected Conflict, got Store({e})"),
+    }
 }
 
 #[tokio::test]

--- a/crates/nexus/src/error_id.rs
+++ b/crates/nexus/src/error_id.rs
@@ -44,7 +44,7 @@ const fn truncate_at_char_boundary(s: &str, limit: usize) -> usize {
 /// Construct via [`ErrorId::from_display`]; longer values are truncated on a
 /// char boundary and suffixed with `…`. `N` defaults to
 /// [`DEFAULT_ERROR_ID_CAP`] (64).
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct ErrorId<const N: usize = DEFAULT_ERROR_ID_CAP> {
     inner: ArrayString<N>,
 }

--- a/crates/nexus/tests/kernel_tests/error_id_tests.rs
+++ b/crates/nexus/tests/kernel_tests/error_id_tests.rs
@@ -51,6 +51,23 @@ fn default_is_empty() {
     assert!(id.is_empty());
 }
 
+#[test]
+fn error_id_is_copy() {
+    // `ErrorId` must be `Copy`: the fjall adapter's error paths stamp the
+    // same label into several variants in one expression (e.g. `scan.rs`
+    // builds `CorruptValue` then reuses the id for `EnvelopeCorrupt`), which
+    // only compiles move-free when the label is `Copy`. The wrapped
+    // `ArrayString<N>` is `Copy`, so this is sound and additive.
+    fn assert_copy<T: Copy>() {}
+    assert_copy::<ErrorId<64>>();
+    assert_copy::<ErrorId<128>>();
+
+    let a = ErrorId::<64>::from_display(&"copy-me");
+    let b = a; // copies, not moves
+    assert_eq!(a, b);
+    assert_eq!(a.as_str(), "copy-me");
+}
+
 // ── Defensive boundary: lengths {0, 1, N-1, N, N+1} ────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

PR 3 of 4 for #208 ("seal public dependency leaks before the 1.0 freeze"). This is the cross-crate (`nexus-fjall` + `nexus-store`) step: it retypes every error field that carried `arrayvec::ArrayString` to the kernel-owned `nexus::ErrorId<N>` introduced in PR 1. `ErrorId<N>` keeps the same stack-allocated bytes for IoT/embedded targets without coupling our SemVer to arrayvec 0.x, and gains `…`-truncation signalling for free (CLAUDE.md "truncation must be visually signalled").

Depends on PR 2 (#232, merged), which retyped `StoreError` and added the transitional facade conversion this PR removes.

## Changes

- **kernel (`nexus`)** — add `Copy` to `ErrorId`'s derive. Additive and sound: `ErrorId<N>` wraps `ArrayString<N>`, which is itself `Copy`. Required because the fjall scan path stamps one label into several error variants in a single move-free expression (`scan.rs::build_envelope`).
- **`nexus-fjall`** — `FjallError::{CorruptValue, EnvelopeCorrupt, CorruptMeta, InvalidInput}.stream_id` → `ErrorId`; `InvalidInput.reason` → `ErrorId<128>`. `reason_label` now returns `ErrorId<128>` via `ErrorId::from_display` (no longer silently truncating). `StreamScan.label` and `build_envelope`'s param → `ErrorId`. All construction goes through `ErrorId::from_display(&id)` / `ErrorId::default()` rather than `id.to_label()` (which still returns `ArrayString<64>` until PR 4).
- **`nexus-store`** — `AppendError::Conflict.stream_id` → `ErrorId` (deferred to this PR from PR 2, because the field is *constructed* by `nexus-fjall` and `InMemoryStore`). The two repository facade arms drop PR 2's transitional `ErrorId::from_display` re-wrap and pass the `ErrorId` through directly; `InMemoryStore` construction sites migrated.

## Tests (CLAUDE.md rule 7)

- **kernel**: `ErrorId` is `Copy` (static assertion + copy round-trip).
- **defensive boundary**: `FjallError::CorruptValue` (`ErrorId<64>`) and `InvalidInput` (`ErrorId<128>` reason) render truncated, `…`-suffixed through `Display`.
- **lifecycle/sequence**: a real conflict via `FjallStore` and `InMemoryStore` with an over-long stream id surfaces a truncated, `…`-suffixed `AppendError::Conflict.stream_id` — driven through the real SUT, not a hand-rolled probe.

The SUT truncation tests were written first against the old `ArrayString` fields and confirmed to **fail** (no ellipsis under `to_label`'s silent truncation) before the retype made them pass.

## Breaking changes (intentional, pre-1.0 freeze)

- `FjallError` field types: `ArrayString<64>` → `ErrorId`, `ArrayString<128>` → `ErrorId<128>`.
- `AppendError::Conflict.stream_id`: `ArrayString<64>` → `ErrorId`.
- **Additive (non-breaking):** `nexus::ErrorId` now derives `Copy`.

## Follow-up

PR 4 retypes `Id::to_label() -> ErrorId` (the last arrayvec leak). After this PR, **no `ArrayString<64>` consumer of `to_label` remains outside the kernel** — `to_label` is called only via `.as_str()` in `nexus-store::state`, which is type-agnostic — so PR 4 is unblocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
