### PR TITLE
feat(kernel)!: Id::to_label returns ErrorId, seal arrayvec from public API (#208, PR 4/4)

### DIFF
--- a/crates/nexus/src/id.rs
+++ b/crates/nexus/src/id.rs
@@ -1,20 +1,7 @@
-use std::fmt::{Debug, Display, Write};
+use std::fmt::{Debug, Display};
 use std::hash::Hash;
 
-use arrayvec::ArrayString;
-
-/// Find the largest byte position at or before `limit` that sits on a
-/// UTF-8 char boundary in `s`. Returns 0 if no valid boundary exists.
-const fn truncate_at_char_boundary(s: &str, limit: usize) -> usize {
-    if limit >= s.len() {
-        return s.len();
-    }
-    let mut pos = limit;
-    while pos > 0 && !s.is_char_boundary(pos) {
-        pos -= 1;
-    }
-    pos
-}
+use crate::ErrorId;
 
 pub trait Id: Clone + Send + Sync + Debug + Hash + Eq + Display + AsRef<[u8]> + 'static {
     /// Fixed byte length of this ID's storage representation.
@@ -22,27 +9,11 @@ pub trait Id: Clone + Send + Sync + Debug + Hash + Eq + Display + AsRef<[u8]> + 
     const BYTE_LEN: usize;
 
     /// Stack-allocated diagnostic label for error messages.
-    /// Truncates at a char boundary if the display representation exceeds 64 bytes.
-    fn to_label(&self) -> ArrayString<64> {
-        /// Wrapper that fills an `ArrayString` with partial writes,
-        /// silently dropping overflow instead of returning `Err`.
-        struct LabelWriter(ArrayString<64>);
-
-        impl Write for LabelWriter {
-            fn write_str(&mut self, s: &str) -> std::fmt::Result {
-                let remaining = 64 - self.0.len();
-                if remaining == 0 {
-                    return Ok(());
-                }
-                let end = truncate_at_char_boundary(s, remaining);
-                // Safety: end is at a char boundary and end <= remaining <= capacity - len.
-                self.0.try_push_str(&s[..end]).ok();
-                Ok(())
-            }
-        }
-
-        let mut writer = LabelWriter(ArrayString::new());
-        let _ = write!(writer, "{self}");
-        writer.0
+    ///
+    /// If the display representation exceeds 64 bytes it is truncated on a
+    /// char boundary and the tail is replaced with `…`, so truncation is
+    /// always visually signalled (never silent). See [`ErrorId`].
+    fn to_label(&self) -> ErrorId {
+        ErrorId::from_display(self)
     }
 }

--- a/crates/nexus/tests/kernel_tests/traits_tests.rs
+++ b/crates/nexus/tests/kernel_tests/traits_tests.rs
@@ -1,8 +1,6 @@
 use nexus::*;
 use std::fmt;
 
-use arrayvec::ArrayString;
-
 // --- Test ID type ---
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 struct TestId(String);
@@ -119,18 +117,48 @@ fn aggregate_state_apply_mutates() {
 }
 
 #[test]
-fn id_to_label_returns_display_as_array_string() {
+fn id_to_label_returns_errorid_verbatim_for_short_id() {
+    // `to_label` now returns the sealed `ErrorId`, not `arrayvec::ArrayString`.
     let id = TestId("order-123".into());
-    let label: ArrayString<64> = id.to_label();
+    let label: ErrorId = id.to_label();
     assert_eq!(label.as_str(), "order-123");
 }
 
 #[test]
-fn id_to_label_truncates_long_ids() {
-    // Create an ID whose Display output exceeds 64 bytes
+fn id_to_label_signals_truncation_with_ellipsis() {
+    // An ID whose Display exceeds 64 bytes is truncated, and — unlike the old
+    // silent `LabelWriter` — the overflow is *signalled* with a trailing `…`.
     let long_name = "x".repeat(100);
     let id = TestId(long_name);
     let label = id.to_label();
-    assert!(label.len() <= 64);
-    assert_eq!(label.len(), 64);
+    assert!(label.len() <= 64, "label must fit the 64-byte cap");
+    assert!(
+        label.as_str().ends_with('…'),
+        "truncation must be visually signalled with `…`, got {:?}",
+        label.as_str()
+    );
+    // The verbatim prefix is preserved up to the cap (minus the marker).
+    assert!(label.as_str().starts_with("xxxx"));
+}
+
+#[test]
+fn id_to_label_truncation_is_utf8_safe_on_multibyte_boundary() {
+    // Defensive boundary (CLAUDE.md rule 7): a multi-byte char straddling the
+    // cap must not panic and must leave the label valid UTF-8. `あ` is 3 bytes,
+    // so the 64-byte cap lands mid-character and forces a boundary backstep.
+    let long_name = "あ".repeat(40); // 120 bytes
+    let id = TestId(long_name);
+    let label = id.to_label();
+    assert!(label.len() <= 64, "label must fit the 64-byte cap");
+    assert!(
+        label.as_str().ends_with('…'),
+        "truncation must be signalled with `…`, got {:?}",
+        label.as_str()
+    );
+    // Every retained char is the intact `あ` (no split code unit) plus the `…`.
+    assert!(
+        label.as_str().chars().all(|c| c == 'あ' || c == '…'),
+        "truncation left a broken/unexpected char: {:?}",
+        label.as_str()
+    );
 }


### PR DESCRIPTION
Final PR (4/4) of #208 — *seal public dependency leaks before the 1.0 freeze*.

## What changed
Retypes `Id::to_label` from `arrayvec::ArrayString<64>` to the sealed `ErrorId` (= `ErrorId<64>`) and collapses its body to a single `ErrorId::from_display(self)`. The bespoke `LabelWriter` + `truncate_at_char_boundary` machinery (and the `arrayvec::ArrayString` / `std::fmt::Write` imports) are deleted — the truncation logic now lives in exactly one place, `error_id.rs`.

Net change: `2 files changed, 44 insertions(+), 45 deletions(-)` — a consolidation, not new surface.

## Breaking change
- `Id::to_label` return type: `arrayvec::ArrayString<64>` → `nexus::ErrorId`.
- **Behaviour on overflow:** the old return *silently* truncated to 64 bytes with no marker; the new one truncates on a char boundary and appends `…` (U+2026), so truncation is now **visually signalled**. Callers that used the result via `Display` / `.as_str()` are unaffected; any that named `ArrayString<64>` must switch to `ErrorId`.

All intentional, pre-1.0-freeze.

## This closes the arrayvec leak
After this PR, `arrayvec` appears in **no public API name** anywhere in the workspace. The sole remaining use is the **private** tuple field of `nexus_store::codec::BytemuckError` (no `pub` on the field, no accessor — does not leak), which is the documented internal-only exception.

So #208's leak-sealing is **complete**, save the separately-tracked fjall independent-versioning follow-up (#221).

## Tests (TDD, CLAUDE.md rule 7)
`crates/nexus/tests/kernel_tests/traits_tests.rs`:
- `id_to_label_returns_errorid_verbatim_for_short_id` — short id → verbatim; binding typed `ErrorId` (sequence/protocol + return-type wiring).
- `id_to_label_signals_truncation_with_ellipsis` — long ASCII id → `len <= 64` and ends with `…` (the behaviour change vs. the old silent truncation).
- `id_to_label_truncation_is_utf8_safe_on_multibyte_boundary` — 3-byte chars straddling the cap: no panic, stays valid UTF-8, every retained char intact + `…` (defensive boundary).

Written red against the current silent `to_label`, then green after the retype. ErrorId's own truncation property stays tested once in `error_id_tests.rs` — these tests cover the `to_label` *wiring*, not duplicate it.

## Verification
- Full `nix flake check` gate: all 6 checks green (clippy, fmt, deny, nextest, doc, hakari).
- `cargo clippy --all-targets -p nexus`: clean.
- `cargo build --workspace`: clean.

Closes #208 (bar deferred #221).

🤖 Generated with [Claude Code](https://claude.com/claude-code)