### PR TITLE
feat(store)!: narrow pub mod wire to the minimal adapter surface (#210)

### DIFF
--- a/crates/nexus-fjall/src/scan.rs
+++ b/crates/nexus-fjall/src/scan.rs
@@ -408,7 +408,12 @@ mod tests {
         // the `event_type` bytes in place (same length) with invalid UTF-8.
         let (k, v) = row(b"user-1", 7, 42, "ABC", b"data");
         let mut raw = v.to_vec();
-        let et_start = crate::wire_key::EVENT_VALUE_HEADER_SIZE;
+        // Derive the event_type start offset from a publicly-decoded
+        // `FrameOffsets` rather than a private wire header-size constant —
+        // `decode_frame` is the adapter-facing read path and already exposes
+        // every offset a decoder needs.
+        let et_start =
+            usize::try_from(wire::decode_frame(&raw).unwrap().offsets.event_type.start).unwrap();
         // 0xFF is never a valid UTF-8 byte; keep the 3-byte length intact.
         raw[et_start] = 0xFF;
         raw[et_start + 1] = 0xFE;

--- a/crates/nexus-fjall/src/wire_key.rs
+++ b/crates/nexus-fjall/src/wire_key.rs
@@ -46,12 +46,6 @@ const EVENT_KEY_VERSION_SIZE: usize = 8;
 /// Size of an encoded stream version value in bytes: `[u64 LE version]`.
 pub const STREAM_VERSION_SIZE: usize = 8;
 
-/// Size of the fixed header in an encoded event value.
-///
-/// Re-exported from [`wire::HEADER_FIXED_SIZE`] for adapter-local tests.
-#[cfg(test)]
-pub const EVENT_VALUE_HEADER_SIZE: usize = wire::HEADER_FIXED_SIZE;
-
 /// Compute the total size of an event key for a given ID length.
 ///
 /// Format: `[u16 BE id_len][id_bytes][u64 BE version]`.
@@ -191,7 +185,7 @@ pub fn decode_stream_version(value: &[u8]) -> Result<u64, DecodeError> {
 ///
 /// All three ranges are valid offsets into the `&Bytes` that was passed
 /// to `decode_event_value`. `metadata_range` is `None` when the encoded
-/// `meta_len` is the [`wire::META_LEN_ABSENT`] sentinel. The payload offset
+/// `meta_len` is the absent sentinel (`u32::MAX`). The payload offset
 /// honors the 16-byte alignment invariant from
 /// [`nexus_store::wire`][wire]. `schema_version` is the typed
 /// [`nexus_store::value::SchemaVersion`] — corrupt on-disk zeros are

--- a/crates/nexus-store/src/wire.rs
+++ b/crates/nexus-store/src/wire.rs
@@ -64,25 +64,25 @@ pub const PAYLOAD_ALIGN: usize = 16;
 ///
 /// Fields: `frame_format_version` (1) + `global_seq` (8) + `schema_version` (4)
 /// + `et_len` (2) + `meta_len` (4) = 19.
-pub const HEADER_FIXED_SIZE: usize = 19;
+pub(crate) const HEADER_FIXED_SIZE: usize = 19;
 
 /// Offset of the `frame_format_version` byte in the frame's header.
-pub const VERSION_OFFSET: usize = 0;
+pub(crate) const VERSION_OFFSET: usize = 0;
 
 /// Offset of the `global_seq` field in the frame's header.
-pub const GLOBAL_SEQ_OFFSET: usize = 1;
+pub(crate) const GLOBAL_SEQ_OFFSET: usize = 1;
 
 /// Offset of the `schema_version` field in the frame's header.
-pub const SCHEMA_VERSION_OFFSET: usize = 9;
+pub(crate) const SCHEMA_VERSION_OFFSET: usize = 9;
 
 /// Offset of the `event_type_len` field in the frame's header.
-pub const EVENT_TYPE_LEN_OFFSET: usize = 13;
+pub(crate) const EVENT_TYPE_LEN_OFFSET: usize = 13;
 
 /// Offset of the `meta_len` field in the frame's header.
-pub const META_LEN_OFFSET: usize = 15;
+pub(crate) const META_LEN_OFFSET: usize = 15;
 
 /// Sentinel `meta_len` value meaning "no metadata field present".
-pub const META_LEN_ABSENT: u32 = u32::MAX;
+pub(crate) const META_LEN_ABSENT: u32 = u32::MAX;
 
 /// Bytes needed after `offset` to reach the next multiple of `align`.
 ///
@@ -101,14 +101,14 @@ const fn align_padding(offset: usize, align: usize) -> usize {
 /// adding the next variant is a compile-error-forcing one-liner here and in
 /// `decode_frame`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum FrameFormatVersion {
+pub(crate) enum FrameFormatVersion {
     /// The original layout: see the module-level diagram.
     V1,
 }
 
 impl FrameFormatVersion {
     /// The version every freshly-encoded frame is stamped with.
-    pub const CURRENT: Self = Self::V1;
+    pub(crate) const CURRENT: Self = Self::V1;
 
     /// On-wire byte for this version.
     #[inline]
@@ -147,32 +147,17 @@ impl FrameFormatVersion {
 /// deserialize as a unit. Use [`FrameHeader::write_into`] from the build
 /// path and [`FrameHeader::read_from`] from the decode path.
 #[derive(Debug, Clone, Copy)]
-pub struct FrameHeader {
-    pub format_version: FrameFormatVersion,
-    pub global_seq: u64,
-    pub schema_version: u32,
+pub(crate) struct FrameHeader {
+    pub(crate) format_version: FrameFormatVersion,
+    pub(crate) global_seq: u64,
+    pub(crate) schema_version: u32,
     event_type_len: u16,
     metadata_len: Option<u32>,
 }
 
 impl FrameHeader {
     /// Header size in bytes. Matches [`HEADER_FIXED_SIZE`].
-    pub const SIZE: usize = HEADER_FIXED_SIZE;
-
-    /// Public view of the event-type length as a `u16`.
-    #[inline]
-    #[must_use]
-    pub const fn event_type_len(&self) -> u16 {
-        self.event_type_len
-    }
-
-    /// Public view of the metadata length as `Option<u32>`. `None` means
-    /// the absent sentinel ([`META_LEN_ABSENT`]) is on the wire.
-    #[inline]
-    #[must_use]
-    pub const fn metadata_len(&self) -> Option<u32> {
-        self.metadata_len
-    }
+    pub(crate) const SIZE: usize = HEADER_FIXED_SIZE;
 
     /// Construct a header from already-validated raw lengths.
     ///
@@ -236,7 +221,7 @@ impl FrameHeader {
     /// - [`DecodeError::ValueTooShort`] if `value.len() < SIZE`.
     /// - [`DecodeError::UnsupportedFrameVersion`] if the leading version byte
     ///   is not a known [`FrameFormatVersion`].
-    pub fn read_from(value: &[u8]) -> Result<Self, DecodeError> {
+    pub(crate) fn read_from(value: &[u8]) -> Result<Self, DecodeError> {
         if value.len() < Self::SIZE {
             return Err(DecodeError::ValueTooShort {
                 min: Self::SIZE,


### PR DESCRIPTION
Closes #210 — a Tier-1 1.0-API-freeze blocker (milestone "1 — Nexus: Pre-Freeze (1.0 blockers)"), sibling of #208 (which sealed `arrayvec`). Same theme: shrink the public surface *before* the freeze makes it permanent.

## Why

`nexus-store/src/lib.rs` does `pub mod wire;`, re-exporting **every** `pub` item in `wire.rs` — including raw byte-offset constants and the internal `FrameHeader` / `FrameFormatVersion` types. Once 1.0 freezes, downstream code could hard-depend on `HEADER_FIXED_SIZE == 19`, the offset values, or the `FrameHeader` field set, turning the **on-disk byte layout into a public SemVer commitment**. That defeats the purpose of the `frame_format_version` byte (#205), whose whole point is that the frame stays *evolvable*. Also resolves a CLAUDE.md rule 4 violation ("internal wire-format helpers must be `pub(crate)`, not `pub`"). An adapter only needs `encode_frame`/`decode_frame` + the result/error types — fjall proves it.

This is a **visibility-only** change. The on-disk bytes are identical before and after.

## Keep public (the adapter contract)

`encode_frame`, `decode_frame`, `EncodedFrame`, `DecodedFrame`, `FrameOffsets`, `WireError`, `DecodeError`, `PAYLOAD_ALIGN`.

## Demoted to `pub(crate)`

- `HEADER_FIXED_SIZE`
- all `*_OFFSET` consts: `VERSION_OFFSET`, `GLOBAL_SEQ_OFFSET`, `SCHEMA_VERSION_OFFSET`, `EVENT_TYPE_LEN_OFFSET`, `META_LEN_OFFSET`
- `META_LEN_ABSENT`
- `FrameFormatVersion` (+ `CURRENT`)
- `FrameHeader` (+ `SIZE`, the `format_version` / `global_seq` / `schema_version` fields, `read_from`)

The unused `FrameHeader::event_type_len` / `metadata_len` accessor methods are **deleted** rather than carried as dead `pub(crate)` code (rule 4 / YAGNI). They were exempt from `dead_code` only because they were `pub`; internal code reads the private fields directly, so demotion would have made them dead. `DecodedFrame` / `EncodedFrame` stay public and expose **no** `FrameHeader` / `FrameFormatVersion` in any field or method, so nothing public references a demoted type.

## fjall consumer fixes

- The only cross-crate use of a demoted item was a `#[cfg(test)]` re-export `EVENT_VALUE_HEADER_SIZE = wire::HEADER_FIXED_SIZE` in `wire_key.rs`, consumed by one `scan.rs` white-box test (`stream_decode_rejects_non_utf8_event_type`). Rewrote that test to derive the event-type start offset from the **public** `decode_frame(..).offsets.event_type.start` and **deleted** the re-export. The test still forges invalid UTF-8 in the event-type bytes and asserts the exact `FjallError::EnvelopeCorrupt { stream_id: "user-1", version: 7 }` — same corruption path, still fails on regression.
- Reworded two fjall intra-doc links (`[\`wire::HEADER_FIXED_SIZE\`]`, `[\`wire::META_LEN_ABSENT\`]`) to plain text so `cargo doc` (the `nexus-doc` gate) stays green once the targets are private.

## Verification

- `nix flake check` (pre-commit hook): all checks ✅ — clippy, **doc**, nextest, fmt, deny, audit, hakari, toml-fmt.
- Hand-run `cargo clippy --all-targets --all-features -p nexus-store -p nexus-fjall`: clean apart from two **pre-existing** `range_plus_one` lints in `wire.rs`'s `#[cfg(test)]` module (lines 906, 1220 — untouched by this PR).
- Grep confirms no crate other than `nexus-store` itself names any demoted `wire` item.

## Breaking change

Several `nexus_store::wire::*` items (`HEADER_FIXED_SIZE`, the `*_OFFSET` constants, `META_LEN_ABSENT`, `FrameFormatVersion`, `FrameHeader`) are no longer reachable from downstream crates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)