### PR TITLE
docs(examples): end-to-end fjall example — persistence + subscription + export/import (#227)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -788,6 +788,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "nexus-example-fjall-end-to-end"
+version = "0.0.0"
+dependencies = [
+ "bytes",
+ "futures",
+ "nexus",
+ "nexus-fjall",
+ "nexus-store",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror",
+ "tokio",
+ "workspace-hack",
+]
+
+[[package]]
 name = "nexus-example-inmemory"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "crates/nexus-store-testing",
     "crates/workspace-hack",
     "examples/closing-the-books",
+    "examples/fjall-end-to-end",
     "examples/inmemory",
     "examples/projection-tokio",
     "examples/store-and-kernel",

--- a/examples/fjall-end-to-end/Cargo.toml
+++ b/examples/fjall-end-to-end/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "nexus-example-fjall-end-to-end"
+version = "0.0.0"
+edition.workspace = true
+publish = false
+
+[dependencies]
+bytes.workspace = true
+futures.workspace = true
+nexus = { path = "../../crates/nexus", features = ["derive"] }
+# json    → built-in JsonCodec + a default-codec `store.repository()`
+# cbor    → the CBOR backup box (implies import + export)
+# subscription → the catch-up + live-tail cursor
+nexus-store = { path = "../../crates/nexus-store", features = [
+    "json",
+    "cbor",
+    "subscription",
+] }
+# export + import → FjallStore's StreamLister + AtomicAppend impls (#220)
+nexus-fjall = { path = "../../crates/nexus-fjall", features = [
+    "export",
+    "import",
+] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tempfile = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = [
+    "macros",
+    "rt-multi-thread",
+    "time",
+    "sync",
+] }
+workspace-hack = { version = "0.1", path = "../../crates/workspace-hack" }
+
+[lints]
+workspace = true

--- a/examples/fjall-end-to-end/README.md
+++ b/examples/fjall-end-to-end/README.md
@@ -1,0 +1,37 @@
+# fjall-end-to-end
+
+The executable proof that the freeze-ready public API **composes** on the real
+persistent adapter. Every other example uses `InMemoryStore`; this one runs the
+complete path on `nexus-fjall`, exercising three surfaces that previously had
+zero example coverage — composed over one bank-account domain.
+
+```bash
+cargo run -p nexus-example-fjall-end-to-end     # narrate the three phases
+cargo test -p nexus-example-fjall-end-to-end    # the gate-checked proofs
+```
+
+## What it proves
+
+1. **Persistence lifecycle** (`run_persistence`) — persist an aggregate to an
+   on-disk `FjallStore` via the typed repository, **close** the keyspace,
+   **reopen** it, and rehydrate. The rehydrated state equals the pre-close
+   state.
+2. **Subscription** (`run_subscription`) — open the catch-up + live-tail cursor,
+   drain existing history, then observe a **genuinely live** append on the same
+   stream (spawned writer + `Barrier`, bounded by a timeout because the cursor
+   never returns `None`). Plus **strict-after resume**: a cursor reopened from
+   `Some(v3)` starts at v4, no redelivery.
+3. **Export / import** (`run_export_import`) — back several streams up through
+   the CBOR box to a **file on disk**, restore into a fresh store, and assert the
+   restored aggregates rehydrate **identical** to the originals. Plus the
+   `Corrupt` (per-block crc) vs `Malformed` (framing) distinction.
+
+The real assertions live in `#[tokio::test]`s (run by the gate's nextest);
+`main.rs` drives the same three functions for a human.
+
+## Ergonomics note (pre-freeze)
+
+`EventStore<S, C>` implements `Repository<A>` for *every* aggregate `A`, so
+`repo.load(id)` can't infer `A` — the inline call sites name it
+(`let acct: AggregateRoot<BankAccount> = repo.load(id).await?`). Tracked in
+#243 (aggregate-bound repository); when that lands, those annotations come out.

--- a/examples/fjall-end-to-end/src/domain.rs
+++ b/examples/fjall-end-to-end/src/domain.rs
@@ -1,0 +1,155 @@
+//! Shared domain for the end-to-end example: a tiny event-sourced bank
+//! account (the same shape as `examples/inmemory`, with `serde` derives added
+//! so the built-in `JsonCodec` can persist it). Reused across all three phases
+//! so the example demonstrates *one* domain flowing through persistence,
+//! subscription, and backup/restore.
+
+use std::fmt;
+
+use nexus::{AggregateState, DomainEvent, Events, Handle, Id, events};
+use serde::{Deserialize, Serialize};
+
+// ── Id ──────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub struct AccountId(pub String);
+
+impl fmt::Display for AccountId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl AsRef<[u8]> for AccountId {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_bytes()
+    }
+}
+
+impl Id for AccountId {
+    const BYTE_LEN: usize = 0;
+}
+
+// ── Events (serde-encodable so the built-in JsonCodec can persist them) ──────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AccountOpened {
+    pub owner: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MoneyDeposited {
+    pub amount: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MoneyWithdrawn {
+    pub amount: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, DomainEvent)]
+pub enum AccountEvent {
+    Opened(AccountOpened),
+    Deposited(MoneyDeposited),
+    Withdrawn(MoneyWithdrawn),
+}
+
+// ── State ───────────────────────────────────────────────────────────────────
+
+/// `PartialEq`/`Eq` so the example can assert round-trip *aggregate equality*
+/// (rehydrated state `==` original) after a reopen or a backup/restore.
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
+pub struct AccountState {
+    pub owner: String,
+    pub balance: u64,
+    pub is_open: bool,
+}
+
+impl AggregateState for AccountState {
+    type Event = AccountEvent;
+
+    fn initial() -> Self {
+        Self::default()
+    }
+
+    fn apply(mut self, event: &AccountEvent) -> Self {
+        match event {
+            AccountEvent::Opened(e) => {
+                self.owner = e.owner.clone();
+                self.is_open = true;
+            }
+            AccountEvent::Deposited(e) => self.balance += e.amount,
+            AccountEvent::Withdrawn(e) => self.balance -= e.amount,
+        }
+        self
+    }
+}
+
+// ── Error ───────────────────────────────────────────────────────────────────
+
+#[derive(Debug, thiserror::Error)]
+pub enum AccountError {
+    #[error("account already open")]
+    AlreadyOpen,
+    #[error("account is closed")]
+    Closed,
+    #[error("insufficient funds: have {balance}, need {amount}")]
+    InsufficientFunds { balance: u64, amount: u64 },
+}
+
+// ── Aggregate marker + commands ─────────────────────────────────────────────
+
+#[nexus::aggregate(state = AccountState, error = AccountError, id = AccountId)]
+pub struct BankAccount;
+
+pub struct OpenAccount {
+    pub owner: String,
+}
+pub struct Deposit {
+    pub amount: u64,
+}
+pub struct Withdraw {
+    pub amount: u64,
+}
+
+impl Handle<OpenAccount> for BankAccount {
+    fn handle(
+        state: &AccountState,
+        cmd: OpenAccount,
+    ) -> Result<Events<AccountEvent>, AccountError> {
+        if state.is_open {
+            return Err(AccountError::AlreadyOpen);
+        }
+        Ok(events![AccountEvent::Opened(AccountOpened {
+            owner: cmd.owner
+        })])
+    }
+}
+
+impl Handle<Deposit> for BankAccount {
+    fn handle(state: &AccountState, cmd: Deposit) -> Result<Events<AccountEvent>, AccountError> {
+        if !state.is_open {
+            return Err(AccountError::Closed);
+        }
+        Ok(events![AccountEvent::Deposited(MoneyDeposited {
+            amount: cmd.amount
+        })])
+    }
+}
+
+impl Handle<Withdraw> for BankAccount {
+    fn handle(state: &AccountState, cmd: Withdraw) -> Result<Events<AccountEvent>, AccountError> {
+        if !state.is_open {
+            return Err(AccountError::Closed);
+        }
+        if state.balance < cmd.amount {
+            return Err(AccountError::InsufficientFunds {
+                balance: state.balance,
+                amount: cmd.amount,
+            });
+        }
+        Ok(events![AccountEvent::Withdrawn(MoneyWithdrawn {
+            amount: cmd.amount
+        })])
+    }
+}

--- a/examples/fjall-end-to-end/src/lib.rs
+++ b/examples/fjall-end-to-end/src/lib.rs
@@ -1,0 +1,479 @@
+//! End-to-end demonstration of the **complete persistent path** on the real
+//! `nexus-fjall` adapter — the three about-to-freeze surfaces that previously
+//! had zero example coverage, composed over one domain:
+//!
+//! 1. **Persistence lifecycle** ([`run_persistence`]) — persist an aggregate to
+//!    a real on-disk `FjallStore` via the typed repository, close the keyspace,
+//!    reopen it, and rehydrate: the state survives the round-trip.
+//! 2. **Subscription** ([`run_subscription`]) — open the catch-up + live-tail
+//!    cursor, drain existing history, then observe a *genuinely live* append on
+//!    the same stream; plus strict-after resume (a reopened cursor does not
+//!    redeliver).
+//! 3. **Export / import** ([`run_export_import`]) — back several streams up
+//!    through the CBOR box to a file on disk, restore into a fresh store, and
+//!    assert the restored aggregates rehydrate **identical** to the originals;
+//!    plus the `Corrupt` (per-block crc) vs `Malformed` (framing) distinction.
+//!
+//! The proofs live in `#[tokio::test]`s (run by the gate's nextest); `main.rs`
+//! drives the same three functions for a human. Nothing here touches a
+//! production crate — it is a consumer of the frozen public API, which doubles
+//! as a last-chance ergonomics review of those surfaces.
+//!
+//! ## Ergonomics finding (pre-freeze)
+//!
+//! `EventStore<S, C>` implements `Repository<A>` for **every** aggregate `A`,
+//! so `repo.load(id)` cannot infer `A` from `id` alone (`A::Id == AccountId`
+//! does not pin `A`). At a bare `EventStore` call site you must name the
+//! aggregate — `let acct: AggregateRoot<BankAccount> = repo.load(id).await?`.
+//! Inside an `A`-bounded function (`seed_account`) the bound supplies it and
+//! the call is clean. A per-aggregate builder (e.g. `store.repository::<A>()`)
+//! that returns a repository bound to one `A` would remove the annotation
+//! entirely. Tracked in #243 (aggregate-bound repository); when it lands, the
+//! `AggregateRoot<BankAccount>` annotations at the inline call sites come out.
+
+// Example code relaxes a handful of strict lints locally (production crates do
+// NOT) — same posture as `examples/closing-the-books` and `examples/inmemory`.
+#![allow(
+    clippy::missing_errors_doc,
+    clippy::missing_panics_doc,
+    reason = "example: error/panic conditions are obvious from the narrative"
+)]
+#![allow(
+    clippy::too_long_first_doc_paragraph,
+    reason = "example: narrative doc comments lead with a full sentence"
+)]
+#![allow(
+    clippy::expect_used,
+    reason = "example: expect documents an assumption inside the spawned writer"
+)]
+#![allow(
+    clippy::shadow_reuse,
+    clippy::shadow_unrelated,
+    reason = "example: shadowing `decided`/`repo` reads clearly here"
+)]
+#![allow(
+    clippy::assigning_clones,
+    reason = "example: clarity over the clone_into micro-optimization"
+)]
+#![allow(
+    clippy::result_large_err,
+    reason = "example surfaces the adapter's own (large) error type directly"
+)]
+
+pub mod domain;
+
+use std::path::Path;
+use std::time::Duration;
+
+use futures::StreamExt;
+use nexus::{AggregateRoot, Version};
+use nexus_fjall::FjallStore;
+use nexus_store::cbor::{decode_chunk, encode_block, encode_header, encode_section_heading};
+use nexus_store::export::{EventExporter, StreamLister};
+use nexus_store::import::{Atomicity, EventImporter, StreamOutcome};
+use nexus_store::repository::Repository;
+use nexus_store::store::Store;
+use nexus_store::{PersistedEnvelope, Subscription};
+
+use domain::{AccountEvent, AccountId, AccountState, BankAccount, Deposit, OpenAccount, Withdraw};
+
+/// One boxed error domain for the example (every underlying error —
+/// `FjallError`, the repository error, `ChunkError`, `ImportError`, `io::Error`
+/// — is `Error + Send + Sync`, so `?` folds them all into this).
+type BoxErr = Box<dyn std::error::Error + Send + Sync>;
+
+/// Open a `FjallStore` at `path` and wrap it in a `Store` handle (the shared,
+/// `Arc`-backed entry point that both the repository builder and the
+/// subscription consume).
+fn open(path: &Path) -> Result<Store<FjallStore>, BoxErr> {
+    Ok(Store::new(FjallStore::builder(path).open()?))
+}
+
+/// Open an account and apply a series of deposits via the typed repository,
+/// returning the resulting in-memory state. Generic over any `Repository` for
+/// the account aggregate — and *because* of that `Repository<BankAccount>`
+/// bound, `repo.load(id)` resolves cleanly here with no annotation. (The
+/// friction surfaces only at the bare `EventStore` call sites below, where the
+/// aggregate isn't pinned — see the module-level note.)
+async fn seed_account<R: Repository<BankAccount>>(
+    repo: &R,
+    id: &AccountId,
+    owner: &str,
+    deposits: &[u64],
+) -> Result<AccountState, BoxErr> {
+    let mut account = repo.load(id.clone()).await?;
+    let decided = account.handle(OpenAccount {
+        owner: owner.to_owned(),
+    })?;
+    repo.save(&mut account, &decided).await?;
+    for &amount in deposits {
+        let decided = account.handle(Deposit { amount })?;
+        repo.save(&mut account, &decided).await?;
+    }
+    Ok(account.state().clone())
+}
+
+/// Fold a raw subscription envelope's payload into a running balance — the
+/// "consumer holds the codec" model: `Subscription` yields raw
+/// [`PersistedEnvelope`]s, the consumer decodes them.
+fn fold_balance(balance: u64, env: &PersistedEnvelope) -> Result<u64, BoxErr> {
+    let event: AccountEvent = serde_json::from_slice(env.payload())?;
+    Ok(match event {
+        AccountEvent::Opened(_) => balance,
+        AccountEvent::Deposited(d) => balance + d.amount,
+        AccountEvent::Withdrawn(w) => balance - w.amount,
+    })
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Phase 1 — persistence lifecycle: write → close → reopen → rehydrate
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Persist an account, **close** the keyspace, **reopen** it, and rehydrate.
+/// Returns `(before_close, after_reopen)` states; they must be equal.
+pub async fn run_persistence(path: &Path) -> Result<(AccountState, AccountState), BoxErr> {
+    let id = AccountId("alice".to_owned());
+
+    // Scope the first store so it (and its Arc) drops at block end, closing and
+    // flushing the keyspace before we reopen the same path.
+    let before = {
+        let store = open(path)?;
+        let repo = store.repository().build();
+        seed_account(&repo, &id, "Alice", &[1_000, 500]).await?;
+        // One more command so the persisted stream isn't trivial. The annotation
+        // pins the aggregate: `EventStore` is `Repository<A>` for *every* `A`, so
+        // `repo.load(id)` is ambiguous until the bound is named (see module note).
+        let mut account: AggregateRoot<BankAccount> = repo.load(id.clone()).await?;
+        let decided = account.handle(Withdraw { amount: 300 })?;
+        repo.save(&mut account, &decided).await?;
+        account.state().clone()
+    };
+
+    // Reopen from scratch and rehydrate purely from the on-disk event log.
+    let store = open(path)?;
+    let repo = store.repository().build();
+    let reopened: AggregateRoot<BankAccount> = repo.load(id).await?;
+    let after = reopened.state().clone();
+
+    Ok((before, after))
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Phase 2 — subscription: catch-up then a genuinely live tail
+// ════════════════════════════════════════════════════════════════════════════
+
+/// What the subscription phase observed, for the test to assert on.
+#[derive(Debug)]
+pub struct SubscriptionOutcome {
+    /// Versions seen during catch-up over existing history.
+    pub catchup_versions: Vec<u64>,
+    /// Read-model balance after folding the catch-up prefix.
+    pub catchup_balance: u64,
+    /// Version of the event observed *live* on the tail (appended after
+    /// catch-up drained).
+    pub live_version: u64,
+    /// Read-model balance after folding the live event.
+    pub live_balance: u64,
+    /// First version a fresh `subscribe(_, Some(v3))` delivers — must be 4, not
+    /// 1 (strict-after resume: no redelivery).
+    pub resumed_first_version: u64,
+}
+
+/// Open a subscription, drain catch-up history, observe a live append, and
+/// demonstrate strict-after resume.
+pub async fn run_subscription(path: &Path) -> Result<SubscriptionOutcome, BoxErr> {
+    let store = open(path)?;
+    let repo = store.repository().build();
+    let id = AccountId("alice".to_owned());
+
+    // Seed exactly three events (open + 2 deposits → v1, v2, v3).
+    seed_account(&repo, &id, "Alice", &[1_000, 500]).await?;
+
+    let subscription = Subscription::new(&store);
+
+    // Catch-up: the cursor never returns `None`, and we seeded a known count,
+    // so drain exactly three. The stream is `!Unpin` → pin before polling.
+    let stream = subscription.subscribe(&id, None)?;
+    tokio::pin!(stream);
+    let mut catchup_versions = Vec::new();
+    let mut balance = 0u64;
+    for _ in 0..3 {
+        let env = stream
+            .next()
+            .await
+            .ok_or("subscription closed during catch-up")??;
+        catchup_versions.push(env.version().as_u64());
+        balance = fold_balance(balance, &env)?;
+    }
+    let catchup_balance = balance;
+
+    // Live tail: a separate task appends a NEW event (v4) after a barrier
+    // rendezvous; the same parked cursor must observe it.
+    let writer_store = store.clone();
+    let writer_id = id.clone();
+    let barrier = std::sync::Arc::new(tokio::sync::Barrier::new(2));
+    let writer_barrier = std::sync::Arc::clone(&barrier);
+    let writer = tokio::spawn(async move {
+        let repo = writer_store.repository().build();
+        writer_barrier.wait().await;
+        let mut account: AggregateRoot<BankAccount> =
+            repo.load(writer_id).await.expect("load for live append");
+        let decided = account
+            .handle(Deposit { amount: 250 })
+            .expect("live deposit decides");
+        repo.save(&mut account, &decided)
+            .await
+            .expect("live append persists");
+    });
+
+    barrier.wait().await;
+    // Bound the live observation with a timeout — the cursor would otherwise
+    // park forever waiting for the next event.
+    let env = timeout_next(&mut stream, "live tail").await?;
+    let live_version = env.version().as_u64();
+    let live_balance = fold_balance(balance, &env)?;
+    writer
+        .await
+        .map_err(|e| format!("writer task panicked: {e}"))?;
+
+    // Strict-after resume: a fresh cursor from Some(v3) must begin at v4.
+    let v3 = Version::new(3).ok_or("v3 is nonzero")?;
+    let resume = subscription.subscribe(&id, Some(v3))?;
+    tokio::pin!(resume);
+    let first = timeout_next(&mut resume, "resume").await?;
+    let resumed_first_version = first.version().as_u64();
+
+    Ok(SubscriptionOutcome {
+        catchup_versions,
+        catchup_balance,
+        live_version,
+        live_balance,
+        resumed_first_version,
+    })
+}
+
+/// Poll the next item from a never-`None` subscription stream, bounded by a
+/// timeout so a stuck tail fails the example rather than hanging it.
+async fn timeout_next<S>(stream: &mut S, what: &str) -> Result<PersistedEnvelope, BoxErr>
+where
+    S: futures::Stream<Item = Result<PersistedEnvelope, nexus_fjall::FjallError>> + Unpin,
+{
+    let item = tokio::time::timeout(Duration::from_secs(5), stream.next())
+        .await
+        .map_err(|_| format!("timed out waiting for {what} event"))?
+        .ok_or_else(|| format!("subscription closed during {what}"))?;
+    Ok(item?)
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Phase 3 — export → CBOR box → file → import, round-trip aggregate equality
+// ════════════════════════════════════════════════════════════════════════════
+
+/// One account's id + final state, for round-trip comparison.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AccountSummary {
+    pub id: String,
+    pub state: AccountState,
+}
+
+/// What the export/import phase produced.
+#[derive(Debug)]
+pub struct RoundTripOutcome {
+    /// Source aggregates (id + final state), in id order.
+    pub originals: Vec<AccountSummary>,
+    /// Restored aggregates after backup → restore, in the same order.
+    pub restored: Vec<AccountSummary>,
+    /// Per-stream outcome of importing a chunk with one corrupted block.
+    pub corrupt_outcome: StreamOutcome,
+    /// Whether unparseable framing surfaced as `ChunkError::Malformed`.
+    pub malformed_detected: bool,
+}
+
+/// Map a section's origin id bytes back to the same target id (the ids are
+/// UTF-8 account names).
+fn identity_route(origin: &[u8]) -> AccountId {
+    AccountId(String::from_utf8_lossy(origin).into_owned())
+}
+
+/// Build a CBOR backup chunk from every stream in `store`, via the store's own
+/// `list_streams` + `export_stream` — the production export path. Streams are
+/// sorted for a deterministic layout.
+async fn build_chunk(store: &FjallStore) -> Result<Vec<u8>, BoxErr> {
+    let mut ids: Vec<Vec<u8>> = store
+        .list_streams()
+        .await?
+        .map(|r| r.map(|b| b.to_vec()))
+        .collect::<Vec<_>>()
+        .await
+        .into_iter()
+        .collect::<Result<_, _>>()?;
+    ids.sort();
+
+    let mut chunk = Vec::new();
+    chunk.extend_from_slice(&encode_header(None)?);
+    for id_bytes in ids {
+        chunk.extend_from_slice(&encode_section_heading(&id_bytes)?);
+        let mut events = store
+            .export_stream(&identity_route(&id_bytes), Version::INITIAL)
+            .await?;
+        while let Some(item) = events.next().await {
+            chunk.extend_from_slice(&encode_block(&item?)?);
+        }
+    }
+    Ok(chunk)
+}
+
+/// Populate several streams, back them up to a file, restore into a fresh
+/// store, and prove the restored aggregates rehydrate identical to the
+/// originals. Also exercises the `Corrupt` vs `Malformed` distinction.
+///
+/// `work_dir` holds the three keyspaces (`src`, `dst`, `probe`) and the backup
+/// file (`backup.nxch`).
+pub async fn run_export_import(work_dir: &Path) -> Result<RoundTripOutcome, BoxErr> {
+    // 1. Populate several streams in the source store.
+    let src = open(&work_dir.join("src"))?;
+    let src_repo = src.repository().build();
+    let specs: [(&str, &str, &[u64]); 3] = [
+        ("alice", "Alice", &[1_000, 500]),
+        ("bob", "Bob", &[200]),
+        ("carol", "Carol", &[50, 50, 50]),
+    ];
+    let mut originals = Vec::new();
+    for (id, owner, deposits) in specs {
+        let account_id = AccountId(id.to_owned());
+        let state = seed_account(&src_repo, &account_id, owner, deposits).await?;
+        originals.push(AccountSummary {
+            id: id.to_owned(),
+            state,
+        });
+    }
+
+    // 2. Export every stream through the CBOR box to a real file on disk.
+    let chunk = build_chunk(src.raw()).await?;
+    let chunk_path = work_dir.join("backup.nxch");
+    std::fs::write(&chunk_path, &chunk)?;
+
+    // 3. Reopen the file, decode it, and import into a FRESH store.
+    let sections = decode_chunk(&std::fs::read(&chunk_path)?)?;
+    let dst = open(&work_dir.join("dst"))?;
+    dst.raw()
+        .import(&sections, identity_route, Atomicity::WholeChunk)
+        .await?;
+
+    // 4. Rehydrate each aggregate from the destination and compare to source.
+    let dst_repo = dst.repository().build();
+    let mut restored = Vec::new();
+    for summary in &originals {
+        let restored_root: AggregateRoot<BankAccount> =
+            dst_repo.load(AccountId(summary.id.clone())).await?;
+        let state = restored_root.state().clone();
+        restored.push(AccountSummary {
+            id: summary.id.clone(),
+            state,
+        });
+    }
+
+    // 5a. Corrupt one block's body (flip the last byte → its crc no longer
+    //     matches). Framing still parses, so the bad block decodes to
+    //     `ImportBlock::Corrupt`; a per-stream import halts that stream's good
+    //     prefix → `StreamOutcome::Corrupt`.
+    let mut corrupted = chunk;
+    let last = corrupted.len() - 1;
+    corrupted[last] ^= 0xFF;
+    let corrupt_sections = decode_chunk(&corrupted)?;
+    let probe = open(&work_dir.join("probe"))?;
+    let report = probe
+        .raw()
+        .import(&corrupt_sections, identity_route, Atomicity::PerStream)
+        .await?;
+    let corrupt_outcome = report
+        .streams()
+        .iter()
+        .map(|s| s.outcome)
+        .find(|o| !o.is_complete())
+        .ok_or("expected one corrupted stream in the report")?;
+
+    // 5b. Unparseable framing is a *decode* error, a distinct failure domain.
+    let malformed_detected = matches!(
+        decode_chunk(b"not a valid nxch chunk"),
+        Err(nexus_store::cbor::ChunkError::Malformed(_))
+    );
+
+    Ok(RoundTripOutcome {
+        originals,
+        restored,
+        corrupt_outcome,
+        malformed_detected,
+    })
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Tests — the gate's nextest runs these (the real proofs).
+// ════════════════════════════════════════════════════════════════════════════
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn persistence_survives_close_and_reopen() -> Result<(), BoxErr> {
+        let dir = tempfile::tempdir()?;
+        let (before, after) = run_persistence(&dir.path().join("db")).await?;
+
+        // 1000 + 500 - 300 = 1200, and the rehydrated state is identical.
+        assert_eq!(before.balance, 1_200);
+        assert_eq!(before.owner, "Alice");
+        assert!(before.is_open);
+        assert_eq!(
+            before, after,
+            "rehydrated state must equal the pre-close state",
+        );
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn subscription_catches_up_then_tails_a_live_append() -> Result<(), BoxErr> {
+        let dir = tempfile::tempdir()?;
+        let outcome = run_subscription(&dir.path().join("db")).await?;
+
+        // Catch-up replayed exactly the seeded history.
+        assert_eq!(outcome.catchup_versions, vec![1, 2, 3]);
+        assert_eq!(outcome.catchup_balance, 1_500);
+        // The live append (v4, +250) was observed on the tail, not in catch-up.
+        assert_eq!(outcome.live_version, 4);
+        assert_eq!(outcome.live_balance, 1_750);
+        // Strict-after resume from v3 begins at v4 — no redelivery of 1..3.
+        assert_eq!(outcome.resumed_first_version, 4);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn export_import_round_trip_rehydrates_identical_aggregates() -> Result<(), BoxErr> {
+        let dir = tempfile::tempdir()?;
+        let outcome = run_export_import(dir.path()).await?;
+
+        // Round-trip aggregate equality: restored == originals, in order.
+        assert_eq!(
+            outcome.restored, outcome.originals,
+            "restored aggregates must rehydrate identical to the originals",
+        );
+        // Three distinct accounts actually made the trip.
+        assert_eq!(outcome.originals.len(), 3);
+        assert_eq!(outcome.originals[0].state.balance, 1_500); // alice
+        assert_eq!(outcome.originals[1].state.balance, 200); // bob
+        assert_eq!(outcome.originals[2].state.balance, 150); // carol
+
+        // Corruption distinctions: a crc-failed block halts its stream (Corrupt,
+        // carrying the good prefix), while bad framing is Malformed.
+        assert!(
+            matches!(outcome.corrupt_outcome, StreamOutcome::Corrupt { .. }),
+            "a crc-failed block must surface as StreamOutcome::Corrupt, got {:?}",
+            outcome.corrupt_outcome,
+        );
+        assert!(
+            outcome.malformed_detected,
+            "unparseable framing must surface as ChunkError::Malformed",
+        );
+        Ok(())
+    }
+}

--- a/examples/fjall-end-to-end/src/main.rs
+++ b/examples/fjall-end-to-end/src/main.rs
@@ -1,0 +1,58 @@
+//! Runnable narration of the three end-to-end phases. The real, gate-checked
+//! proofs are the `#[tokio::test]`s in `lib.rs`; this binary just drives the
+//! same three functions for a human and prints what each one observed.
+//!
+//! Run with: `cargo run -p nexus-example-fjall-end-to-end`
+
+#![allow(clippy::print_stdout, reason = "example narrates progress to stdout")]
+
+use nexus_example_fjall_end_to_end::{run_export_import, run_persistence, run_subscription};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let dir = tempfile::tempdir()?;
+
+    println!("=== Phase 1: persistence lifecycle (write → close → reopen → rehydrate) ===");
+    let (before, after) = run_persistence(&dir.path().join("persist")).await?;
+    println!("  before close: {before:?}");
+    println!("  after reopen: {after:?}");
+    println!("  state survived the round-trip: {}", before == after);
+
+    println!("\n=== Phase 2: subscription (catch-up → live tail) ===");
+    let sub = run_subscription(&dir.path().join("subscribe")).await?;
+    println!(
+        "  catch-up versions {:?} → balance {}",
+        sub.catchup_versions, sub.catchup_balance
+    );
+    println!(
+        "  observed a LIVE append: v{} → balance {}",
+        sub.live_version, sub.live_balance
+    );
+    println!(
+        "  strict-after resume from v3 began at v{} (no redelivery)",
+        sub.resumed_first_version
+    );
+
+    println!("\n=== Phase 3: export → CBOR box → file → import (round-trip) ===");
+    let round_trip = run_export_import(&dir.path().join("backup")).await?;
+    for (original, restored) in round_trip.originals.iter().zip(&round_trip.restored) {
+        println!(
+            "  {}: balance {} → restored {} ({})",
+            original.id,
+            original.state.balance,
+            restored.state.balance,
+            if original == restored {
+                "identical"
+            } else {
+                "DIFFERS!"
+            },
+        );
+    }
+    println!(
+        "  corruption surfaced as {:?}; malformed framing detected: {}",
+        round_trip.corrupt_outcome, round_trip.malformed_detected
+    );
+
+    println!("\nDone — fjall persistence + live subscription + export/import all demonstrated.");
+    Ok(())
+}


### PR DESCRIPTION
Closes #227.

Every example used `InMemoryStore`; three about-to-freeze surfaces had zero example coverage. This adds a single capstone example crate (`examples/fjall-end-to-end`) that runs the **complete persistent path** on the real `nexus-fjall` adapter, composed over one bank-account domain. Proofs are `#[tokio::test]`s (the gate's nextest runs them); `main.rs` narrates the same phases for a human. No production crate is touched.

## Three phases

- **`run_persistence`** — persist via the typed repository → close the keyspace → reopen → rehydrate; rehydrated state `==` pre-close state.
- **`run_subscription`** — catch-up over history, then observe a **genuinely live** append on the same stream (spawned writer + `Barrier`, bounded by a timeout since the cursor never returns `None`); plus strict-after resume (reopen from `Some(v3)` starts at v4, no redelivery).
- **`run_export_import`** — back several streams up through the CBOR box to a **file on disk**, restore into a fresh store, assert restored aggregates rehydrate **identical** to the originals; plus `Corrupt` (per-block crc) vs `Malformed` (framing).

## Ergonomics review (the example's real second job)

Per the issue, a last-chance ergonomics pass on the freeze surface. It surfaced **13 warts**, each filed as a self-contained research card in the Pre-Freeze milestone (#243–#255). Several example helpers are deliberate **canaries** — each deletes when its card lands: #243 (load annotations), #244 (`open`), #245 (`identity_route`), #246 (`build_chunk`), #247, #248, #249 (`fold_balance`), #250 (`timeout_next`), #251, #252, #253, #254, #255.

🤖 Generated with [Claude Code](https://claude.com/claude-code)