### PR TITLE
feat(store)!: stream-id byte/typed boundary — concrete StreamKey at the raw layer (#245)

### DIFF
--- a/crates/nexus-fjall/benches/fjall_benchmarks.rs
+++ b/crates/nexus-fjall/benches/fjall_benchmarks.rs
@@ -11,11 +11,11 @@ use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_m
 use futures::StreamExt;
 use nexus::Version;
 use nexus_fjall::FjallStore;
+use nexus_store::StreamKey;
 use nexus_store::envelope::pending_envelope;
 use nexus_store::store::RawEventStore;
 use nexus_store::value::{EventType, Payload, SchemaVersion};
 use nexus_store::wire;
-use std::fmt;
 use tempfile::TempDir;
 use tokio::runtime::Runtime;
 
@@ -23,23 +23,8 @@ use tokio::runtime::Runtime;
 // Helpers
 // ---------------------------------------------------------------------------
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
-struct BenchId(String);
-impl fmt::Display for BenchId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.0)
-    }
-}
-impl AsRef<[u8]> for BenchId {
-    fn as_ref(&self) -> &[u8] {
-        self.0.as_bytes()
-    }
-}
-impl nexus::Id for BenchId {
-    const BYTE_LEN: usize = 0;
-}
-fn bid(s: &str) -> BenchId {
-    BenchId(s.to_owned())
+fn sk(s: &str) -> StreamKey {
+    StreamKey::from_slice(s.as_bytes())
 }
 
 fn make_envelope(version: u64, payload: &[u8]) -> nexus_store::PendingEnvelope {
@@ -160,7 +145,7 @@ fn append_batch_throughput(c: &mut Criterion) {
                 |(store, _dir, envs)| {
                     rt.block_on(async {
                         store
-                            .append(&bid("bench-stream"), None, &envs)
+                            .append(&sk("bench-stream"), None, &envs)
                             .await
                             .unwrap();
                     });
@@ -191,7 +176,7 @@ fn append_sequential_throughput(c: &mut Criterion) {
                         let env = make_envelope(v, &event_payload);
                         let expected = if v == 1 { None } else { Version::new(v - 1) };
                         store
-                            .append(&bid("bench-stream"), expected, &[env])
+                            .append(&sk("bench-stream"), expected, &[env])
                             .await
                             .unwrap();
                     }
@@ -219,7 +204,7 @@ fn read_throughput(c: &mut Criterion) {
             let envs = make_envelopes(count, &event_payload);
             rt.block_on(async {
                 store
-                    .append(&bid("bench-stream"), None, &envs)
+                    .append(&sk("bench-stream"), None, &envs)
                     .await
                     .unwrap();
             });
@@ -227,7 +212,7 @@ fn read_throughput(c: &mut Criterion) {
             b.iter(|| {
                 rt.block_on(async {
                     let mut stream = store
-                        .read_stream(&bid("bench-stream"), Version::INITIAL)
+                        .read_stream(&sk("bench-stream"), Version::INITIAL)
                         .await
                         .unwrap();
                     while let Some(item) = stream.next().await {
@@ -274,7 +259,8 @@ fn lifecycle_benchmarks(c: &mut Criterion) {
                             let store = FjallStore::builder(&db_path).open().unwrap();
                             rt.block_on(async {
                                 for i in 0..stream_count {
-                                    let id = BenchId(format!("stream-{i}"));
+                                    let id =
+                                        StreamKey::from_slice(format!("stream-{i}").as_bytes());
                                     let env = make_envelope(1, &event_payload);
                                     store.append(&id, None, &[env]).await.unwrap();
                                 }

--- a/crates/nexus-fjall/src/scan.rs
+++ b/crates/nexus-fjall/src/scan.rs
@@ -229,8 +229,9 @@ impl<S: ScanStrategy + Unpin> futures::Stream for ScanCursor<S> {
 mod tests {
     use super::*;
     use crate::store::FjallStore;
-    use crate::store::read_test_helpers::{Tid, temp_store, tid};
+    use crate::store::read_test_helpers::{sk, temp_store};
     use futures::StreamExt;
+    use nexus_store::StreamKey;
     use nexus_store::envelope::pending_envelope;
     use nexus_store::store::RawEventStore;
     use nexus_store::value::{EventType, Payload, SchemaVersion};
@@ -252,7 +253,7 @@ mod tests {
 
     async fn append_versions(
         store: &FjallStore,
-        id: &Tid,
+        id: &StreamKey,
         versions: std::ops::RangeInclusive<u64>,
     ) {
         for v in versions {
@@ -268,7 +269,7 @@ mod tests {
     #[tokio::test]
     async fn scan_cursor_yields_rows_in_order() {
         let (store, _dir) = temp_store();
-        let id = tid("s");
+        let id = sk("s");
         append_versions(&store, &id, 1..=3).await;
 
         let cursor = ScanCursor::open(
@@ -291,7 +292,7 @@ mod tests {
     #[tokio::test]
     async fn scan_cursor_opens_from_midpoint() {
         let (store, _dir) = temp_store();
-        let id = tid("s");
+        let id = sk("s");
         append_versions(&store, &id, 1..=5).await;
 
         let cursor = ScanCursor::open(
@@ -314,8 +315,8 @@ mod tests {
     #[tokio::test]
     async fn scan_cursor_global_yields_ascending_global_seq() {
         let (store, _dir) = temp_store();
-        let a = tid("a");
-        let b = tid("b");
+        let a = sk("a");
+        let b = sk("b");
 
         // Interleave appends across two streams so global_seq order differs
         // from per-stream version order.
@@ -341,26 +342,10 @@ mod tests {
         }
     }
 
-    /// A minimal [`nexus::Id`] over borrowed bytes, used only to feed
+    /// A [`StreamKey`] over borrowed bytes, used only to feed
     /// [`OwnedStreamId::from_id`] in tests.
-    fn label_id(bytes: &[u8]) -> TestId {
-        TestId(bytes.to_vec())
-    }
-
-    #[derive(Debug, Clone, Hash, PartialEq, Eq)]
-    struct TestId(Vec<u8>);
-    impl std::fmt::Display for TestId {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            write!(f, "{}", String::from_utf8_lossy(&self.0))
-        }
-    }
-    impl AsRef<[u8]> for TestId {
-        fn as_ref(&self) -> &[u8] {
-            &self.0
-        }
-    }
-    impl nexus::Id for TestId {
-        const BYTE_LEN: usize = 0;
+    fn label_id(bytes: &[u8]) -> StreamKey {
+        StreamKey::from_slice(bytes)
     }
 
     fn row(id: &[u8], version: u64, global_seq: u64, et: &str, payload: &[u8]) -> (Slice, Slice) {

--- a/crates/nexus-fjall/src/store.rs
+++ b/crates/nexus-fjall/src/store.rs
@@ -6,8 +6,9 @@ use crate::wire_key::{
     decode_stream_version, encode_event_key, encode_global_key, encode_stream_version,
 };
 use fjall::{Readable, Slice};
-use nexus::{ErrorId, Id, Version};
+use nexus::{ErrorId, Version};
 use nexus_store::PendingEnvelope;
+use nexus_store::StreamKey;
 use nexus_store::error::AppendError;
 use nexus_store::notify::{NotifyError, StreamNotifiers, WakeReg};
 use nexus_store::store::{GlobalSeq, RawEventStore};
@@ -68,7 +69,7 @@ impl FjallStore {
     fn read_version_raw(
         &self,
         tx: &fjall::SingleWriterWriteTx<'_>,
-        id: &impl Id,
+        id: &StreamKey,
     ) -> Result<u64, FjallError> {
         tx.get(&self.streams, id.as_ref())
             .map_err(FjallError::Io)?
@@ -84,7 +85,7 @@ impl FjallStore {
     fn read_current_version(
         &self,
         tx: &fjall::SingleWriterWriteTx<'_>,
-        id: &impl Id,
+        id: &StreamKey,
     ) -> Result<u64, AppendError<FjallError>> {
         self.read_version_raw(tx, id).map_err(AppendError::Store)
     }
@@ -95,7 +96,7 @@ impl FjallStore {
     fn check_optimistic(
         current: u64,
         expected: Option<Version>,
-        id: &impl Id,
+        id: &StreamKey,
     ) -> Result<(), AppendError<FjallError>> {
         if current == 0 {
             // New stream: expected_version must be None.
@@ -127,7 +128,7 @@ impl FjallStore {
     fn read_global_raw(
         &self,
         tx: &fjall::SingleWriterWriteTx<'_>,
-        id: &impl Id,
+        id: &StreamKey,
     ) -> Result<u64, FjallError> {
         tx.get(&self.global, GLOBAL_SEQ_KEY)
             .map_err(FjallError::Io)?
@@ -148,7 +149,7 @@ impl FjallStore {
     fn read_current_global(
         &self,
         tx: &fjall::SingleWriterWriteTx<'_>,
-        id: &impl Id,
+        id: &StreamKey,
     ) -> Result<u64, AppendError<FjallError>> {
         self.read_global_raw(tx, id).map_err(AppendError::Store)
     }
@@ -165,7 +166,7 @@ impl RawEventStore for FjallStore {
     )]
     async fn append(
         &self,
-        id: &impl Id,
+        id: &StreamKey,
         expected_version: Option<Version>,
         envelopes: &[PendingEnvelope],
     ) -> Result<(), AppendError<Self::Error>> {
@@ -278,7 +279,11 @@ impl RawEventStore for FjallStore {
         Ok(())
     }
 
-    async fn read_stream(&self, id: &impl Id, from: Version) -> Result<Self::Stream, Self::Error> {
+    async fn read_stream(
+        &self,
+        id: &StreamKey,
+        from: Version,
+    ) -> Result<Self::Stream, Self::Error> {
         // A single bounded range scan; a nonexistent stream simply yields an
         // empty range, so no separate existence check is needed.
         ScanCursor::open(
@@ -302,8 +307,9 @@ impl RawEventStore for FjallStore {
 
 #[cfg(feature = "snapshot")]
 mod snapshot_impl {
-    use super::{ErrorId, FjallError, FjallStore, Id, Version};
+    use super::{ErrorId, FjallError, FjallStore, Version};
     use crate::snapshot::{decode_snapshot_value, encode_snapshot_value};
+    use nexus::Id;
     use nexus_store::state::SnapshotStore;
     use std::num::NonZeroU32;
 
@@ -371,8 +377,8 @@ mod snapshot_impl {
 #[cfg(feature = "import")]
 mod atomic_append_impl {
     use super::{
-        ErrorId, FjallError, FjallStore, GLOBAL_SEQ_KEY, Id, Slice, Version, encode_event_key,
-        encode_global_key, encode_stream_version, reason_label, wire,
+        ErrorId, FjallError, FjallStore, GLOBAL_SEQ_KEY, Slice, StreamKey, Version,
+        encode_event_key, encode_global_key, encode_stream_version, reason_label, wire,
     };
     use nexus_store::import::{AtomicAppend, AtomicAppendError, PlannedAppend};
     use std::collections::HashMap;
@@ -384,8 +390,8 @@ mod atomic_append_impl {
     /// concrete error type so both `encode_event_key`'s `EncodeError` and
     /// `wire::encode_frame`'s `WireError` flow through one site (rule 3 — keep
     /// the source's structured detail rather than collapsing it).
-    fn invalid_input<I: Id, E: std::fmt::Display>(
-        target: &I,
+    fn invalid_input<E: std::fmt::Display>(
+        target: &StreamKey,
         version: u64,
         source: &E,
     ) -> AtomicAppendError<FjallError> {
@@ -403,10 +409,10 @@ mod atomic_append_impl {
         /// stream) conflict here instead of concatenating into a corrupt,
         /// non-monotonic stream (`AtomicAppend` distinct-targets contract). The
         /// projected head is keyed by raw id bytes — ids need not be UTF-8.
-        fn validate_atomic_writes<I: Id>(
+        fn validate_atomic_writes(
             &self,
             tx: &Tx<'_>,
-            writes: &[PlannedAppend<I>],
+            writes: &[PlannedAppend],
         ) -> Result<(), AtomicAppendError<FjallError>> {
             let mut projected: HashMap<Vec<u8>, u64> = HashMap::with_capacity(writes.len());
             for (index, w) in writes.iter().enumerate() {
@@ -454,10 +460,10 @@ mod atomic_append_impl {
         /// running counter shared across all streams (monotonic; gaps
         /// permitted). `writes` is non-empty (the caller returns early on
         /// empty), so `writes[0]` labels a corrupt global-counter error.
-        fn write_atomic_runs<I: Id>(
+        fn write_atomic_runs(
             &self,
             tx: &mut Tx<'_>,
-            writes: &[PlannedAppend<I>],
+            writes: &[PlannedAppend],
         ) -> Result<(), AtomicAppendError<FjallError>> {
             let current_global = self
                 .read_global_raw(tx, &writes[0].target)
@@ -511,9 +517,9 @@ mod atomic_append_impl {
             clippy::significant_drop_tightening,
             reason = "the single write_tx is held across validation + every insert + commit so the whole batch is one atomic transaction (rule 1)"
         )]
-        async fn atomic_append_many<I: Id>(
+        async fn atomic_append_many(
             &self,
-            writes: &[PlannedAppend<I>],
+            writes: &[PlannedAppend],
         ) -> Result<(), AtomicAppendError<FjallError>> {
             // Nothing to commit — don't open an empty transaction.
             if writes.is_empty() {
@@ -552,6 +558,7 @@ mod stream_lister_impl {
     use bytes::Bytes;
     use core::pin::Pin;
     use core::task::{Context, Poll};
+    use nexus_store::StreamKey;
     use nexus_store::export::StreamLister;
 
     /// A lazy cursor over the `streams` partition's keys — each key is one
@@ -568,15 +575,15 @@ mod stream_lister_impl {
     }
 
     impl StreamIdCursor {
-        fn poll_one(&mut self) -> Option<Result<Bytes, FjallError>> {
+        fn poll_one(&mut self) -> Option<Result<StreamKey, FjallError>> {
             if self.poisoned {
                 return None;
             }
             // `key()` loads the key only (no value): an id enumeration never
             // needs the stored version counter, and the `bytes_1` feature makes
-            // the `Slice → Bytes` conversion zero-copy.
+            // the `Slice → Bytes` conversion zero-copy into the `StreamKey`.
             match self.iter.next()?.key() {
-                Ok(key) => Some(Ok(Bytes::from(key))),
+                Ok(key) => Some(Ok(StreamKey::from_bytes(Bytes::from(key)))),
                 Err(e) => {
                     self.poisoned = true;
                     Some(Err(FjallError::Io(e)))
@@ -587,7 +594,7 @@ mod stream_lister_impl {
 
     // `fjall::Iter` is `Unpin`, so the cursor is `Unpin` and `get_mut()` is sound.
     impl futures::Stream for StreamIdCursor {
-        type Item = Result<Bytes, FjallError>;
+        type Item = Result<StreamKey, FjallError>;
 
         fn poll_next(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
             Poll::Ready(self.get_mut().poll_one())
@@ -635,24 +642,10 @@ pub(crate) mod read_test_helpers {
     use super::*;
     use nexus_store::envelope::pending_envelope;
 
-    #[derive(Debug, Clone, Hash, PartialEq, Eq)]
-    pub struct Tid(pub String);
-    impl std::fmt::Display for Tid {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            f.write_str(&self.0)
-        }
-    }
-    impl AsRef<[u8]> for Tid {
-        fn as_ref(&self) -> &[u8] {
-            self.0.as_bytes()
-        }
-    }
-    impl nexus::Id for Tid {
-        const BYTE_LEN: usize = 0;
-    }
-
-    pub fn tid(s: &str) -> Tid {
-        Tid(s.to_owned())
+    /// Build a [`StreamKey`] for the in-crate tests — the byte-level store API
+    /// speaks `StreamKey` directly (issue #245).
+    pub fn sk(s: &str) -> StreamKey {
+        StreamKey::from_slice(s.as_bytes())
     }
 
     // Opens a default store. The cursor is a single lazy `fjall::Iter` that
@@ -663,7 +656,7 @@ pub(crate) mod read_test_helpers {
         (store, dir)
     }
 
-    pub async fn seed(store: &FjallStore, id: &Tid, count: u64) {
+    pub async fn seed(store: &FjallStore, id: &StreamKey, count: u64) {
         for v in 1..=count {
             let env = pending_envelope(Version::new(v).unwrap())
                 .event_type("E")
@@ -683,27 +676,8 @@ mod tests {
     use futures::StreamExt;
     use nexus_store::envelope::pending_envelope;
 
-    #[derive(Debug, Clone, Hash, PartialEq, Eq)]
-    struct TestId(String);
-
-    impl std::fmt::Display for TestId {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            f.write_str(&self.0)
-        }
-    }
-
-    impl AsRef<[u8]> for TestId {
-        fn as_ref(&self) -> &[u8] {
-            self.0.as_bytes()
-        }
-    }
-
-    impl nexus::Id for TestId {
-        const BYTE_LEN: usize = 0;
-    }
-
-    fn tid(s: &str) -> TestId {
-        TestId(s.to_owned())
+    fn sk(s: &str) -> StreamKey {
+        StreamKey::from_slice(s.as_bytes())
     }
 
     fn make_envelope(version: u64, event_type: &'static str, payload: &[u8]) -> PendingEnvelope {
@@ -727,7 +701,7 @@ mod tests {
         let (store, _dir) = temp_store();
         let env = make_envelope(1, "Created", b"payload");
 
-        let result = store.append(&tid("stream-1"), None, &[env]).await;
+        let result = store.append(&sk("stream-1"), None, &[env]).await;
         assert!(result.is_ok());
     }
 
@@ -740,7 +714,7 @@ mod tests {
             make_envelope(3, "Updated", b"p3"),
         ];
 
-        let result = store.append(&tid("stream-1"), None, &envs).await;
+        let result = store.append(&sk("stream-1"), None, &envs).await;
         assert!(result.is_ok());
     }
 
@@ -748,11 +722,11 @@ mod tests {
     async fn append_detects_version_conflict() {
         let (store, _dir) = temp_store();
         let env1 = make_envelope(1, "Created", b"p1");
-        store.append(&tid("stream-1"), None, &[env1]).await.unwrap();
+        store.append(&sk("stream-1"), None, &[env1]).await.unwrap();
 
         // Try appending with wrong expected version (None instead of Some(1)).
         let env2 = make_envelope(1, "Duplicate", b"p2");
-        let result = store.append(&tid("stream-1"), None, &[env2]).await;
+        let result = store.append(&sk("stream-1"), None, &[env2]).await;
         assert!(result.is_err());
         match result.unwrap_err() {
             AppendError::Conflict {
@@ -777,7 +751,7 @@ mod tests {
         let env = make_envelope(1, "E", b"p");
         // New stream + Some(expected) → immediate optimistic-concurrency conflict.
         let err = store
-            .append(&tid(&long), Version::new(1), &[env])
+            .append(&sk(&long), Version::new(1), &[env])
             .await
             .unwrap_err();
         match err {
@@ -799,9 +773,7 @@ mod tests {
         let (store, _dir) = temp_store();
         let env = make_envelope(6, "Created", b"payload");
 
-        let result = store
-            .append(&tid("stream-1"), Version::new(5), &[env])
-            .await;
+        let result = store.append(&sk("stream-1"), Version::new(5), &[env]).await;
         assert!(result.is_err());
         match result.unwrap_err() {
             AppendError::Conflict {
@@ -819,7 +791,7 @@ mod tests {
     #[tokio::test]
     async fn append_writes_events_global_index() {
         let (store, _dir) = temp_store();
-        let id = tid("acct-1");
+        let id = sk("acct-1");
         let env = pending_envelope(Version::new(1).unwrap())
             .event_type("Created")
             .payload(b"x".to_vec())
@@ -850,10 +822,10 @@ mod tests {
             make_envelope(1, "Created", b"p1"),
             make_envelope(2, "Updated", b"p2"),
         ];
-        store.append(&tid("stream-1"), None, &envs).await.unwrap();
+        store.append(&sk("stream-1"), None, &envs).await.unwrap();
 
         let mut stream = store
-            .read_stream(&tid("stream-1"), Version::new(1).unwrap())
+            .read_stream(&sk("stream-1"), Version::new(1).unwrap())
             .await
             .unwrap();
 
@@ -880,16 +852,16 @@ mod tests {
     async fn version_tracks_across_appends() {
         let (store, _dir) = temp_store();
         store
-            .append(&tid("s"), None, &[make_envelope(1, "A", b"")])
+            .append(&sk("s"), None, &[make_envelope(1, "A", b"")])
             .await
             .unwrap();
         store
-            .append(&tid("s"), Version::new(1), &[make_envelope(2, "B", b"")])
+            .append(&sk("s"), Version::new(1), &[make_envelope(2, "B", b"")])
             .await
             .unwrap();
 
         let mut stream = store
-            .read_stream(&tid("s"), Version::new(1).unwrap())
+            .read_stream(&sk("s"), Version::new(1).unwrap())
             .await
             .unwrap();
         {
@@ -907,7 +879,7 @@ mod tests {
 
     #[tokio::test]
     async fn read_yields_all_rows_in_order() {
-        use crate::store::read_test_helpers::{seed, temp_store, tid as btid};
+        use crate::store::read_test_helpers::{seed, sk as btid, temp_store};
         let (store, _dir) = temp_store();
         let id = btid("s");
         seed(&store, &id, 14).await;
@@ -921,7 +893,7 @@ mod tests {
 
     #[tokio::test]
     async fn read_terminates_at_end_of_stream() {
-        use crate::store::read_test_helpers::{seed, temp_store, tid as btid};
+        use crate::store::read_test_helpers::{seed, sk as btid, temp_store};
         let (store, _dir) = temp_store();
         let id = btid("s");
         seed(&store, &id, 8).await;
@@ -936,7 +908,7 @@ mod tests {
 
     #[tokio::test]
     async fn read_from_midpoint() {
-        use crate::store::read_test_helpers::{seed, temp_store, tid as btid};
+        use crate::store::read_test_helpers::{seed, sk as btid, temp_store};
         let (store, _dir) = temp_store();
         let id = btid("s");
         seed(&store, &id, 10).await;
@@ -955,7 +927,7 @@ mod tests {
     async fn read_reopened_store_recovers_all() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("db");
-        let id = tid("s");
+        let id = sk("s");
         {
             let store = FjallStore::builder(&path).open().unwrap();
             for v in 1..=10u64 {
@@ -981,8 +953,8 @@ mod tests {
     async fn read_all_yields_global_order_across_streams() {
         let dir = tempfile::tempdir().unwrap();
         let store = FjallStore::builder(dir.path().join("db")).open().unwrap();
-        let a = TestId("a".to_owned());
-        let b = TestId("b".to_owned());
+        let a = sk("a");
+        let b = sk("b");
 
         let mk = |v: u64, p: &[u8]| {
             pending_envelope(Version::new(v).unwrap())
@@ -1018,7 +990,7 @@ mod tests {
     async fn read_all_from_is_inclusive() {
         let dir = tempfile::tempdir().unwrap();
         let store = FjallStore::builder(dir.path().join("db")).open().unwrap();
-        let a = TestId("a".to_owned());
+        let a = sk("a");
         let mk = |v: u64| {
             #[allow(
                 clippy::as_conversions,
@@ -1053,7 +1025,7 @@ mod tests {
     async fn read_all_survives_reopen() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("db");
-        let a = TestId("a".to_owned());
+        let a = sk("a");
         {
             let store = FjallStore::builder(&path).open().unwrap();
             let env = pending_envelope(Version::new(1).unwrap())
@@ -1079,7 +1051,7 @@ mod tests {
     )]
     #[tokio::test]
     async fn reader_sees_monotonic_gapfree_while_writer_appends() {
-        use crate::store::read_test_helpers::{seed, temp_store, tid as btid};
+        use crate::store::read_test_helpers::{seed, sk as btid, temp_store};
         use std::sync::Arc as StdArc;
         use tokio::sync::Barrier;
 
@@ -1151,7 +1123,7 @@ mod tests {
 #[allow(clippy::panic, reason = "test code")]
 mod atomic_append_tests {
     use super::*;
-    use crate::store::read_test_helpers::{Tid, temp_store, tid};
+    use crate::store::read_test_helpers::{sk, temp_store};
     use futures::StreamExt;
     use nexus_store::envelope::pending_envelope;
     use nexus_store::import::{AtomicAppend, AtomicAppendError, PlannedAppend};
@@ -1166,15 +1138,15 @@ mod atomic_append_tests {
             .build()
     }
 
-    fn planned(target: &str, expected: Option<u64>, versions: &[u64]) -> PlannedAppend<Tid> {
+    fn planned(target: &str, expected: Option<u64>, versions: &[u64]) -> PlannedAppend {
         PlannedAppend {
-            target: tid(target),
+            target: sk(target),
             expected_version: expected.and_then(Version::new),
             events: versions.iter().map(|n| pending(*n, b"p")).collect(),
         }
     }
 
-    async fn read_versions(store: &FjallStore, id: &Tid) -> Vec<u64> {
+    async fn read_versions(store: &FjallStore, id: &StreamKey) -> Vec<u64> {
         let mut stream = store.read_stream(id, Version::INITIAL).await.unwrap();
         let mut out = Vec::new();
         while let Some(item) = stream.next().await {
@@ -1189,7 +1161,7 @@ mod atomic_append_tests {
         ks.inner().iter().count()
     }
 
-    fn stream_counter(store: &FjallStore, id: &Tid) -> Option<u64> {
+    fn stream_counter(store: &FjallStore, id: &StreamKey) -> Option<u64> {
         store
             .streams
             .inner()
@@ -1225,15 +1197,15 @@ mod atomic_append_tests {
         let writes = vec![planned("a", None, &[1, 2]), planned("b", None, &[1])];
         store.atomic_append_many(&writes).await.unwrap();
 
-        assert_eq!(read_versions(&store, &tid("a")).await, vec![1, 2]);
-        assert_eq!(read_versions(&store, &tid("b")).await, vec![1]);
+        assert_eq!(read_versions(&store, &sk("a")).await, vec![1, 2]);
+        assert_eq!(read_versions(&store, &sk("b")).await, vec![1]);
         // Three events total → events + events_global each hold 3 rows, and the
         // shared global counter advanced to 3.
         assert_eq!(row_count(&store.events), 3);
         assert_eq!(row_count(&store.events_global), 3);
         assert_eq!(global_counter(&store), Some(3));
-        assert_eq!(stream_counter(&store, &tid("a")), Some(2));
-        assert_eq!(stream_counter(&store, &tid("b")), Some(1));
+        assert_eq!(stream_counter(&store, &sk("a")), Some(2));
+        assert_eq!(stream_counter(&store, &sk("b")), Some(1));
     }
 
     #[tokio::test]
@@ -1246,11 +1218,11 @@ mod atomic_append_tests {
             .await
             .unwrap();
         store
-            .append(&tid("a"), Version::new(2), &[pending(3, b"p")])
+            .append(&sk("a"), Version::new(2), &[pending(3, b"p")])
             .await
             .unwrap();
 
-        assert_eq!(read_versions(&store, &tid("a")).await, vec![1, 2, 3]);
+        assert_eq!(read_versions(&store, &sk("a")).await, vec![1, 2, 3]);
         // global_seq is contiguous across the two paths: 1,2 (atomic) then 3.
         assert_eq!(global_counter(&store), Some(3));
         let mut all = store.read_all(GlobalSeq::INITIAL).await.unwrap();
@@ -1264,7 +1236,7 @@ mod atomic_append_tests {
     #[tokio::test]
     async fn empty_writes_commit_nothing() {
         let (store, _dir) = temp_store();
-        store.atomic_append_many::<Tid>(&[]).await.unwrap();
+        store.atomic_append_many(&[]).await.unwrap();
         assert_eq!(partition_snapshot(&store), (0, 0, None));
     }
 
@@ -1282,12 +1254,12 @@ mod atomic_append_tests {
                 .unwrap();
         }
         let store = FjallStore::builder(&path).open().unwrap();
-        assert_eq!(read_versions(&store, &tid("a")).await, vec![1, 2]);
-        assert_eq!(read_versions(&store, &tid("b")).await, vec![1]);
+        assert_eq!(read_versions(&store, &sk("a")).await, vec![1, 2]);
+        assert_eq!(read_versions(&store, &sk("b")).await, vec![1]);
         // A post-reopen normal append continues the global sequence (4th event
         // → global_seq 4), proving the counter persisted.
         store
-            .append(&tid("a"), Version::new(2), &[pending(3, b"p")])
+            .append(&sk("a"), Version::new(2), &[pending(3, b"p")])
             .await
             .unwrap();
         assert_eq!(global_counter(&store), Some(4));
@@ -1304,7 +1276,7 @@ mod atomic_append_tests {
         // EVERY partition byte-identical to the pre-import snapshot.
         let (store, _dir) = temp_store();
         store
-            .append(&tid("b"), None, &[pending(1, b"seed")])
+            .append(&sk("b"), None, &[pending(1, b"seed")])
             .await
             .unwrap();
         let before = partition_snapshot(&store);
@@ -1323,10 +1295,10 @@ mod atomic_append_tests {
 
         // Nothing landed anywhere: "a" has no events + no version counter, the
         // event/global row counts and the global seq counter are unchanged.
-        assert_eq!(read_versions(&store, &tid("a")).await, Vec::<u64>::new());
-        assert_eq!(stream_counter(&store, &tid("a")), None);
-        assert_eq!(read_versions(&store, &tid("b")).await, vec![1], "b intact");
-        assert_eq!(stream_counter(&store, &tid("b")), Some(1));
+        assert_eq!(read_versions(&store, &sk("a")).await, Vec::<u64>::new());
+        assert_eq!(stream_counter(&store, &sk("a")), None);
+        assert_eq!(read_versions(&store, &sk("b")).await, vec![1], "b intact");
+        assert_eq!(stream_counter(&store, &sk("b")), Some(1));
         assert_eq!(
             partition_snapshot(&store),
             before,
@@ -1352,7 +1324,7 @@ mod atomic_append_tests {
             other => panic!("expected Conflict, got {other}"),
         }
         // All-or-nothing: "t" is empty, definitely not [1,2,1,2].
-        assert_eq!(read_versions(&store, &tid("t")).await, Vec::<u64>::new());
+        assert_eq!(read_versions(&store, &sk("t")).await, Vec::<u64>::new());
         assert_eq!(partition_snapshot(&store), (0, 0, None));
     }
 
@@ -1401,7 +1373,7 @@ mod atomic_append_tests {
         // stream mid-growth; every observation must be a contiguous 1..=len
         // prefix (no gap/reorder/dup) and never exceed the 3 appended events.
         for _ in 0..64u32 {
-            let seen = read_versions(&store, &tid("a")).await;
+            let seen = read_versions(&store, &sk("a")).await;
             let valid_prefix: Vec<u64> = (1u64..).take(seen.len()).collect();
             assert_eq!(
                 seen, valid_prefix,
@@ -1413,7 +1385,7 @@ mod atomic_append_tests {
             );
         }
         handle.await.unwrap();
-        assert_eq!(read_versions(&store, &tid("a")).await, vec![1, 2, 3]);
+        assert_eq!(read_versions(&store, &sk("a")).await, vec![1, 2, 3]);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -1426,11 +1398,11 @@ mod atomic_append_tests {
         let (raw, _dir) = temp_store();
         let store = StdArc::new(raw);
         store
-            .append(&tid("a"), None, &[pending(1, b"seed")])
+            .append(&sk("a"), None, &[pending(1, b"seed")])
             .await
             .unwrap();
         store
-            .append(&tid("b"), None, &[pending(1, b"seed")])
+            .append(&sk("b"), None, &[pending(1, b"seed")])
             .await
             .unwrap();
 
@@ -1446,7 +1418,7 @@ mod atomic_append_tests {
 
         barrier.wait().await;
         for _ in 0..64u32 {
-            let seen = read_versions(&store, &tid("a")).await;
+            let seen = read_versions(&store, &sk("a")).await;
             assert_eq!(
                 seen,
                 vec![1],
@@ -1454,7 +1426,7 @@ mod atomic_append_tests {
             );
         }
         handle.await.unwrap();
-        assert_eq!(read_versions(&store, &tid("a")).await, vec![1]);
+        assert_eq!(read_versions(&store, &sk("a")).await, vec![1]);
     }
 }
 
@@ -1466,7 +1438,7 @@ mod atomic_append_tests {
 #[allow(clippy::unwrap_used, reason = "test code")]
 mod stream_lister_tests {
     use super::*;
-    use crate::store::read_test_helpers::{seed, temp_store, tid};
+    use crate::store::read_test_helpers::{seed, sk, temp_store};
     use futures::StreamExt;
     use nexus_store::export::StreamLister;
     use std::collections::HashSet;
@@ -1474,7 +1446,7 @@ mod stream_lister_tests {
     async fn list_ids(store: &FjallStore) -> HashSet<Vec<u8>> {
         let stream = store.list_streams().await.unwrap();
         stream
-            .map(|r| r.unwrap().to_vec())
+            .map(|r| r.unwrap().as_bytes().to_vec())
             .collect::<Vec<_>>()
             .await
             .into_iter()
@@ -1484,9 +1456,9 @@ mod stream_lister_tests {
     #[tokio::test]
     async fn lists_exactly_the_appended_ids() {
         let (store, _dir) = temp_store();
-        seed(&store, &tid("alpha"), 1).await;
-        seed(&store, &tid("beta"), 2).await;
-        seed(&store, &tid("gamma"), 3).await;
+        seed(&store, &sk("alpha"), 1).await;
+        seed(&store, &sk("beta"), 2).await;
+        seed(&store, &sk("gamma"), 3).await;
 
         let ids = list_ids(&store).await;
         let expected: HashSet<Vec<u8>> = [b"alpha".to_vec(), b"beta".to_vec(), b"gamma".to_vec()]
@@ -1506,10 +1478,10 @@ mod stream_lister_tests {
         // A 50-event stream is one id, not 50 — the lister scans the `streams`
         // partition (one row per stream), never the `events` partition.
         let (store, _dir) = temp_store();
-        seed(&store, &tid("busy"), 50).await;
+        seed(&store, &sk("busy"), 50).await;
         let stream = store.list_streams().await.unwrap();
         let all: Vec<Vec<u8>> = stream
-            .map(|r| r.unwrap().to_vec())
+            .map(|r| r.unwrap().as_bytes().to_vec())
             .collect::<Vec<_>>()
             .await;
         assert_eq!(all, vec![b"busy".to_vec()]);
@@ -1521,8 +1493,8 @@ mod stream_lister_tests {
         let path = dir.path().join("db");
         {
             let store = FjallStore::builder(&path).open().unwrap();
-            seed(&store, &tid("a"), 1).await;
-            seed(&store, &tid("b"), 1).await;
+            seed(&store, &sk("a"), 1).await;
+            seed(&store, &sk("b"), 1).await;
         }
         let store = FjallStore::builder(&path).open().unwrap();
         let ids = list_ids(&store).await;
@@ -1537,8 +1509,8 @@ mod stream_lister_tests {
         // boundary the lister must round-trip faithfully.
         let (store, _dir) = temp_store();
         let long = "x".repeat(300);
-        seed(&store, &tid(&long), 1).await;
-        seed(&store, &tid("short"), 1).await;
+        seed(&store, &sk(&long), 1).await;
+        seed(&store, &sk("short"), 1).await;
         let ids = list_ids(&store).await;
         assert!(ids.contains(long.as_bytes()));
         assert!(ids.contains(b"short".as_slice()));

--- a/crates/nexus-fjall/src/subscription_id.rs
+++ b/crates/nexus-fjall/src/subscription_id.rs
@@ -4,6 +4,7 @@
 //! re-reads the generic subscription loop performs.
 
 use nexus::Id;
+use nexus_store::StreamKey;
 
 /// Owned byte-key wrapper to satisfy the [`Id`] trait's `'static` bound
 /// when re-reading from the store during subscription refills.
@@ -11,8 +12,8 @@ use nexus::Id;
 pub struct OwnedStreamId(Vec<u8>);
 
 impl OwnedStreamId {
-    /// Create from any [`Id`] by capturing its byte representation.
-    pub fn from_id(id: &impl Id) -> Self {
+    /// Create from any stream key by capturing its byte representation.
+    pub fn from_id(id: &StreamKey) -> Self {
         Self(id.as_ref().to_vec())
     }
 }

--- a/crates/nexus-fjall/tests/export_import_tests.rs
+++ b/crates/nexus-fjall/tests/export_import_tests.rs
@@ -24,11 +24,11 @@
 )]
 
 use std::collections::BTreeSet;
-use std::fmt;
 
 use futures::StreamExt;
-use nexus::{Id, Version};
+use nexus::Version;
 use nexus_fjall::FjallStore;
+use nexus_store::StreamKey;
 use nexus_store::cbor::{
     ChunkError, decode_chunk, encode_block, encode_header, encode_section_heading,
 };
@@ -37,30 +37,13 @@ use nexus_store::export::{EventExporter, StreamLister};
 use nexus_store::import::{AbortReason, Atomicity, EventImporter, ImportError, StreamOutcome};
 use nexus_store::store::{GlobalSeq, RawEventStore};
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
-struct Tid(String);
-
-impl fmt::Display for Tid {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.0)
-    }
-}
-impl AsRef<[u8]> for Tid {
-    fn as_ref(&self) -> &[u8] {
-        self.0.as_bytes()
-    }
-}
-impl Id for Tid {
-    const BYTE_LEN: usize = 0;
+fn sk(s: &str) -> StreamKey {
+    StreamKey::from_slice(s.as_bytes())
 }
 
-fn tid(s: &str) -> Tid {
-    Tid(s.to_owned())
-}
-
-/// Route a section's origin id bytes straight back to the same target id.
-fn identity_route(origin: &[u8]) -> Tid {
-    Tid(String::from_utf8(origin.to_vec()).expect("utf8 origin"))
+/// Route a section's origin id bytes straight back to the same target key.
+fn identity_route(origin: &[u8]) -> StreamKey {
+    StreamKey::from_slice(origin)
 }
 
 fn open_store(path: &std::path::Path) -> FjallStore {
@@ -70,7 +53,7 @@ fn open_store(path: &std::path::Path) -> FjallStore {
 /// Append one event with the given fields, advancing the stream by one.
 async fn append_one(
     store: &FjallStore,
-    id: &Tid,
+    id: &StreamKey,
     version: u64,
     event_type: &'static str,
     metadata: Option<&[u8]>,
@@ -89,7 +72,7 @@ async fn append_one(
 }
 
 /// Drain a stream into owned envelopes (whole stream from v1).
-async fn collect_stream(store: &FjallStore, id: &Tid) -> Vec<PersistedEnvelope> {
+async fn collect_stream(store: &FjallStore, id: &StreamKey) -> Vec<PersistedEnvelope> {
     store
         .export_stream(id, Version::INITIAL)
         .await
@@ -108,7 +91,7 @@ async fn build_chunk(store: &FjallStore) -> Vec<u8> {
         .list_streams()
         .await
         .expect("list opens")
-        .map(|r| r.expect("no list error").to_vec())
+        .map(|r| r.expect("no list error").as_bytes().to_vec())
         .collect::<Vec<_>>()
         .await;
     ids.sort();
@@ -128,7 +111,11 @@ async fn build_chunk(store: &FjallStore) -> Vec<u8> {
 /// Assert two stores hold byte-identical streams **modulo `global_seq`** (export
 /// preserves version/schema/type/payload/metadata; import re-stamps a fresh
 /// `global_seq` on re-append).
-async fn assert_streams_equal_modulo_global_seq(src: &FjallStore, dst: &FjallStore, id: &Tid) {
+async fn assert_streams_equal_modulo_global_seq(
+    src: &FjallStore,
+    dst: &FjallStore,
+    id: &StreamKey,
+) {
     let a = collect_stream(src, id).await;
     let b = collect_stream(dst, id).await;
     assert_eq!(a.len(), b.len(), "stream {id} length differs");
@@ -153,10 +140,10 @@ async fn persistent_round_trip_through_a_file_preserves_streams() {
 
     // 1. Seed a source store with two streams of varied shape.
     let src = open_store(&src_dir.path().join("src-db"));
-    append_one(&src, &tid("task-1"), 1, "Created", Some(b"hlc=1"), b"alpha").await;
-    append_one(&src, &tid("task-1"), 2, "Updated", None, b"beta").await;
-    append_one(&src, &tid("task-1"), 3, "Closed", Some(b"hlc=3"), b"gamma").await;
-    append_one(&src, &tid("task-2"), 1, "Created", None, b"solo").await;
+    append_one(&src, &sk("task-1"), 1, "Created", Some(b"hlc=1"), b"alpha").await;
+    append_one(&src, &sk("task-1"), 2, "Updated", None, b"beta").await;
+    append_one(&src, &sk("task-1"), 3, "Closed", Some(b"hlc=3"), b"gamma").await;
+    append_one(&src, &sk("task-2"), 1, "Created", None, b"solo").await;
 
     // 2 + 3. Export + CBOR-encode to a REAL file on disk.
     let chunk = build_chunk(&src).await;
@@ -176,8 +163,8 @@ async fn persistent_round_trip_through_a_file_preserves_streams() {
     assert!(report.all_complete(), "every stream restored");
 
     // 6. Streams are byte-equal modulo global_seq.
-    assert_streams_equal_modulo_global_seq(&src, &dst, &tid("task-1")).await;
-    assert_streams_equal_modulo_global_seq(&src, &dst, &tid("task-2")).await;
+    assert_streams_equal_modulo_global_seq(&src, &dst, &sk("task-1")).await;
+    assert_streams_equal_modulo_global_seq(&src, &dst, &sk("task-2")).await;
 
     // And global_seq is genuinely RE-STAMPED: the destination's $all sequence
     // is a fresh contiguous 1..=4, independent of the source's values.
@@ -204,8 +191,8 @@ async fn round_trip_survives_source_store_close_before_export() {
     let db = dir.path().join("db");
     {
         let src = open_store(&db);
-        append_one(&src, &tid("s"), 1, "E", None, b"one").await;
-        append_one(&src, &tid("s"), 2, "E", None, b"two").await;
+        append_one(&src, &sk("s"), 1, "E", None, b"one").await;
+        append_one(&src, &sk("s"), 2, "E", None, b"two").await;
     }
     let reopened = open_store(&db);
     let chunk = build_chunk(&reopened).await;
@@ -215,7 +202,7 @@ async fn round_trip_survives_source_store_close_before_export() {
     dst.import(&sections, identity_route, Atomicity::PerStream)
         .await
         .expect("import");
-    assert_streams_equal_modulo_global_seq(&reopened, &dst, &tid("s")).await;
+    assert_streams_equal_modulo_global_seq(&reopened, &dst, &sk("s")).await;
 }
 
 // ════════════════════════════════════════════════════════════════════════════
@@ -232,8 +219,8 @@ async fn on_disk_block_corruption_imports_as_stream_corrupt_not_malformed() {
     let chunk_file = dir.path().join("backup.nxch");
 
     let src = open_store(&dir.path().join("src"));
-    append_one(&src, &tid("s"), 1, "E", None, b"good-one").await;
-    append_one(&src, &tid("s"), 2, "E", None, b"good-two").await;
+    append_one(&src, &sk("s"), 1, "E", None, b"good-one").await;
+    append_one(&src, &sk("s"), 2, "E", None, b"good-two").await;
     let chunk = build_chunk(&src).await;
     std::fs::write(&chunk_file, &chunk).expect("write");
 
@@ -264,7 +251,7 @@ async fn on_disk_block_corruption_imports_as_stream_corrupt_not_malformed() {
         "good prefix applied, corrupt block halts the stream",
     );
     // The store holds exactly the good prefix [v1].
-    let restored = collect_stream(&dst, &tid("s")).await;
+    let restored = collect_stream(&dst, &sk("s")).await;
     assert_eq!(restored.len(), 1);
     assert_eq!(restored[0].version(), Version::new(1).unwrap());
     assert_eq!(restored[0].payload(), b"good-one");
@@ -277,8 +264,8 @@ async fn on_disk_block_corruption_aborts_whole_chunk_restore() {
     // (cross-partition rollback on the persistent adapter).
     let dir = tempfile::tempdir().unwrap();
     let src = open_store(&dir.path().join("src"));
-    append_one(&src, &tid("s"), 1, "E", None, b"good-one").await;
-    append_one(&src, &tid("s"), 2, "E", None, b"good-two").await;
+    append_one(&src, &sk("s"), 1, "E", None, b"good-one").await;
+    append_one(&src, &sk("s"), 2, "E", None, b"good-two").await;
     let mut chunk = build_chunk(&src).await;
     let last = chunk.len() - 1;
     chunk[last] ^= 0xFF; // corrupt the last block's body
@@ -291,7 +278,7 @@ async fn on_disk_block_corruption_aborts_whole_chunk_restore() {
         .expect_err("whole-chunk corruption must abort");
     match err {
         ImportError::Aborted { stream, reason } => {
-            assert_eq!(stream, tid("s"));
+            assert_eq!(stream, sk("s"));
             assert_eq!(reason, AbortReason::Corrupt);
         }
         other => panic!("expected Aborted/Corrupt, got {other:?}"),
@@ -301,7 +288,7 @@ async fn on_disk_block_corruption_aborts_whole_chunk_restore() {
         .list_streams()
         .await
         .unwrap()
-        .map(|r| r.unwrap().to_vec())
+        .map(|r| r.unwrap().as_bytes().to_vec())
         .collect::<Vec<_>>()
         .await;
     assert!(ids.is_empty(), "aborted whole-chunk restore wrote nothing");
@@ -320,7 +307,7 @@ async fn malformed_chunk_framing_is_a_decode_error_not_a_corrupt_block() {
     // A real header with a flipped magic byte is also Malformed.
     let dir = tempfile::tempdir().unwrap();
     let src = open_store(&dir.path().join("src"));
-    append_one(&src, &tid("s"), 1, "E", None, b"x").await;
+    append_one(&src, &sk("s"), 1, "E", None, b"x").await;
     let mut chunk = build_chunk(&src).await;
     chunk[3] ^= 0xFF; // the magic is the first bytes of the header map
     match decode_chunk(&chunk) {
@@ -339,29 +326,29 @@ async fn non_injective_route_aborts_whole_chunk_no_corruption_on_disk() {
     // abort with nothing committed — never a concatenated [1,2,1,2] stream.
     let dir = tempfile::tempdir().unwrap();
     let src = open_store(&dir.path().join("src"));
-    append_one(&src, &tid("o1"), 1, "E", None, b"a").await;
-    append_one(&src, &tid("o1"), 2, "E", None, b"b").await;
-    append_one(&src, &tid("o2"), 1, "E", None, b"c").await;
-    append_one(&src, &tid("o2"), 2, "E", None, b"d").await;
+    append_one(&src, &sk("o1"), 1, "E", None, b"a").await;
+    append_one(&src, &sk("o1"), 2, "E", None, b"b").await;
+    append_one(&src, &sk("o2"), 1, "E", None, b"c").await;
+    append_one(&src, &sk("o2"), 2, "E", None, b"d").await;
     let chunk = build_chunk(&src).await;
     let sections = decode_chunk(&chunk).expect("decode");
 
     let dst = open_store(&dir.path().join("dst"));
-    let to_same = |_origin: &[u8]| tid("merged");
+    let to_same = |_origin: &[u8]| sk("merged");
     let err = dst
         .import(&sections, to_same, Atomicity::WholeChunk)
         .await
         .expect_err("non-injective route must abort");
     assert!(matches!(err, ImportError::Aborted { .. }));
     // The target never received the corrupt concatenation.
-    assert!(collect_stream(&dst, &tid("merged")).await.is_empty());
+    assert!(collect_stream(&dst, &sk("merged")).await.is_empty());
 
     // Sanity: the source really did hold two distinct streams.
     let origins: BTreeSet<Vec<u8>> = src
         .list_streams()
         .await
         .unwrap()
-        .map(|r| r.unwrap().to_vec())
+        .map(|r| r.unwrap().as_bytes().to_vec())
         .collect::<Vec<_>>()
         .await
         .into_iter()

--- a/crates/nexus-fjall/tests/fjall_conformance.rs
+++ b/crates/nexus-fjall/tests/fjall_conformance.rs
@@ -20,32 +20,14 @@
 
 use std::num::NonZeroU32;
 
-use nexus::{Id, Version};
+use nexus::Version;
 use nexus_fjall::{FjallError, FjallStore};
 use nexus_store::PendingEnvelope;
+use nexus_store::StreamKey;
 use nexus_store::envelope::{PersistedEnvelope, pending_envelope};
 use nexus_store::store::RawEventStore;
 use nexus_store::value::SchemaVersion;
 use nexus_store_testing::{ConformanceRow, assert_event_stream_conformance};
-
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
-struct StreamName(&'static str);
-
-impl std::fmt::Display for StreamName {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.0)
-    }
-}
-
-impl AsRef<[u8]> for StreamName {
-    fn as_ref(&self) -> &[u8] {
-        self.0.as_bytes()
-    }
-}
-
-impl Id for StreamName {
-    const BYTE_LEN: usize = 0;
-}
 
 /// The `read_stream` cursor plus the `FjallStore` and `TempDir` it depends on.
 /// The cursor holds a live `fjall::Iter` referencing data that becomes invalid
@@ -79,7 +61,7 @@ async fn fjall_event_stream_conforms() {
         let store = FjallStore::builder(tempdir.path().join("db"))
             .open()
             .expect("open fjall store");
-        let stream_id = StreamName("conformance");
+        let stream_id = StreamKey::from_slice(b"conformance");
 
         if !rows.is_empty() {
             let envelopes: Vec<PendingEnvelope> = rows

--- a/crates/nexus-fjall/tests/metadata_roundtrip_tests.rs
+++ b/crates/nexus-fjall/tests/metadata_roundtrip_tests.rs
@@ -17,28 +17,14 @@
 
 use bytes::Bytes;
 use futures::StreamExt;
-use nexus::{Id, Version};
+use nexus::Version;
 use nexus_fjall::FjallStore;
+use nexus_store::StreamKey;
 use nexus_store::envelope::pending_envelope;
 use nexus_store::store::RawEventStore;
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
-struct StreamName(&'static str);
-
-impl std::fmt::Display for StreamName {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.0)
-    }
-}
-
-impl AsRef<[u8]> for StreamName {
-    fn as_ref(&self) -> &[u8] {
-        self.0.as_bytes()
-    }
-}
-
-impl Id for StreamName {
-    const BYTE_LEN: usize = 0;
+fn sk(s: &str) -> StreamKey {
+    StreamKey::from_slice(s.as_bytes())
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -49,7 +35,7 @@ impl Id for StreamName {
 async fn metadata_roundtrips_across_multiple_events() {
     let dir = tempfile::tempdir().unwrap();
     let store = FjallStore::builder(dir.path().join("db")).open().unwrap();
-    let id = StreamName("multi");
+    let id = sk("multi");
 
     let envs: Vec<_> = (1..=5u64)
         .map(|i| {
@@ -103,7 +89,7 @@ async fn metadata_survives_store_reopen() {
             .with_metadata(Bytes::from_static(b"important-meta"))
             .expect("valid metadata");
         store
-            .append(&StreamName("reopen-stream"), None, &[env])
+            .append(&sk("reopen-stream"), None, &[env])
             .await
             .unwrap();
     }
@@ -111,7 +97,7 @@ async fn metadata_survives_store_reopen() {
 
     let store = FjallStore::builder(&db_path).open().unwrap();
     let mut cursor = store
-        .read_stream(&StreamName("reopen-stream"), Version::INITIAL)
+        .read_stream(&sk("reopen-stream"), Version::INITIAL)
         .await
         .unwrap();
     let env = cursor.next().await.unwrap().expect("event present");
@@ -128,7 +114,7 @@ async fn metadata_survives_store_reopen() {
 async fn none_metadata_roundtrips_as_none() {
     let dir = tempfile::tempdir().unwrap();
     let store = FjallStore::builder(dir.path().join("db")).open().unwrap();
-    let id = StreamName("none-meta");
+    let id = sk("none-meta");
 
     let pending = pending_envelope(Version::INITIAL)
         .event_type("X")

--- a/crates/nexus-fjall/tests/property_tests.rs
+++ b/crates/nexus-fjall/tests/property_tests.rs
@@ -47,6 +47,7 @@ use futures::StreamExt;
 use nexus::Version;
 use nexus_fjall::FjallStore;
 use nexus_store::PendingEnvelope;
+use nexus_store::StreamKey;
 use nexus_store::envelope::pending_envelope;
 use nexus_store::error::AppendError;
 use nexus_store::store::RawEventStore;
@@ -54,23 +55,8 @@ use nexus_store::value::SchemaVersion;
 
 use proptest::prelude::*;
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
-struct TestId(String);
-impl std::fmt::Display for TestId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&self.0)
-    }
-}
-impl AsRef<[u8]> for TestId {
-    fn as_ref(&self) -> &[u8] {
-        self.0.as_bytes()
-    }
-}
-impl nexus::Id for TestId {
-    const BYTE_LEN: usize = 0;
-}
-fn tid(s: &str) -> TestId {
-    TestId(s.to_owned())
+fn sk(s: &str) -> StreamKey {
+    StreamKey::from_slice(s.as_bytes())
 }
 
 // ============================================================================
@@ -138,7 +124,7 @@ fn build_envelopes_from(start_version: u64, payloads: &[Vec<u8>]) -> Vec<Pending
         .collect()
 }
 
-async fn read_all_payloads(store: &FjallStore, stream_id: &TestId) -> Vec<Vec<u8>> {
+async fn read_all_payloads(store: &FjallStore, stream_id: &StreamKey) -> Vec<Vec<u8>> {
     let mut stream = store
         .read_stream(stream_id, Version::INITIAL)
         .await
@@ -151,7 +137,7 @@ async fn read_all_payloads(store: &FjallStore, stream_id: &TestId) -> Vec<Vec<u8
     payloads
 }
 
-async fn read_all_versions(store: &FjallStore, stream_id: &TestId) -> Vec<u64> {
+async fn read_all_versions(store: &FjallStore, stream_id: &StreamKey) -> Vec<u64> {
     let mut stream = store
         .read_stream(stream_id, Version::INITIAL)
         .await
@@ -164,7 +150,7 @@ async fn read_all_versions(store: &FjallStore, stream_id: &TestId) -> Vec<u64> {
     versions
 }
 
-async fn read_all_event_types(store: &FjallStore, stream_id: &TestId) -> Vec<String> {
+async fn read_all_event_types(store: &FjallStore, stream_id: &StreamKey) -> Vec<String> {
     let mut stream = store
         .read_stream(stream_id, Version::INITIAL)
         .await
@@ -177,7 +163,7 @@ async fn read_all_event_types(store: &FjallStore, stream_id: &TestId) -> Vec<Str
     types
 }
 
-async fn count_events(store: &FjallStore, stream_id: &TestId) -> u64 {
+async fn count_events(store: &FjallStore, stream_id: &StreamKey) -> u64 {
     let mut stream = store
         .read_stream(stream_id, Version::INITIAL)
         .await
@@ -195,10 +181,10 @@ async fn count_events(store: &FjallStore, stream_id: &TestId) -> u64 {
 // Strategies
 // ============================================================================
 
-fn stream_id_strategy() -> impl Strategy<Value = TestId> {
+fn stream_id_strategy() -> impl Strategy<Value = StreamKey> {
     prop::string::string_regex("[a-z][a-z0-9_-]{0,29}")
         .unwrap()
-        .prop_map(TestId)
+        .prop_map(|s| StreamKey::from_slice(s.as_bytes()))
 }
 
 fn evil_stream_id_strategy() -> impl Strategy<Value = String> {
@@ -257,7 +243,7 @@ proptest! {
         let rt = tokio::runtime::Runtime::new().unwrap();
         rt.block_on(async {
             let (store, _dir) = temp_store();
-            let stream_id = tid("roundtrip-test");
+            let stream_id = sk("roundtrip-test");
             let envelopes = build_envelopes(&payloads);
 
             store.append(&stream_id, None, &envelopes).await.unwrap();
@@ -279,7 +265,7 @@ proptest! {
         let rt = tokio::runtime::Runtime::new().unwrap();
         rt.block_on(async {
             let (store, _dir) = temp_store();
-            let stream_id = tid("evil-roundtrip");
+            let stream_id = sk("evil-roundtrip");
             let envelopes = build_envelopes(&payloads);
 
             store.append(&stream_id, None, &envelopes).await.unwrap();
@@ -316,7 +302,7 @@ async fn attack_append_read_roundtrip_fixed_evil_payloads() {
     ];
 
     for (i, (description, payload)) in evil_payloads.iter().enumerate() {
-        let stream_id = TestId(format!("evil-{}", i));
+        let stream_id = StreamKey::from_slice(format!("evil-{}", i).as_bytes());
         let version = u64::try_from(i).unwrap() + 1;
 
         // Each gets its own stream to avoid version conflicts
@@ -360,8 +346,8 @@ async fn attack_evil_stream_ids() {
     let (store, _dir) = temp_store();
 
     for (evil_id, description) in &evil_ids {
-        // Use the evil_id directly as a TestId — no StreamId validation anymore.
-        let stream_id = TestId(evil_id.to_string());
+        // Use the evil_id directly as a StreamKey — no StreamId validation anymore.
+        let stream_id = StreamKey::from_slice(evil_id.as_bytes());
 
         let env = make_envelope(1, "Created", b"test-payload");
         let result = store.append(&stream_id, None, &[env]).await;
@@ -454,7 +440,7 @@ proptest! {
 async fn attack_version_boundaries_basic() {
     let (store, _dir) = temp_store();
     let env = make_envelope(1, "Created", b"ok");
-    let result = store.append(&tid("v-basic"), None, &[env]).await;
+    let result = store.append(&sk("v-basic"), None, &[env]).await;
     assert!(result.is_ok(), "basic version 0->1 must succeed");
 }
 
@@ -487,7 +473,7 @@ proptest! {
         let rt = tokio::runtime::Runtime::new().unwrap();
         rt.block_on(async {
             let (store, _dir) = temp_store();
-            let stream_id = tid("conflict-detect");
+            let stream_id = sk("conflict-detect");
 
             // Put N events in the stream
             let payloads: Vec<Vec<u8>> = (0..n).map(|i| vec![i as u8]).collect();
@@ -534,17 +520,17 @@ async fn attack_sequential_version_enforcement() {
 
     // [1, 3] — gap
     let envs_gap = vec![make_envelope(1, "A", b""), make_envelope(3, "B", b"")];
-    let result = store.append(&tid("seq-gap"), None, &envs_gap).await;
+    let result = store.append(&sk("seq-gap"), None, &envs_gap).await;
     assert!(result.is_err(), "[1, 3] gap must be rejected");
 
     // [2, 1] — reversed
     let envs_rev = vec![make_envelope(2, "A", b""), make_envelope(1, "B", b"")];
-    let result = store.append(&tid("seq-rev"), None, &envs_rev).await;
+    let result = store.append(&sk("seq-rev"), None, &envs_rev).await;
     assert!(result.is_err(), "[2, 1] reversed must be rejected");
 
     // [1, 1] — duplicate
     let envs_dup = vec![make_envelope(1, "A", b""), make_envelope(1, "B", b"")];
-    let result = store.append(&tid("seq-dup"), None, &envs_dup).await;
+    let result = store.append(&sk("seq-dup"), None, &envs_dup).await;
     assert!(result.is_err(), "[1, 1] duplicate must be rejected");
 
     // [0, 1] — starts at 0 instead of 1
@@ -566,7 +552,7 @@ proptest! {
         let rt = tokio::runtime::Runtime::new().unwrap();
         rt.block_on(async {
             let (store, _dir) = temp_store();
-            let stream_id = tid("random-versions");
+            let stream_id = sk("random-versions");
 
             let envelopes: Vec<_> = versions.iter().map(|&v| {
                 make_envelope(v, leak("E"), &[v as u8])
@@ -605,7 +591,7 @@ async fn attack_concurrent_appends_one_wins() {
         let store = Arc::clone(&store);
         let handle = tokio::spawn(async move {
             let env = make_envelope(1, "Raced", &[task_id as u8]);
-            store.append(&tid("race-stream"), None, &[env]).await
+            store.append(&sk("race-stream"), None, &[env]).await
         });
         handles.push(handle);
     }
@@ -635,7 +621,7 @@ async fn attack_concurrent_appends_one_wins() {
     );
 
     // Verify the stream has exactly 1 event
-    let count = count_events(&store, &tid("race-stream")).await;
+    let count = count_events(&store, &sk("race-stream")).await;
     assert_eq!(count, 1, "race-stream must have exactly 1 event");
 }
 
@@ -652,10 +638,7 @@ async fn attack_read_during_write() {
     let batch1: Vec<_> = (1..=10u64)
         .map(|v| make_envelope(v, "Batch1", &[v as u8]))
         .collect();
-    store
-        .append(&tid("rw-stream"), None, &batch1)
-        .await
-        .unwrap();
+    store.append(&sk("rw-stream"), None, &batch1).await.unwrap();
 
     // Spawn a writer for batch 2 (versions 11-20)
     let store_write = Arc::clone(&store);
@@ -664,7 +647,7 @@ async fn attack_read_during_write() {
             .map(|v| make_envelope(v, "Batch2", &[v as u8]))
             .collect();
         store_write
-            .append(&tid("rw-stream"), Version::new(10), &batch2)
+            .append(&sk("rw-stream"), Version::new(10), &batch2)
             .await
             .unwrap();
     });
@@ -672,7 +655,7 @@ async fn attack_read_during_write() {
     // Read concurrently
     let store_read = Arc::clone(&store);
     let read_handle = tokio::spawn(async move {
-        let versions = read_all_versions(&store_read, &tid("rw-stream")).await;
+        let versions = read_all_versions(&store_read, &sk("rw-stream")).await;
         versions.len()
     });
 
@@ -708,7 +691,7 @@ async fn attack_persistence_across_many_reopens() {
                 .map(|v| make_envelope(v, "Tick", &[v as u8]))
                 .collect();
             store
-                .append(&tid("persist-stream"), Version::new(total_events), &envs)
+                .append(&sk("persist-stream"), Version::new(total_events), &envs)
                 .await
                 .unwrap();
             total_events += 100;
@@ -717,7 +700,7 @@ async fn attack_persistence_across_many_reopens() {
         // Reopen and verify cumulative count
         {
             let store = FjallStore::builder(&db_path).open().unwrap();
-            let count = count_events(&store, &tid("persist-stream")).await;
+            let count = count_events(&store, &sk("persist-stream")).await;
             assert_eq!(
                 count, total_events,
                 "round {}: expected {} events, got {}",
@@ -725,7 +708,7 @@ async fn attack_persistence_across_many_reopens() {
             );
 
             // Also verify first and last event
-            let versions = read_all_versions(&store, &tid("persist-stream")).await;
+            let versions = read_all_versions(&store, &sk("persist-stream")).await;
             assert_eq!(versions[0], 1, "round {}: first version wrong", round);
             assert_eq!(
                 *versions.last().unwrap(),
@@ -747,15 +730,15 @@ async fn attack_stream_recovery_across_reopen() {
     {
         let store = FjallStore::builder(&db_path).open().unwrap();
         store
-            .append(&tid("a"), None, &[make_envelope(1, "A", b"a-data")])
+            .append(&sk("a"), None, &[make_envelope(1, "A", b"a-data")])
             .await
             .unwrap();
         store
-            .append(&tid("b"), None, &[make_envelope(1, "B", b"b-data")])
+            .append(&sk("b"), None, &[make_envelope(1, "B", b"b-data")])
             .await
             .unwrap();
         store
-            .append(&tid("c"), None, &[make_envelope(1, "C", b"c-data")])
+            .append(&sk("c"), None, &[make_envelope(1, "C", b"c-data")])
             .await
             .unwrap();
     }
@@ -764,7 +747,7 @@ async fn attack_stream_recovery_across_reopen() {
     {
         let store = FjallStore::builder(&db_path).open().unwrap();
         store
-            .append(&tid("d"), None, &[make_envelope(1, "D", b"d-data")])
+            .append(&sk("d"), None, &[make_envelope(1, "D", b"d-data")])
             .await
             .unwrap();
 
@@ -775,7 +758,7 @@ async fn attack_stream_recovery_across_reopen() {
             ("c", "C", b"c-data"),
             ("d", "D", b"d-data"),
         ] {
-            let stream_id = tid(id);
+            let stream_id = sk(id);
             let mut stream = store
                 .read_stream(&stream_id, Version::INITIAL)
                 .await
@@ -802,7 +785,7 @@ async fn attack_many_streams_recovery() {
     {
         let store = FjallStore::builder(&db_path).open().unwrap();
         for stream_num in 0..100u64 {
-            let stream_id = TestId(format!("stream-{}", stream_num));
+            let stream_id = StreamKey::from_slice(format!("stream-{}", stream_num).as_bytes());
             let envs: Vec<_> = (1..=10u64)
                 .map(|v| make_envelope(v, "Tick", &[stream_num as u8, v as u8]))
                 .collect();
@@ -814,7 +797,7 @@ async fn attack_many_streams_recovery() {
     {
         let store = FjallStore::builder(&db_path).open().unwrap();
         for stream_num in 0..100u64 {
-            let stream_id = TestId(format!("stream-{}", stream_num));
+            let stream_id = StreamKey::from_slice(format!("stream-{}", stream_num).as_bytes());
             let count = count_events(&store, &stream_id).await;
             assert_eq!(
                 count, 10,
@@ -845,7 +828,7 @@ async fn attack_many_streams_isolation() {
     let (store, _dir) = temp_store();
 
     for stream_num in 0..50u64 {
-        let stream_id = TestId(format!("iso-{}", stream_num));
+        let stream_id = StreamKey::from_slice(format!("iso-{}", stream_num).as_bytes());
         let envs: Vec<_> = (1..=5u64)
             .map(|v| {
                 let event_type = leak(&format!("Event{}", stream_num));
@@ -857,7 +840,7 @@ async fn attack_many_streams_isolation() {
 
     // Verify each stream is isolated
     for stream_num in 0..50u64 {
-        let stream_id = TestId(format!("iso-{}", stream_num));
+        let stream_id = StreamKey::from_slice(format!("iso-{}", stream_num).as_bytes());
         let expected_type = format!("Event{}", stream_num);
 
         let types = read_all_event_types(&store, &stream_id).await;
@@ -898,7 +881,7 @@ async fn attack_large_event_stream() {
             .map(|v| make_envelope(v, "Tick", &v.to_le_bytes()))
             .collect();
         store
-            .append(&tid("big-stream"), Version::new(current_version), &envs)
+            .append(&sk("big-stream"), Version::new(current_version), &envs)
             .await
             .unwrap();
         current_version = end;
@@ -906,7 +889,7 @@ async fn attack_large_event_stream() {
 
     // Read all back
     let mut stream = store
-        .read_stream(&tid("big-stream"), Version::new(1).unwrap())
+        .read_stream(&sk("big-stream"), Version::new(1).unwrap())
         .await
         .unwrap();
     let mut count = 0u64;
@@ -939,11 +922,11 @@ async fn attack_large_payloads() {
 
     let env = make_envelope(1, "HugeEvent", &payload_1mb);
     store
-        .append(&tid("large-payload"), None, &[env])
+        .append(&sk("large-payload"), None, &[env])
         .await
         .unwrap();
 
-    let payloads = read_all_payloads(&store, &tid("large-payload")).await;
+    let payloads = read_all_payloads(&store, &sk("large-payload")).await;
     assert_eq!(payloads.len(), 1);
     assert_eq!(
         payloads[0].len(),
@@ -961,11 +944,11 @@ async fn attack_many_small_events() {
         .map(|v| make_envelope(v, "Tiny", &[v as u8]))
         .collect();
     store
-        .append(&tid("small-events"), None, &envs)
+        .append(&sk("small-events"), None, &envs)
         .await
         .unwrap();
 
-    let count = count_events(&store, &tid("small-events")).await;
+    let count = count_events(&store, &sk("small-events")).await;
     assert_eq!(count, 1000, "expected 1000 small events, got {}", count);
 }
 
@@ -978,10 +961,10 @@ async fn attack_many_small_events() {
 async fn attack_schema_version_min_valid() {
     let (store, _dir) = temp_store();
     let env = make_envelope_with_schema(1, "Created", b"data", 1);
-    store.append(&tid("sv-min"), None, &[env]).await.unwrap();
+    store.append(&sk("sv-min"), None, &[env]).await.unwrap();
 
     let mut stream = store
-        .read_stream(&tid("sv-min"), Version::new(1).unwrap())
+        .read_stream(&sk("sv-min"), Version::new(1).unwrap())
         .await
         .unwrap();
     let persisted = stream.next().await.unwrap().unwrap();
@@ -993,10 +976,10 @@ async fn attack_schema_version_min_valid() {
 async fn attack_schema_version_u32_max() {
     let (store, _dir) = temp_store();
     let env = make_envelope_with_schema(1, "Created", b"data", u32::MAX);
-    store.append(&tid("sv-max"), None, &[env]).await.unwrap();
+    store.append(&sk("sv-max"), None, &[env]).await.unwrap();
 
     let mut stream = store
-        .read_stream(&tid("sv-max"), Version::new(1).unwrap())
+        .read_stream(&sk("sv-max"), Version::new(1).unwrap())
         .await
         .unwrap();
     let persisted = stream.next().await.unwrap().unwrap();
@@ -1027,11 +1010,11 @@ async fn attack_schema_version_zero_clamped_by_builder() {
         "schema_version must be 1 (NonZeroU32::MIN)"
     );
 
-    store.append(&tid("sv-zero"), None, &[env]).await.unwrap();
+    store.append(&sk("sv-zero"), None, &[env]).await.unwrap();
 
     // Read succeeds because schema_version is now 1
     let mut stream = store
-        .read_stream(&tid("sv-zero"), Version::new(1).unwrap())
+        .read_stream(&sk("sv-zero"), Version::new(1).unwrap())
         .await
         .unwrap();
     let persisted = stream.next().await.unwrap().unwrap();
@@ -1083,7 +1066,7 @@ proptest! {
                             .get(stream_id)
                             .map_or(0u64, |v| u64::try_from(v.len()).unwrap());
 
-                        let sid = TestId(stream_id.clone());
+                        let sid = StreamKey::from_slice(stream_id.as_bytes());
                         let envelopes: Vec<_> = (1..=*n_events).map(|i| {
                             let version = current_count + u64::try_from(i).unwrap();
                             let payload = format!("op-{}-v{}", stream_id, version);
@@ -1113,7 +1096,7 @@ proptest! {
                     }
                     Op::Read { stream_idx } => {
                         let stream_id = &stream_ids[*stream_idx];
-                        let sid = TestId(stream_id.clone());
+                        let sid = StreamKey::from_slice(stream_id.as_bytes());
                         let shadow_data = shadow.get(stream_id);
 
                         let real_payloads = read_all_payloads(&store, &sid).await;
@@ -1163,14 +1146,14 @@ async fn attack_read_from_initial_version() {
         make_envelope(3, "C", b"c"),
     ];
     store
-        .append(&tid("initial-read"), None, &envs)
+        .append(&sk("initial-read"), None, &envs)
         .await
         .unwrap();
 
     // Version::INITIAL is 0, so read_stream(_, from=0) — implementation may
     // return events starting at 1, or from 0. Let's test what actually happens.
     let mut stream = store
-        .read_stream(&tid("initial-read"), Version::INITIAL)
+        .read_stream(&sk("initial-read"), Version::INITIAL)
         .await
         .unwrap();
     let mut versions = Vec::new();
@@ -1192,13 +1175,10 @@ async fn attack_read_from_initial_version() {
 async fn attack_stream_fused_after_exhaustion() {
     let (store, _dir) = temp_store();
     let env = make_envelope(1, "Created", b"data");
-    store
-        .append(&tid("fused-test"), None, &[env])
-        .await
-        .unwrap();
+    store.append(&sk("fused-test"), None, &[env]).await.unwrap();
 
     let mut stream = store
-        .read_stream(&tid("fused-test"), Version::new(1).unwrap())
+        .read_stream(&sk("fused-test"), Version::new(1).unwrap())
         .await
         .unwrap();
 
@@ -1237,15 +1217,15 @@ async fn attack_multiple_sequential_appends() {
             })
             .collect();
         store
-            .append(&tid("multi-append"), Version::new(start_version), &envs)
+            .append(&sk("multi-append"), Version::new(start_version), &envs)
             .await
             .unwrap();
     }
 
-    let count = count_events(&store, &tid("multi-append")).await;
+    let count = count_events(&store, &sk("multi-append")).await;
     assert_eq!(count, 100, "20 batches of 5 = 100 events");
 
-    let versions = read_all_versions(&store, &tid("multi-append")).await;
+    let versions = read_all_versions(&store, &sk("multi-append")).await;
     for (i, v) in versions.iter().enumerate() {
         assert_eq!(
             *v,
@@ -1263,14 +1243,11 @@ async fn attack_read_with_from_version_filters() {
     let envs: Vec<_> = (1..=10u64)
         .map(|v| make_envelope(v, "Tick", &v.to_le_bytes()))
         .collect();
-    store
-        .append(&tid("filter-test"), None, &envs)
-        .await
-        .unwrap();
+    store.append(&sk("filter-test"), None, &envs).await.unwrap();
 
     // Read from version 5 — should get versions 5..=10
     let mut stream = store
-        .read_stream(&tid("filter-test"), Version::new(5).unwrap())
+        .read_stream(&sk("filter-test"), Version::new(5).unwrap())
         .await
         .unwrap();
     let mut versions = Vec::new();
@@ -1295,9 +1272,9 @@ async fn attack_event_type_preserved() {
         .enumerate()
         .map(|(i, &t)| make_envelope(u64::try_from(i).unwrap() + 1, t, b""))
         .collect();
-    store.append(&tid("type-test"), None, &envs).await.unwrap();
+    store.append(&sk("type-test"), None, &envs).await.unwrap();
 
-    let read_types = read_all_event_types(&store, &tid("type-test")).await;
+    let read_types = read_all_event_types(&store, &sk("type-test")).await;
     let expected: Vec<String> = types.iter().map(|t| (*t).to_owned()).collect();
     assert_eq!(read_types, expected, "event types not preserved");
 }
@@ -1308,11 +1285,11 @@ async fn attack_append_after_empty_batch() {
     let (store, _dir) = temp_store();
 
     // Empty batch first
-    store.append(&tid("post-empty"), None, &[]).await.unwrap();
+    store.append(&sk("post-empty"), None, &[]).await.unwrap();
 
     // Now a real append — should still succeed with None because empty batch is no-op
     let env = make_envelope(1, "Created", b"after-empty");
-    let result = store.append(&tid("post-empty"), None, &[env]).await;
+    let result = store.append(&sk("post-empty"), None, &[env]).await;
     assert!(
         result.is_ok(),
         "append after empty batch must succeed with INITIAL: {:?}",
@@ -1331,7 +1308,7 @@ proptest! {
         let rt = tokio::runtime::Runtime::new().unwrap();
         rt.block_on(async {
             let (store, _dir) = temp_store();
-            let stream_id = TestId(format!("sv-{}", schema_ver));
+            let stream_id = StreamKey::from_slice(format!("sv-{}", schema_ver).as_bytes());
             let env = make_envelope_with_schema(
                 1,
                 "SchemaTest",
@@ -1360,7 +1337,7 @@ proptest! {
         let rt = tokio::runtime::Runtime::new().unwrap();
         rt.block_on(async {
             let (store, _dir) = temp_store();
-            let stream_id = tid("monotonic-test");
+            let stream_id = sk("monotonic-test");
             let payloads: Vec<Vec<u8>> = (0..n).map(|i| vec![i as u8]).collect();
             let envelopes = build_envelopes(&payloads);
             store.append(&stream_id, None, &envelopes).await.unwrap();

--- a/crates/nexus-fjall/tests/resilience_tests.rs
+++ b/crates/nexus-fjall/tests/resilience_tests.rs
@@ -42,6 +42,7 @@ use futures::StreamExt;
 use nexus::Version;
 use nexus_fjall::FjallStore;
 use nexus_store::PendingEnvelope;
+use nexus_store::StreamKey;
 use nexus_store::envelope::pending_envelope;
 use nexus_store::error::AppendError;
 use nexus_store::store::RawEventStore;
@@ -52,23 +53,8 @@ use proptest::prelude::*;
 // Helpers
 // ============================================================================
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
-struct TestId(String);
-impl std::fmt::Display for TestId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&self.0)
-    }
-}
-impl AsRef<[u8]> for TestId {
-    fn as_ref(&self) -> &[u8] {
-        self.0.as_bytes()
-    }
-}
-impl nexus::Id for TestId {
-    const BYTE_LEN: usize = 0;
-}
-fn tid(s: &str) -> TestId {
-    TestId(s.to_owned())
+fn sk(s: &str) -> StreamKey {
+    StreamKey::from_slice(s.as_bytes())
 }
 
 fn leak(s: &str) -> &'static str {
@@ -89,7 +75,7 @@ fn temp_store() -> (FjallStore, tempfile::TempDir) {
     (store, dir)
 }
 
-async fn read_all_payloads(store: &FjallStore, stream_id: &TestId) -> Vec<Vec<u8>> {
+async fn read_all_payloads(store: &FjallStore, stream_id: &StreamKey) -> Vec<Vec<u8>> {
     let mut stream = store
         .read_stream(stream_id, Version::INITIAL)
         .await
@@ -102,7 +88,7 @@ async fn read_all_payloads(store: &FjallStore, stream_id: &TestId) -> Vec<Vec<u8
     payloads
 }
 
-async fn read_all_versions(store: &FjallStore, stream_id: &TestId) -> Vec<u64> {
+async fn read_all_versions(store: &FjallStore, stream_id: &StreamKey) -> Vec<u64> {
     let mut stream = store
         .read_stream(stream_id, Version::INITIAL)
         .await
@@ -115,7 +101,7 @@ async fn read_all_versions(store: &FjallStore, stream_id: &TestId) -> Vec<u64> {
     versions
 }
 
-async fn read_all_event_types(store: &FjallStore, stream_id: &TestId) -> Vec<String> {
+async fn read_all_event_types(store: &FjallStore, stream_id: &StreamKey) -> Vec<String> {
     let mut stream = store
         .read_stream(stream_id, Version::INITIAL)
         .await
@@ -128,7 +114,7 @@ async fn read_all_event_types(store: &FjallStore, stream_id: &TestId) -> Vec<Str
     types
 }
 
-async fn count_events(store: &FjallStore, stream_id: &TestId) -> u64 {
+async fn count_events(store: &FjallStore, stream_id: &StreamKey) -> u64 {
     let mut stream = store
         .read_stream(stream_id, Version::INITIAL)
         .await
@@ -248,8 +234,8 @@ async fn attack_dual_instance_same_path() {
         Ok(store2) => {
             // DANGEROUS: two writers on same DB!
             // Try creating different streams from each
-            let sid1 = tid("stream-from-store1");
-            let sid2 = tid("stream-from-store2");
+            let sid1 = sk("stream-from-store1");
+            let sid2 = sk("stream-from-store2");
             let env1 = make_envelope(1, "A", b"from-1");
             let env2 = make_envelope(1, "B", b"from-2");
 
@@ -306,8 +292,8 @@ proptest! {
             let mut store = FjallStore::builder(&path).open().unwrap();
 
             // Shadow model: stream_idx -> list of payloads
-            let stream_names: Vec<TestId> = (0..5)
-                .map(|i| tid(&format!("stream_{i}")))
+            let stream_names: Vec<StreamKey> = (0..5)
+                .map(|i| sk(&format!("stream_{i}")))
                 .collect();
             let mut model: HashMap<usize, Vec<Vec<u8>>> = HashMap::new();
 
@@ -378,7 +364,7 @@ proptest! {
 async fn attack_read_snapshot_isolation() {
     // Append 1000 events in 10 batches of 100, then verify read consistency
     let (store, _dir) = temp_store();
-    let sid_val = tid("snapshot-stream");
+    let sid_val = sk("snapshot-stream");
 
     for batch in 0..10u64 {
         let start = batch * 100 + 1;
@@ -420,7 +406,7 @@ async fn attack_crash_simulation_forget_store() {
     {
         let store = FjallStore::builder(&path).open().unwrap();
         let envs = vec![make_envelope(1, "Before", b"crash-data")];
-        store.append(&tid("crash-test"), None, &envs).await.unwrap();
+        store.append(&sk("crash-test"), None, &envs).await.unwrap();
         std::mem::forget(store); // Simulate crash — no Drop, no flush
     }
 
@@ -437,7 +423,7 @@ async fn attack_crash_simulation_forget_store() {
             );
         }
         Ok(store) => {
-            let payloads = read_all_payloads(&store, &tid("crash-test")).await;
+            let payloads = read_all_payloads(&store, &sk("crash-test")).await;
             if payloads.is_empty() {
                 println!(
                     "DURABILITY NOTE: data lost after mem::forget — \
@@ -462,10 +448,10 @@ async fn attack_version_u64_max_read() {
     // Read from version u64::MAX — should return empty (no events at that version)
     let (store, _dir) = temp_store();
     let envs = vec![make_envelope(1, "A", b"data")];
-    store.append(&tid("s"), None, &envs).await.unwrap();
+    store.append(&sk("s"), None, &envs).await.unwrap();
 
     let mut stream = store
-        .read_stream(&tid("s"), Version::new(u64::MAX).unwrap())
+        .read_stream(&sk("s"), Version::new(u64::MAX).unwrap())
         .await
         .unwrap();
     assert!(
@@ -480,10 +466,10 @@ async fn attack_read_from_version_zero() {
     // because events start at version 1, and the range scan starts from 0.
     let (store, _dir) = temp_store();
     let envs = vec![make_envelope(1, "A", b"1"), make_envelope(2, "B", b"2")];
-    store.append(&tid("s"), None, &envs).await.unwrap();
+    store.append(&sk("s"), None, &envs).await.unwrap();
 
     // Read from version 0 (INITIAL)
-    let count = count_events(&store, &tid("s")).await;
+    let count = count_events(&store, &sk("s")).await;
     assert_eq!(count, 2, "reading from INITIAL should return all events");
 }
 
@@ -491,7 +477,7 @@ async fn attack_read_from_version_zero() {
 async fn attack_read_nonexistent_stream() {
     let (store, _dir) = temp_store();
     let mut stream = store
-        .read_stream(&tid("does-not-exist"), Version::INITIAL)
+        .read_stream(&sk("does-not-exist"), Version::INITIAL)
         .await
         .unwrap();
     assert!(
@@ -509,10 +495,10 @@ async fn attack_read_past_end_of_stream() {
         make_envelope(2, "B", b"2"),
         make_envelope(3, "C", b"3"),
     ];
-    store.append(&tid("s"), None, &envs).await.unwrap();
+    store.append(&sk("s"), None, &envs).await.unwrap();
 
     let mut stream = store
-        .read_stream(&tid("s"), Version::new(100).unwrap())
+        .read_stream(&sk("s"), Version::new(100).unwrap())
         .await
         .unwrap();
     assert!(
@@ -536,7 +522,7 @@ async fn attack_recovery_torture_100_streams_reopen_5_times() {
         let store = FjallStore::builder(&path).open().unwrap();
 
         for (stream_idx, current_total) in total_events_per_stream.iter_mut().enumerate() {
-            let sid_val = tid(&format!("torture_{stream_idx}"));
+            let sid_val = sk(&format!("torture_{stream_idx}"));
             let current = *current_total;
             let new_events = 5u64;
 
@@ -556,7 +542,7 @@ async fn attack_recovery_torture_100_streams_reopen_5_times() {
 
         // Verify all streams before closing
         for (stream_idx, expected) in total_events_per_stream.iter().enumerate() {
-            let sid_val = tid(&format!("torture_{stream_idx}"));
+            let sid_val = sk(&format!("torture_{stream_idx}"));
             let count = count_events(&store, &sid_val).await;
             assert_eq!(
                 count, *expected,
@@ -582,7 +568,7 @@ async fn attack_concurrent_append_storm_50_tasks() {
     for i in 0..50u64 {
         let store_clone = Arc::clone(&store);
         let handle = tokio::spawn(async move {
-            let sid_val = TestId(format!("concurrent_{i}"));
+            let sid_val = StreamKey::from_slice(format!("concurrent_{i}").as_bytes());
             let env = pending_envelope(Version::INITIAL)
                 .event_type(leak(&format!("Created_{i}")))
                 .payload(i.to_le_bytes().to_vec())
@@ -614,7 +600,7 @@ async fn attack_concurrent_append_storm_50_tasks() {
 
     // Verify all 50 streams are readable
     for i in 0..50u64 {
-        let sid_val = TestId(format!("concurrent_{i}"));
+        let sid_val = StreamKey::from_slice(format!("concurrent_{i}").as_bytes());
         let count = count_events(&store, &sid_val).await;
         assert_eq!(
             count, 1,
@@ -634,7 +620,7 @@ async fn attack_concurrent_append_same_stream_conflict() {
     for i in 0..10u64 {
         let store_clone = Arc::clone(&store);
         let handle = tokio::spawn(async move {
-            let sid_val = TestId("contested-stream".to_owned());
+            let sid_val = StreamKey::from_slice(b"contested-stream");
             let env = pending_envelope(Version::INITIAL)
                 .event_type(leak(&format!("Contested_{i}")))
                 .payload(i.to_le_bytes().to_vec())
@@ -667,7 +653,7 @@ async fn attack_concurrent_append_same_stream_conflict() {
     assert_eq!(other_errors, 0, "no other errors expected");
 
     // Verify the stream has exactly 1 event
-    let sid_val = tid("contested-stream");
+    let sid_val = sk("contested-stream");
     let count = count_events(&store, &sid_val).await;
     assert_eq!(count, 1, "contested stream should have exactly 1 event");
 }
@@ -685,7 +671,7 @@ async fn attack_version_gap_in_batch() {
         make_envelope(3, "C", b"3"), // skip version 2!
     ];
 
-    let result = store.append(&tid("gap"), None, &envs).await;
+    let result = store.append(&sk("gap"), None, &envs).await;
     assert!(result.is_err(), "version gap in batch must be rejected");
 }
 
@@ -698,7 +684,7 @@ async fn attack_version_duplicate_in_batch() {
         make_envelope(1, "B", b"2"), // duplicate version!
     ];
 
-    let result = store.append(&tid("dup"), None, &envs).await;
+    let result = store.append(&sk("dup"), None, &envs).await;
     assert!(
         result.is_err(),
         "duplicate version in batch must be rejected"
@@ -714,7 +700,7 @@ async fn attack_version_backwards_in_batch() {
         make_envelope(1, "A", b"1"), // wrong order!
     ];
 
-    let result = store.append(&tid("back"), Version::new(1), &envs).await;
+    let result = store.append(&sk("back"), Version::new(1), &envs).await;
     // This depends on validation: first envelope has version 2, expected is 2 (1+1) → OK
     // Second envelope has version 1, expected is 3 (1+1+1) → CONFLICT
     assert!(
@@ -729,27 +715,27 @@ async fn attack_empty_batch_does_not_advance_version() {
 
     // Create stream with 1 event
     store
-        .append(&tid("empty-batch"), None, &[make_envelope(1, "A", b"1")])
+        .append(&sk("empty-batch"), None, &[make_envelope(1, "A", b"1")])
         .await
         .unwrap();
 
     // Append empty batch
     store
-        .append(&tid("empty-batch"), Version::new(1), &[])
+        .append(&sk("empty-batch"), Version::new(1), &[])
         .await
         .unwrap();
 
     // Should still be able to append at version 2 (empty batch didn't advance)
     store
         .append(
-            &tid("empty-batch"),
+            &sk("empty-batch"),
             Version::new(1),
             &[make_envelope(2, "B", b"2")],
         )
         .await
         .unwrap();
 
-    let count = count_events(&store, &tid("empty-batch")).await;
+    let count = count_events(&store, &sk("empty-batch")).await;
     assert_eq!(count, 2, "should have exactly 2 events after empty batch");
 }
 
@@ -765,7 +751,7 @@ async fn attack_empty_batch_does_not_advance_version() {
 async fn append_assigns_monotonic_global_seq_across_streams() {
     let (store, _dir) = temp_store();
 
-    async fn read_global_seqs(store: &FjallStore, stream_id: &TestId) -> Vec<u64> {
+    async fn read_global_seqs(store: &FjallStore, stream_id: &StreamKey) -> Vec<u64> {
         let mut stream = store
             .read_stream(stream_id, Version::INITIAL)
             .await
@@ -781,7 +767,7 @@ async fn append_assigns_monotonic_global_seq_across_streams() {
     // Append 1: two events to stream "a" -> global_seq 1, 2.
     store
         .append(
-            &tid("a"),
+            &sk("a"),
             None,
             &[make_envelope(1, "A1", b"a1"), make_envelope(2, "A2", b"a2")],
         )
@@ -790,22 +776,22 @@ async fn append_assigns_monotonic_global_seq_across_streams() {
 
     // Append 2: one event to a different stream "b" -> global_seq 3.
     store
-        .append(&tid("b"), None, &[make_envelope(1, "B1", b"b1")])
+        .append(&sk("b"), None, &[make_envelope(1, "B1", b"b1")])
         .await
         .unwrap();
 
     // Append 3: continue stream "a" -> global_seq 4, 5.
     store
         .append(
-            &tid("a"),
+            &sk("a"),
             Version::new(2),
             &[make_envelope(3, "A3", b"a3"), make_envelope(4, "A4", b"a4")],
         )
         .await
         .unwrap();
 
-    let seqs_a = read_global_seqs(&store, &tid("a")).await;
-    let seqs_b = read_global_seqs(&store, &tid("b")).await;
+    let seqs_a = read_global_seqs(&store, &sk("a")).await;
+    let seqs_b = read_global_seqs(&store, &sk("b")).await;
 
     // Stream "a" got events at append positions 1,2 then 4,5.
     assert_eq!(
@@ -846,7 +832,7 @@ async fn attack_recovery_stream_id_counter_correctness() {
     {
         let store = FjallStore::builder(&path).open().unwrap();
         for i in 0..stream_count {
-            let sid_val = tid(&format!("recovery_{i}"));
+            let sid_val = sk(&format!("recovery_{i}"));
             let env = make_envelope(1, "Init", &i.to_le_bytes());
             store.append(&sid_val, None, &[env]).await.unwrap();
         }
@@ -856,13 +842,13 @@ async fn attack_recovery_stream_id_counter_correctness() {
     {
         let store = FjallStore::builder(&path).open().unwrap();
         // Create one more stream — should get a unique numeric ID
-        let sid_val = tid(&format!("recovery_{stream_count}"));
+        let sid_val = sk(&format!("recovery_{stream_count}"));
         let env = make_envelope(1, "Init", b"new");
         store.append(&sid_val, None, &[env]).await.unwrap();
 
         // Verify ALL streams are readable
         for i in 0..=stream_count {
-            let sid_val = tid(&format!("recovery_{i}"));
+            let sid_val = sk(&format!("recovery_{i}"));
             let count = count_events(&store, &sid_val).await;
             assert_eq!(count, 1, "stream recovery_{i} should have 1 event");
         }
@@ -879,14 +865,14 @@ async fn attack_empty_batch_to_nonexistent_stream() {
 
     // Append empty batch to nonexistent stream with INITIAL version
     // Should succeed (no-op) because the early return skips all validation
-    let result = store.append(&tid("phantom"), None, &[]).await;
+    let result = store.append(&sk("phantom"), None, &[]).await;
     assert!(
         result.is_ok(),
         "empty batch to nonexistent stream should be no-op"
     );
 
     // Stream should still not exist (no metadata written)
-    let count = count_events(&store, &tid("phantom")).await;
+    let count = count_events(&store, &sk("phantom")).await;
     assert_eq!(count, 0, "phantom stream should have 0 events");
 }
 
@@ -896,7 +882,7 @@ async fn attack_empty_batch_wrong_version_to_nonexistent() {
     // This means you can "succeed" with a wrong expected_version on an empty batch.
     let (store, _dir) = temp_store();
 
-    let result = store.append(&tid("phantom2"), Version::new(999), &[]).await;
+    let result = store.append(&sk("phantom2"), Version::new(999), &[]).await;
     // The early return at line 61 fires BEFORE any version check.
     // This is arguably a bug: it should still validate expected_version
     // against the actual stream state, even for empty batches.
@@ -916,7 +902,7 @@ async fn attack_empty_batch_wrong_version_to_nonexistent() {
 #[tokio::test]
 async fn attack_large_batch_1000_events() {
     let (store, _dir) = temp_store();
-    let sid_val = tid("large-batch");
+    let sid_val = sk("large-batch");
 
     let envelopes: Vec<_> = (1..=1000u64)
         .map(|v| make_envelope(v, "Tick", &v.to_le_bytes()))
@@ -941,7 +927,7 @@ async fn attack_large_batch_1000_events() {
 async fn attack_reopen_10_times_with_appends() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("db");
-    let sid_val = tid("reopen-torture");
+    let sid_val = sk("reopen-torture");
 
     for cycle in 0..10u64 {
         let store = FjallStore::builder(&path).open().unwrap();
@@ -998,7 +984,7 @@ fn attack_schema_version_zero_rejected_by_type_system() {
 async fn attack_concurrent_reads_and_writes() {
     let (store, _dir) = temp_store();
     let store = Arc::new(store);
-    let sid_val = tid("concurrent-rw");
+    let sid_val = sk("concurrent-rw");
 
     // Pre-populate with 100 events
     let initial_envs: Vec<_> = (1..=100u64)
@@ -1067,10 +1053,10 @@ async fn attack_custom_builder_config_still_works() {
 
     let env = make_envelope(1, "A", b"data");
     store
-        .append(&tid("custom-config"), None, &[env])
+        .append(&sk("custom-config"), None, &[env])
         .await
         .unwrap();
 
-    let count = count_events(&store, &tid("custom-config")).await;
+    let count = count_events(&store, &sk("custom-config")).await;
     assert_eq!(count, 1, "custom config store should work normally");
 }

--- a/crates/nexus-fjall/tests/snapshot_tests.rs
+++ b/crates/nexus-fjall/tests/snapshot_tests.rs
@@ -10,36 +10,17 @@
     reason = "test harness — relaxed lints for test code"
 )]
 
-use std::fmt;
 use std::num::NonZeroU32;
 
-use nexus::{Id, Version};
+use nexus::Version;
 use nexus_fjall::FjallStore;
+use nexus_store::StreamKey;
 use nexus_store::state::SnapshotStore;
 
 const SV1: NonZeroU32 = NonZeroU32::MIN;
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
-struct TestId(String);
-
-impl fmt::Display for TestId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl AsRef<[u8]> for TestId {
-    fn as_ref(&self) -> &[u8] {
-        self.0.as_bytes()
-    }
-}
-
-impl Id for TestId {
-    const BYTE_LEN: usize = 0;
-}
-
-fn tid(s: &str) -> TestId {
-    TestId(s.to_owned())
+fn sk(s: &str) -> StreamKey {
+    StreamKey::from_slice(s.as_bytes())
 }
 
 fn temp_store() -> (FjallStore, tempfile::TempDir) {
@@ -49,7 +30,7 @@ fn temp_store() -> (FjallStore, tempfile::TempDir) {
 }
 
 /// Helper: append events to create a stream so snapshots have something to reference.
-async fn setup_stream(store: &FjallStore, id: &TestId, event_count: u64) {
+async fn setup_stream(store: &FjallStore, id: &StreamKey, event_count: u64) {
     use nexus_store::envelope::pending_envelope;
     use nexus_store::store::RawEventStore;
 
@@ -71,7 +52,7 @@ async fn setup_stream(store: &FjallStore, id: &TestId, event_count: u64) {
 #[tokio::test]
 async fn commit_then_hydrate_roundtrips() {
     let (store, _dir) = temp_store();
-    let id = tid("agg-1");
+    let id = sk("agg-1");
     setup_stream(&store, &id, 5).await;
 
     store
@@ -87,7 +68,7 @@ async fn commit_then_hydrate_roundtrips() {
 #[tokio::test]
 async fn commit_overwrites_previous_snapshot() {
     let (store, _dir) = temp_store();
-    let id = tid("agg-1");
+    let id = sk("agg-1");
     setup_stream(&store, &id, 10).await;
 
     store
@@ -115,7 +96,7 @@ async fn commit_overwrites_previous_snapshot() {
 async fn snapshot_persists_across_reopen() {
     let dir = tempfile::tempdir().unwrap();
     let db_path = dir.path().join("db");
-    let id = tid("agg-1");
+    let id = sk("agg-1");
 
     // First session: create stream + snapshot
     {
@@ -141,14 +122,14 @@ async fn snapshot_persists_across_reopen() {
 #[tokio::test]
 async fn hydrate_unknown_id_returns_none() {
     let (store, _dir) = temp_store();
-    let result = store.hydrate(&tid("nope"), SV1).await.unwrap();
+    let result = store.hydrate(&sk("nope"), SV1).await.unwrap();
     assert!(result.is_none());
 }
 
 #[tokio::test]
 async fn hydrate_id_without_snapshot_returns_none() {
     let (store, _dir) = temp_store();
-    let id = tid("agg-1");
+    let id = sk("agg-1");
     setup_stream(&store, &id, 3).await;
 
     let result = store.hydrate(&id, SV1).await.unwrap();
@@ -160,12 +141,12 @@ async fn commit_without_event_stream_is_persisted() {
     let (store, _dir) = temp_store();
     // No event stream exists — commit writes the snapshot unconditionally.
     store
-        .commit(&tid("nope"), SV1, Version::new(1).unwrap(), &vec![1])
+        .commit(&sk("nope"), SV1, Version::new(1).unwrap(), &vec![1])
         .await
         .unwrap();
 
     // And hydrate reads it back regardless of stream existence.
-    let (version, state) = store.hydrate(&tid("nope"), SV1).await.unwrap().unwrap();
+    let (version, state) = store.hydrate(&sk("nope"), SV1).await.unwrap().unwrap();
     assert_eq!(version, Version::new(1).unwrap());
     assert_eq!(state, vec![1]);
 }
@@ -175,8 +156,8 @@ async fn commit_without_event_stream_is_persisted() {
 #[tokio::test]
 async fn different_streams_have_separate_snapshots() {
     let (store, _dir) = temp_store();
-    let id1 = tid("agg-1");
-    let id2 = tid("agg-2");
+    let id1 = sk("agg-1");
+    let id2 = sk("agg-2");
     setup_stream(&store, &id1, 5).await;
     setup_stream(&store, &id2, 10).await;
 

--- a/crates/nexus-fjall/tests/state_machine_tests.rs
+++ b/crates/nexus-fjall/tests/state_machine_tests.rs
@@ -25,6 +25,7 @@ use futures::StreamExt;
 use nexus::Version;
 use nexus_fjall::FjallStore;
 use nexus_store::PendingEnvelope;
+use nexus_store::StreamKey;
 use nexus_store::envelope::pending_envelope;
 use nexus_store::error::AppendError;
 use nexus_store::store::RawEventStore;
@@ -205,23 +206,8 @@ struct FjallSut {
 // Helpers
 // ---------------------------------------------------------------------------
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
-struct TestId(String);
-impl std::fmt::Display for TestId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&self.0)
-    }
-}
-impl AsRef<[u8]> for TestId {
-    fn as_ref(&self) -> &[u8] {
-        self.0.as_bytes()
-    }
-}
-impl nexus::Id for TestId {
-    const BYTE_LEN: usize = 0;
-}
-fn tid(s: &str) -> TestId {
-    TestId(s.to_owned())
+fn sk(s: &str) -> StreamKey {
+    StreamKey::from_slice(s.as_bytes())
 }
 
 fn make_envelope(version: u64, event_type: &'static str, payload: &[u8]) -> PendingEnvelope {
@@ -269,7 +255,7 @@ impl StateMachineTest for FjallStateMachineTest {
     ) -> Self::SystemUnderTest {
         match transition {
             Transition::CreateStream { ref stream_name } => {
-                let stream_id = tid(stream_name);
+                let stream_id = sk(stream_name);
                 let model_events = ref_state.streams.get(stream_name);
                 let model_len = model_events.map_or(0, Vec::len);
 
@@ -298,7 +284,7 @@ impl StateMachineTest for FjallStateMachineTest {
                 ref stream_name,
                 count,
             } => {
-                let stream_id = tid(stream_name);
+                let stream_id = sk(stream_name);
                 let model_events = &ref_state.streams[stream_name];
 
                 // The model already has the new events appended. The last
@@ -332,7 +318,7 @@ impl StateMachineTest for FjallStateMachineTest {
             }
 
             Transition::AppendConflict { ref stream_name } => {
-                let stream_id = tid(stream_name);
+                let stream_id = sk(stream_name);
                 let model_events = &ref_state.streams[stream_name];
                 let current_version = model_events.last().map_or(0, |(v, _, _)| *v);
 
@@ -377,7 +363,7 @@ impl StateMachineTest for FjallStateMachineTest {
                 let model_events = &ref_state.streams[stream_name];
                 if model_events.is_empty() {
                     // Empty stream: reading from version 1 yields nothing.
-                    let stream_id = tid(stream_name);
+                    let stream_id = sk(stream_name);
                     let result = sut
                         .rt
                         .block_on(sut.store.read_stream(&stream_id, Version::INITIAL));
@@ -395,7 +381,7 @@ impl StateMachineTest for FjallStateMachineTest {
                         .filter(|(v, _, _)| *v >= from_version)
                         .collect();
 
-                    let stream_id = tid(stream_name);
+                    let stream_id = sk(stream_name);
                     let result = sut.rt.block_on(
                         sut.store
                             .read_stream(&stream_id, Version::new(from_version).unwrap()),
@@ -437,7 +423,7 @@ impl StateMachineTest for FjallStateMachineTest {
             }
 
             Transition::AppendEmptyBatch { ref stream_name } => {
-                let stream_id = tid(stream_name);
+                let stream_id = sk(stream_name);
                 let model_events = ref_state.streams.get(stream_name);
                 let current_version = model_events
                     .and_then(|evts| evts.last())
@@ -459,7 +445,7 @@ impl StateMachineTest for FjallStateMachineTest {
 
 /// Helper: read all events from a stream and verify they match the model.
 fn verify_stream(sut: &FjallSut, stream_name: &str, model_events: &[ModelEvent]) {
-    let stream_id = tid(stream_name);
+    let stream_id = sk(stream_name);
     let result = sut
         .rt
         .block_on(sut.store.read_stream(&stream_id, Version::INITIAL));

--- a/crates/nexus-fjall/tests/subscription_tests.rs
+++ b/crates/nexus-fjall/tests/subscription_tests.rs
@@ -14,35 +14,14 @@
 use std::time::Duration;
 
 use futures::StreamExt;
-use nexus::{Id, Version};
+use nexus::Version;
 use nexus_fjall::FjallStore;
 use nexus_store::store::RawEventStore;
-use nexus_store::{PendingEnvelope, Store, Subscription, pending_envelope};
+use nexus_store::{PendingEnvelope, Store, StreamKey, Subscription, pending_envelope};
 use tokio::time::timeout;
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
-struct TestId(String);
-
-impl TestId {
-    fn new(s: &str) -> Self {
-        Self(s.to_owned())
-    }
-}
-
-impl std::fmt::Display for TestId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&self.0)
-    }
-}
-
-impl AsRef<[u8]> for TestId {
-    fn as_ref(&self) -> &[u8] {
-        self.0.as_bytes()
-    }
-}
-
-impl Id for TestId {
-    const BYTE_LEN: usize = 0;
+fn sk(s: &str) -> StreamKey {
+    StreamKey::from_slice(s.as_bytes())
 }
 
 fn make_envelope(version: u64, event_type: &'static str, payload: &[u8]) -> PendingEnvelope {
@@ -62,13 +41,13 @@ fn temp_store() -> (FjallStore, tempfile::TempDir) {
 /// Helper: append a single event to a stream, with expected version.
 async fn append_one(
     store: &Store<FjallStore>,
-    id: &TestId,
+    id: &StreamKey,
     version: u64,
     expected: Option<Version>,
     event_type: &'static str,
 ) {
     let envelope = make_envelope(version, event_type, format!("payload-{version}").as_bytes());
-    store.raw().append(id, expected, &[envelope]).await.unwrap();
+    store.append(id, expected, &[envelope]).await.unwrap();
 }
 
 /// Timeout duration for operations that should complete quickly.
@@ -82,7 +61,7 @@ const TIMEOUT: Duration = Duration::from_secs(2);
 async fn subscribe_catchup_then_live() {
     let (store, _dir) = temp_store();
     let store = Store::new(store);
-    let id = TestId::new("stream-1");
+    let id = sk("stream-1");
 
     // Pre-populate 2 events.
     append_one(&store, &id, 1, None, "E1").await;
@@ -127,7 +106,7 @@ async fn subscribe_catchup_then_live() {
 async fn subscribe_from_checkpoint() {
     let (store, _dir) = temp_store();
     let store = Store::new(store);
-    let id = TestId::new("stream-1");
+    let id = sk("stream-1");
 
     // Pre-populate 3 events.
     append_one(&store, &id, 1, None, "E1").await;
@@ -157,7 +136,7 @@ async fn subscribe_from_checkpoint() {
 async fn drop_and_resubscribe() {
     let (store, _dir) = temp_store();
     let store = Store::new(store);
-    let id = TestId::new("stream-1");
+    let id = sk("stream-1");
 
     // Append event 1.
     append_one(&store, &id, 1, None, "E1").await;
@@ -207,7 +186,7 @@ async fn drop_and_resubscribe() {
 async fn write_close_reopen_subscribe() {
     let dir = tempfile::tempdir().unwrap();
     let db_path = dir.path().join("db");
-    let id = TestId::new("stream-1");
+    let id = sk("stream-1");
 
     // Phase 1: Open, append events, close.
     {
@@ -249,7 +228,7 @@ async fn write_close_reopen_subscribe() {
 async fn subscribe_to_nonexistent_stream_waits() {
     let (store, _dir) = temp_store();
     let store = Store::new(store);
-    let id = TestId::new("ghost-stream");
+    let id = sk("ghost-stream");
 
     let stream = Subscription::new(&store).subscribe(&id, None).unwrap();
     futures::pin_mut!(stream);
@@ -275,7 +254,7 @@ async fn subscribe_to_nonexistent_stream_waits() {
 async fn subscribe_from_beyond_head() {
     let (store, _dir) = temp_store();
     let store = Store::new(store);
-    let id = TestId::new("stream-1");
+    let id = sk("stream-1");
 
     // Append 2 events (head is at version 2).
     append_one(&store, &id, 1, None, "E1").await;
@@ -315,7 +294,7 @@ async fn subscribe_from_beyond_head() {
 async fn concurrent_append_and_subscribe() {
     let (store, _dir) = temp_store();
     let store = Store::new(store);
-    let id = TestId::new("concurrent-stream");
+    let id = sk("concurrent-stream");
     let event_count: u64 = 50;
 
     let stream = Subscription::new(&store).subscribe(&id, None).unwrap();
@@ -361,7 +340,7 @@ async fn concurrent_append_and_subscribe() {
 async fn append_during_catchup_no_loss() {
     let (store, _dir) = temp_store();
     let store = Store::new(store);
-    let id = TestId::new("stream-1");
+    let id = sk("stream-1");
 
     // Pre-populate 20 events.
     for i in 1..=20u64 {
@@ -400,7 +379,7 @@ async fn append_during_catchup_no_loss() {
 async fn multiple_subscribers_same_stream() {
     let (store, _dir) = temp_store();
     let store = Store::new(store);
-    let id = TestId::new("shared-stream");
+    let id = sk("shared-stream");
 
     // Two subscribers to the same stream.
     let sub = Subscription::new(&store);
@@ -441,7 +420,7 @@ async fn subscription_cursor_is_static() {
     fn assert_static<T: 'static>(_: &T) {}
     let (store, _dir) = temp_store();
     let store = Store::new(store);
-    let id = TestId::new("s-1");
+    let id = sk("s-1");
     let sub = Subscription::new(&store).subscribe(&id, None).unwrap();
     assert_static(&sub);
 }

--- a/crates/nexus-store/benches/store_bench.rs
+++ b/crates/nexus-store/benches/store_bench.rs
@@ -32,7 +32,6 @@
 
 use std::collections::HashMap;
 use std::convert::Infallible;
-use std::fmt;
 use std::hint::black_box;
 
 use bytes::Bytes;
@@ -40,30 +39,11 @@ use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use futures::StreamExt;
 use nexus::Version;
 use nexus_store::AppendError;
+use nexus_store::StreamKey;
 use nexus_store::envelope::{PendingEnvelope, PersistedEnvelope};
 use nexus_store::pending_envelope;
 use nexus_store::store::{GlobalSeq, RawEventStore};
 use tokio::sync::Mutex;
-
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
-struct BenchId(String);
-impl fmt::Display for BenchId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.0)
-    }
-}
-impl AsRef<[u8]> for BenchId {
-    fn as_ref(&self) -> &[u8] {
-        self.0.as_bytes()
-    }
-}
-impl nexus::Id for BenchId {
-    const BYTE_LEN: usize = 0;
-}
-
-fn bid(s: &str) -> BenchId {
-    BenchId(s.to_owned())
-}
 
 fn build_persisted(
     version: u64,
@@ -145,7 +125,7 @@ impl RawEventStore for InMemoryRawStore {
 
     async fn append(
         &self,
-        id: &impl nexus::Id,
+        id: &StreamKey,
         expected_version: Option<Version>,
         envelopes: &[PendingEnvelope],
     ) -> Result<(), AppendError<Self::Error>> {
@@ -169,7 +149,7 @@ impl RawEventStore for InMemoryRawStore {
 
     async fn read_stream(
         &self,
-        id: &impl nexus::Id,
+        id: &StreamKey,
         from: Version,
     ) -> Result<Self::Stream, Self::Error> {
         let events = self
@@ -310,7 +290,11 @@ fn bench_append(c: &mut Criterion) {
                 let store = InMemoryRawStore::new();
                 rt.block_on(async {
                     store
-                        .append(&bid("bench-stream"), None, black_box(envs))
+                        .append(
+                            &StreamKey::from_slice(b"bench-stream"),
+                            None,
+                            black_box(envs),
+                        )
                         .await
                         .unwrap();
                 });
@@ -331,7 +315,7 @@ fn bench_read_stream(c: &mut Criterion) {
         let store = InMemoryRawStore::new();
         rt.block_on(async {
             store
-                .append(&bid("bench-stream"), None, &envelopes)
+                .append(&StreamKey::from_slice(b"bench-stream"), None, &envelopes)
                 .await
                 .unwrap();
         });
@@ -340,7 +324,7 @@ fn bench_read_stream(c: &mut Criterion) {
             b.iter(|| {
                 rt.block_on(async {
                     let mut stream = store
-                        .read_stream(&bid("bench-stream"), Version::INITIAL)
+                        .read_stream(&StreamKey::from_slice(b"bench-stream"), Version::INITIAL)
                         .await
                         .unwrap();
                     while let Some(__item) = stream.next().await {

--- a/crates/nexus-store/src/catchup.rs
+++ b/crates/nexus-store/src/catchup.rs
@@ -11,10 +11,11 @@
 use core::future::Future;
 use std::sync::Arc;
 
-use nexus::{Id, Version};
+use nexus::Version;
 
 use crate::envelope::PersistedEnvelope;
 use crate::store::{GlobalSeq, RawEventStore};
+use crate::stream_id::StreamKey;
 use crate::wake::{WakeRegistration, WakeSource};
 
 /// One subscription target's catchup behaviour: a bounded position-keyed scan
@@ -53,42 +54,15 @@ pub trait Catchup: Send {
     fn next_pos(resume: Option<Self::Position>) -> Option<Self::Position>;
 }
 
-/// Owned id satisfying [`Id`]'s `'static` bound across reopened scans.
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
-pub struct OwnedSubId(Vec<u8>);
-
-impl core::fmt::Display for OwnedSubId {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match core::str::from_utf8(&self.0) {
-            Ok(s) => f.write_str(s),
-            Err(_) => write!(f, "<{} bytes>", self.0.len()),
-        }
-    }
-}
-
-impl AsRef<[u8]> for OwnedSubId {
-    fn as_ref(&self) -> &[u8] {
-        &self.0
-    }
-}
-
-impl Id for OwnedSubId {
-    // `OwnedSubId` is variable-length, so it has no fixed `BYTE_LEN`. The
-    // in-process wake path never reads this constant, so it is `0` by the
-    // established workspace convention for variable-length ids.
-    const BYTE_LEN: usize = 0;
-}
-
-impl OwnedSubId {
-    pub fn new(bytes: &[u8]) -> Self {
-        Self(bytes.to_vec())
-    }
-}
-
 /// Per-stream catchup: scans one stream by [`Version`], waits on that stream.
+///
+/// The stream key is held as an owned [`StreamKey`] — it satisfies the
+/// `'static` bound the reopened scans need across refills, and it is exactly
+/// the type [`RawEventStore::read_stream`] consumes, so no per-refill
+/// conversion is required.
 pub struct StreamCatchup<S: RawEventStore + WakeSource> {
     store: Arc<S>,
-    id: OwnedSubId,
+    id: StreamKey,
     reg: <S as WakeSource>::Registration,
 }
 
@@ -101,7 +75,7 @@ impl<S: RawEventStore + WakeSource> StreamCatchup<S> {
         let reg = store.register(Some(id_bytes))?;
         Ok(Self {
             store,
-            id: OwnedSubId::new(id_bytes),
+            id: StreamKey::from_slice(id_bytes),
             reg,
         })
     }
@@ -194,7 +168,7 @@ mod tests {
     #[tokio::test]
     async fn stream_catchup_reads_from_initial() {
         let store = Arc::new(InMemoryStore::new());
-        let id = OwnedSubId::new(b"s");
+        let id = StreamKey::from_slice(b"s");
 
         for v in 1u64..=3 {
             let env = pending_envelope(Version::new(v).unwrap())
@@ -290,7 +264,7 @@ mod tests {
     #[tokio::test]
     async fn reopen_does_not_redeliver_last_event() {
         let store = Arc::new(InMemoryStore::new());
-        let id = OwnedSubId::new(b"s");
+        let id = StreamKey::from_slice(b"s");
 
         for v in 1u64..=3 {
             let env = pending_envelope(Version::new(v).unwrap())

--- a/crates/nexus-store/src/cbor.rs
+++ b/crates/nexus-store/src/cbor.rs
@@ -310,6 +310,7 @@ mod tests {
     use crate::envelope::pending_envelope;
     use crate::import::{Atomicity, EventImporter};
     use crate::store::RawEventStore;
+    use crate::stream_id::StreamKey;
     use crate::testing::InMemoryStore;
     use futures::StreamExt;
 
@@ -849,25 +850,6 @@ mod tests {
 
     // ── Task 7: Full pipeline — export → box → import ───────────────────────
 
-    #[derive(Debug, Clone, Hash, PartialEq, Eq)]
-    struct Tid(String);
-
-    impl core::fmt::Display for Tid {
-        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-            f.write_str(&self.0)
-        }
-    }
-
-    impl AsRef<[u8]> for Tid {
-        fn as_ref(&self) -> &[u8] {
-            self.0.as_bytes()
-        }
-    }
-
-    impl nexus::Id for Tid {
-        const BYTE_LEN: usize = 0;
-    }
-
     #[cfg(feature = "testing")]
     #[tokio::test]
     async fn export_box_import_round_trip_byte_equal_modulo_global_seq() {
@@ -881,7 +863,7 @@ mod tests {
                     .expect("valid payload")
                     .build();
                 src.append(
-                    &Tid(sid.into()),
+                    &StreamKey::from_slice(sid.as_bytes()),
                     Version::new(v - 1),
                     core::slice::from_ref(&pe),
                 )
@@ -895,7 +877,7 @@ mod tests {
         for sid in ["task-1", "task-2"] {
             chunk.extend_from_slice(&encode_section_heading(sid.as_bytes()).expect("heading"));
             let mut s = src
-                .read_stream(&Tid(sid.into()), Version::INITIAL)
+                .read_stream(&StreamKey::from_slice(sid.as_bytes()), Version::INITIAL)
                 .await
                 .expect("read");
             while let Some(item) = s.next().await {
@@ -907,7 +889,9 @@ mod tests {
         // Box-decode → import into a fresh store under origin-namespaced ids.
         let sections = decode_chunk(&chunk).expect("decode");
         let dst = InMemoryStore::new();
-        let route = |origin: &[u8]| Tid(format!("src:{}", String::from_utf8_lossy(origin)));
+        let route = |origin: &[u8]| {
+            StreamKey::from_slice(format!("src:{}", String::from_utf8_lossy(origin)).as_bytes())
+        };
         let report = dst
             .import(&sections, route, Atomicity::PerStream)
             .await
@@ -916,7 +900,7 @@ mod tests {
 
         // Verify byte-equality of payloads/versions modulo global_seq.
         for sid in ["task-1", "task-2"] {
-            let target = Tid(format!("src:{sid}"));
+            let target = StreamKey::from_slice(format!("src:{sid}").as_bytes());
             let got: Vec<(u64, Vec<u8>)> = dst
                 .read_stream(&target, Version::INITIAL)
                 .await

--- a/crates/nexus-store/src/export.rs
+++ b/crates/nexus-store/src/export.rs
@@ -32,12 +32,12 @@
 //! right stream; import then ignores each event's `global_seq`. See issue
 //! #145 §5.
 
-use bytes::Bytes;
 use futures::Stream;
-use nexus::{Id, Version};
+use nexus::Version;
 
 use crate::store::{RawEventStore, Store};
 use crate::stream::EventStream;
+use crate::stream_id::StreamKey;
 
 /// Enumerate the stream ids present in a store.
 ///
@@ -53,7 +53,7 @@ use crate::stream::EventStream;
 /// `streams` partition; in-memory: its map; postgres: `SELECT DISTINCT`).
 pub trait StreamLister: RawEventStore {
     /// The stream of stream ids.
-    type StreamList: Stream<Item = Result<Bytes, Self::Error>> + Send + 'static;
+    type StreamList: Stream<Item = Result<StreamKey, Self::Error>> + Send + 'static;
 
     /// Open a one-shot stream over every stream id in the store, in no
     /// guaranteed order, terminating when exhausted.
@@ -91,7 +91,7 @@ pub trait EventExporter: RawEventStore {
     /// Open a per-stream export of stream `id`, starting at `from` (inclusive).
     fn export_stream(
         &self,
-        id: &impl Id,
+        id: &StreamKey,
         from: Version,
     ) -> impl std::future::Future<Output = Result<Self::ExportStream, Self::Error>> + Send;
 }
@@ -107,7 +107,7 @@ impl<S: RawEventStore> EventExporter for S {
 
     fn export_stream(
         &self,
-        id: &impl Id,
+        id: &StreamKey,
         from: Version,
     ) -> impl std::future::Future<Output = Result<Self::ExportStream, Self::Error>> + Send {
         self.read_stream(id, from)
@@ -148,26 +148,10 @@ mod tests {
     // EventExporter, the adapter impl for StreamLister.
     assert_impl_all!(InMemoryStore: EventExporter, StreamLister, RawEventStore);
 
-    // ── test Id ──────────────────────────────────────────────────────────────
+    // ── test stream key ───────────────────────────────────────────────────────
 
-    #[derive(Debug, Clone, Hash, PartialEq, Eq)]
-    struct Tid(String);
-    impl std::fmt::Display for Tid {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            f.write_str(&self.0)
-        }
-    }
-    impl AsRef<[u8]> for Tid {
-        fn as_ref(&self) -> &[u8] {
-            self.0.as_bytes()
-        }
-    }
-    impl nexus::Id for Tid {
-        const BYTE_LEN: usize = 0;
-    }
-
-    fn tid(s: &str) -> Tid {
-        Tid(s.to_owned())
+    fn sk(s: &str) -> StreamKey {
+        StreamKey::from_slice(s.as_bytes())
     }
 
     fn env(v: u64, payload: &[u8]) -> crate::envelope::PendingEnvelope {
@@ -178,7 +162,7 @@ mod tests {
             .build()
     }
 
-    async fn append_one(store: &InMemoryStore, id: &Tid, v: u64, payload: &[u8]) {
+    async fn append_one(store: &InMemoryStore, id: &StreamKey, v: u64, payload: &[u8]) {
         let expected = Version::new(v - 1);
         store
             .append(id, expected, &[env(v, payload)])
@@ -186,7 +170,7 @@ mod tests {
             .expect("append succeeds");
     }
 
-    async fn seed(store: &InMemoryStore, id: &Tid, count: u64) {
+    async fn seed(store: &InMemoryStore, id: &StreamKey, count: u64) {
         for v in 1..=count {
             append_one(store, id, v, format!("payload-{v}").as_bytes()).await;
         }
@@ -194,7 +178,7 @@ mod tests {
 
     async fn collect_export(
         store: &InMemoryStore,
-        id: &Tid,
+        id: &StreamKey,
         from: Version,
     ) -> Vec<PersistedEnvelope> {
         let stream = store.export_stream(id, from).await.expect("export opens");
@@ -213,7 +197,7 @@ mod tests {
         // The core contract: export is a verbatim pass-through of read_stream.
         // Same versions, global_seqs, schema, event_type, payload, metadata.
         let store = InMemoryStore::new();
-        let id = tid("acct-1");
+        let id = sk("acct-1");
         seed(&store, &id, 5).await;
 
         let exported = collect_export(&store, &id, Version::INITIAL).await;
@@ -244,7 +228,7 @@ mod tests {
     #[tokio::test]
     async fn export_preserves_versions_and_payloads_in_order() {
         let store = InMemoryStore::new();
-        let id = tid("acct-1");
+        let id = sk("acct-1");
         seed(&store, &id, 5).await;
 
         let exported = collect_export(&store, &id, Version::INITIAL).await;
@@ -260,7 +244,7 @@ mod tests {
     #[tokio::test]
     async fn exporting_the_same_stream_twice_is_identical() {
         let store = InMemoryStore::new();
-        let id = tid("acct-1");
+        let id = sk("acct-1");
         seed(&store, &id, 4).await;
 
         let first = collect_export(&store, &id, Version::INITIAL).await;
@@ -277,7 +261,7 @@ mod tests {
     #[tokio::test]
     async fn export_carries_metadata_and_schema_verbatim() {
         let store = InMemoryStore::new();
-        let id = tid("acct-1");
+        let id = sk("acct-1");
         let pending = pending_envelope(Version::INITIAL)
             .event_type("Created")
             .payload(b"body".to_vec())
@@ -304,7 +288,7 @@ mod tests {
     #[tokio::test]
     async fn export_empty_stream_terminates_and_does_not_hang() {
         let store = InMemoryStore::new();
-        let id = tid("never-appended");
+        let id = sk("never-appended");
         let mut stream = store
             .export_stream(&id, Version::INITIAL)
             .await
@@ -318,7 +302,7 @@ mod tests {
     #[tokio::test]
     async fn export_from_past_the_head_is_empty() {
         let store = InMemoryStore::new();
-        let id = tid("acct-1");
+        let id = sk("acct-1");
         seed(&store, &id, 3).await;
 
         let exported = collect_export(&store, &id, Version::new(10).expect("nonzero")).await;
@@ -330,7 +314,7 @@ mod tests {
         // Pins the resolved semantics: `from` is INCLUSIVE (matches
         // read_stream). from=3 on a 5-event stream yields [3,4,5].
         let store = InMemoryStore::new();
-        let id = tid("acct-1");
+        let id = sk("acct-1");
         seed(&store, &id, 5).await;
 
         let exported = collect_export(&store, &id, Version::new(3).expect("nonzero")).await;
@@ -341,7 +325,7 @@ mod tests {
     #[tokio::test]
     async fn export_single_event_stream_yields_one() {
         let store = InMemoryStore::new();
-        let id = tid("acct-1");
+        let id = sk("acct-1");
         seed(&store, &id, 1).await;
 
         let exported = collect_export(&store, &id, Version::INITIAL).await;
@@ -357,9 +341,9 @@ mod tests {
     async fn export_unknown_stream_is_empty_not_error() {
         let store = InMemoryStore::new();
         // Seed a different stream so the store is non-empty.
-        seed(&store, &tid("other"), 2).await;
+        seed(&store, &sk("other"), 2).await;
 
-        let exported = collect_export(&store, &tid("does-not-exist"), Version::INITIAL).await;
+        let exported = collect_export(&store, &sk("does-not-exist"), Version::INITIAL).await;
         assert!(exported.is_empty());
     }
 
@@ -367,8 +351,8 @@ mod tests {
     async fn export_handles_empty_and_unusual_stream_ids() {
         let store = InMemoryStore::new();
         // Empty id and a long id are both structurally legal stream ids.
-        let empty = tid("");
-        let long = tid(&"x".repeat(300));
+        let empty = sk("");
+        let long = sk(&"x".repeat(300));
         seed(&store, &empty, 2).await;
         seed(&store, &long, 3).await;
 
@@ -393,7 +377,7 @@ mod tests {
         // increasing, each event well-formed (payload matches its version) —
         // never a gap, never a torn event.
         let store = Arc::new(InMemoryStore::new());
-        let id = tid("race");
+        let id = sk("race");
         let n = 200u64;
 
         // Seed v1 BEFORE the race. Without this, the exporter can open and drain
@@ -458,7 +442,7 @@ mod tests {
     async fn collect_stream_ids(store: &InMemoryStore) -> HashSet<Vec<u8>> {
         let stream = store.list_streams().await.expect("list opens");
         stream
-            .map(|r| r.expect("no list error").to_vec())
+            .map(|r| r.expect("no list error").as_bytes().to_vec())
             .collect::<Vec<_>>()
             .await
             .into_iter()
@@ -468,9 +452,9 @@ mod tests {
     #[tokio::test]
     async fn list_streams_returns_exactly_the_appended_ids() {
         let store = InMemoryStore::new();
-        seed(&store, &tid("alpha"), 1).await;
-        seed(&store, &tid("beta"), 2).await;
-        seed(&store, &tid("gamma"), 3).await;
+        seed(&store, &sk("alpha"), 1).await;
+        seed(&store, &sk("beta"), 2).await;
+        seed(&store, &sk("gamma"), 3).await;
 
         let ids = collect_stream_ids(&store).await;
         let expected: HashSet<Vec<u8>> = [b"alpha".to_vec(), b"beta".to_vec(), b"gamma".to_vec()]
@@ -489,11 +473,11 @@ mod tests {
     #[tokio::test]
     async fn list_streams_lists_each_stream_once_regardless_of_event_count() {
         let store = InMemoryStore::new();
-        seed(&store, &tid("busy"), 50).await;
+        seed(&store, &sk("busy"), 50).await;
 
         let stream = store.list_streams().await.expect("opens");
         let all: Vec<Vec<u8>> = stream
-            .map(|r| r.expect("no error").to_vec())
+            .map(|r| r.expect("no error").as_bytes().to_vec())
             .collect::<Vec<_>>()
             .await;
         assert_eq!(all, vec![b"busy".to_vec()], "one entry, no per-event dupes");
@@ -511,7 +495,7 @@ mod tests {
             rt.block_on(async {
                 let store = InMemoryStore::new();
                 for s in &ids {
-                    append_one(&store, &tid(s), 1, b"p").await;
+                    append_one(&store, &sk(s), 1, b"p").await;
                 }
                 let listed = collect_stream_ids(&store).await;
                 let oracle: HashSet<Vec<u8>> =
@@ -541,7 +525,7 @@ mod tests {
         // The handle itself appends, lists, and exports — never `.raw()`.
         let store = Store::new(InMemoryStore::new());
         store
-            .append(&tid("acct-1"), None, &[env(1, b"x")])
+            .append(&sk("acct-1"), None, &[env(1, b"x")])
             .await
             .expect("append via the handle");
 
@@ -549,7 +533,7 @@ mod tests {
             .list_streams()
             .await
             .expect("list via the handle")
-            .map(|r| r.expect("no list error").to_vec())
+            .map(|r| r.expect("no list error").as_bytes().to_vec())
             .collect::<Vec<_>>()
             .await
             .into_iter()
@@ -557,7 +541,7 @@ mod tests {
         assert_eq!(ids, [b"acct-1".to_vec()].into_iter().collect());
 
         let exported: Vec<PersistedEnvelope> = store
-            .export_stream(&tid("acct-1"), Version::INITIAL)
+            .export_stream(&sk("acct-1"), Version::INITIAL)
             .await
             .expect("export via the handle")
             .map(|r| r.expect("no read error"))

--- a/crates/nexus-store/src/import.rs
+++ b/crates/nexus-store/src/import.rs
@@ -30,12 +30,13 @@
 //! ingest impl is a later card.
 
 use bytes::Bytes;
-use nexus::{Id, Version};
+use nexus::Version;
 use thiserror::Error;
 
 use crate::envelope::{PendingEnvelope, PersistedEnvelope};
 use crate::error::AppendError;
 use crate::store::{RawEventStore, Store};
+use crate::stream_id::StreamKey;
 
 /// Atomicity granularity for an import — a caller policy, not a format
 /// property. The same chunk imports either way.
@@ -97,9 +98,9 @@ impl StreamOutcome {
 /// One stream's outcome within an import, tagged with the caller's target
 /// stream id (echoed verbatim — import owns no naming policy).
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct StreamReport<I> {
-    /// The caller-supplied target stream id this outcome is for.
-    pub stream: I,
+pub struct StreamReport {
+    /// The target [`StreamKey`] this outcome is for.
+    pub stream: StreamKey,
     /// What happened to it.
     pub outcome: StreamOutcome,
 }
@@ -109,26 +110,26 @@ pub struct StreamReport<I> {
 /// In first-seen order. Describes only work that actually ran (a whole-chunk
 /// abort is an [`ImportError`], not a report of "nothing happened").
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ImportReport<I> {
-    streams: Vec<StreamReport<I>>,
+pub struct ImportReport {
+    streams: Vec<StreamReport>,
 }
 
-impl<I> ImportReport<I> {
+impl ImportReport {
     /// Build a report from per-stream outcomes.
     #[must_use]
-    pub const fn new(streams: Vec<StreamReport<I>>) -> Self {
+    pub const fn new(streams: Vec<StreamReport>) -> Self {
         Self { streams }
     }
 
     /// All per-stream outcomes, in first-seen order.
     #[must_use]
-    pub fn streams(&self) -> &[StreamReport<I>] {
+    pub fn streams(&self) -> &[StreamReport] {
         &self.streams
     }
 
     /// The streams the sync loop must act on — everything that isn't
     /// [`StreamOutcome::Complete`].
-    pub fn unfinished(&self) -> impl Iterator<Item = &StreamReport<I>> {
+    pub fn unfinished(&self) -> impl Iterator<Item = &StreamReport> {
         self.streams.iter().filter(|s| !s.outcome.is_complete())
     }
 
@@ -152,11 +153,10 @@ pub enum AbortReason {
 }
 
 /// A whole-operation import failure — distinct from the *expected* per-stream
-/// outcomes carried in an [`ImportReport`]. `E` is the underlying store
-/// error; `I` is the caller's target stream-id type.
+/// outcomes carried in an [`ImportReport`]. `E` is the underlying store error.
 #[derive(Debug, Error)]
 #[non_exhaustive]
-pub enum ImportError<E, I> {
+pub enum ImportError<E> {
     /// Chunk header unreadable: bad magic, unknown format-version, or a
     /// structurally unparseable block. Distinct from a per-block checksum
     /// failure (that is a per-stream [`StreamOutcome::Corrupt`]).
@@ -165,8 +165,11 @@ pub enum ImportError<E, I> {
     /// Whole-chunk atomicity only: a bad block rolled the entire chunk back —
     /// nothing was written. `stream` is the first offender; retry the whole
     /// chunk. (Per-stream atomicity never aborts — it reports per stream.)
-    #[error("chunk aborted at stream {stream:?}: {reason}")]
-    Aborted { stream: I, reason: AbortReason },
+    #[error("chunk aborted at stream {stream}: {reason}")]
+    Aborted {
+        stream: StreamKey,
+        reason: AbortReason,
+    },
     /// The underlying store transaction failed.
     #[error(transparent)]
     Store(E),
@@ -206,9 +209,9 @@ pub enum ImportBlock {
 /// head the target stream must currently be at (`None` = the stream must be
 /// fresh). Built by the importer's per-section planner.
 #[derive(Debug, Clone)]
-pub struct PlannedAppend<I> {
-    /// The resolved target stream id.
-    pub target: I,
+pub struct PlannedAppend {
+    /// The resolved target [`StreamKey`].
+    pub target: StreamKey,
     /// The version the target must currently be at (`None` = fresh stream).
     pub expected_version: Option<Version>,
     /// The contiguous run to append, in version order (always non-empty).
@@ -259,9 +262,9 @@ pub enum AtomicAppendError<E> {
 /// - On any failure, **no** write is applied.
 pub trait AtomicAppend: RawEventStore {
     /// Append every write atomically. See the trait contract.
-    fn atomic_append_many<I: Id>(
+    fn atomic_append_many(
         &self,
-        writes: &[PlannedAppend<I>],
+        writes: &[PlannedAppend],
     ) -> impl std::future::Future<Output = Result<(), AtomicAppendError<Self::Error>>> + Send;
 }
 
@@ -270,9 +273,9 @@ pub trait AtomicAppend: RawEventStore {
 /// free via the blanket impl below — so a handle holder can `store.import(..)`
 /// without `.raw()`.
 impl<S: AtomicAppend> AtomicAppend for Store<S> {
-    async fn atomic_append_many<I: Id>(
+    async fn atomic_append_many(
         &self,
-        writes: &[PlannedAppend<I>],
+        writes: &[PlannedAppend],
     ) -> Result<(), AtomicAppendError<Self::Error>> {
         self.raw().atomic_append_many(writes).await
     }
@@ -296,15 +299,18 @@ impl<S: AtomicAppend> AtomicAppend for Store<S> {
 /// rolled back. Empty sections produce no report entry.
 pub trait EventImporter: RawEventStore + AtomicAppend {
     /// Import per-stream sections onto caller-routed target streams.
-    fn import<I, R>(
+    ///
+    /// `route` maps each section's origin id bytes to a target [`StreamKey`]
+    /// (e.g. `task-123` → `phone:task-123`); for an identity restore it is
+    /// simply [`StreamKey::from_slice`].
+    fn import<R>(
         &self,
         sections: &[StreamSection],
         route: R,
         atomicity: Atomicity,
-    ) -> impl std::future::Future<Output = Result<ImportReport<I>, ImportError<Self::Error, I>>> + Send
+    ) -> impl std::future::Future<Output = Result<ImportReport, ImportError<Self::Error>>> + Send
     where
-        I: Id,
-        R: Fn(&[u8]) -> I + Send;
+        R: Fn(&[u8]) -> StreamKey + Send;
 }
 
 // =============================================================================
@@ -408,15 +414,14 @@ fn plan_section(section: &StreamSection) -> Result<SectionPlan, PlanError> {
 // =============================================================================
 
 impl<S: RawEventStore + AtomicAppend> EventImporter for S {
-    async fn import<I, R>(
+    async fn import<R>(
         &self,
         sections: &[StreamSection],
         route: R,
         atomicity: Atomicity,
-    ) -> Result<ImportReport<I>, ImportError<Self::Error, I>>
+    ) -> Result<ImportReport, ImportError<Self::Error>>
     where
-        I: Id,
-        R: Fn(&[u8]) -> I + Send,
+        R: Fn(&[u8]) -> StreamKey + Send,
     {
         match atomicity {
             Atomicity::PerStream => import_per_stream(self, sections, route).await,
@@ -436,15 +441,14 @@ impl<S: RawEventStore + AtomicAppend> EventImporter for S {
 /// An empty section (no blocks) produces no `StreamReport` entry; a caller
 /// correlating sections to report entries must not assume positional
 /// correspondence.
-async fn import_per_stream<S, I, R>(
+async fn import_per_stream<S, R>(
     store: &S,
     sections: &[StreamSection],
     route: R,
-) -> Result<ImportReport<I>, ImportError<S::Error, I>>
+) -> Result<ImportReport, ImportError<S::Error>>
 where
     S: RawEventStore,
-    I: Id,
-    R: Fn(&[u8]) -> I + Send,
+    R: Fn(&[u8]) -> StreamKey + Send,
 {
     let mut reports = Vec::with_capacity(sections.len());
     for section in sections {
@@ -493,18 +497,17 @@ where
 /// lands. First offender (section order, then block order) wins.
 ///
 /// [`WholeChunk`]: Atomicity::WholeChunk
-async fn import_whole_chunk<S, I, R>(
+async fn import_whole_chunk<S, R>(
     store: &S,
     sections: &[StreamSection],
     route: R,
-) -> Result<ImportReport<I>, ImportError<S::Error, I>>
+) -> Result<ImportReport, ImportError<S::Error>>
 where
     S: RawEventStore + AtomicAppend,
-    I: Id,
-    R: Fn(&[u8]) -> I + Send,
+    R: Fn(&[u8]) -> StreamKey + Send,
 {
     // Phase 1 — plan every section purely. Any halt is a hard abort here.
-    let mut writes: Vec<PlannedAppend<I>> = Vec::with_capacity(sections.len());
+    let mut writes: Vec<PlannedAppend> = Vec::with_capacity(sections.len());
     let mut firsts: Vec<Version> = Vec::with_capacity(sections.len());
     let mut lasts: Vec<Version> = Vec::with_capacity(sections.len());
     for section in sections {
@@ -611,9 +614,9 @@ mod tests {
         Version::new(n).expect("test version must be nonzero")
     }
 
-    fn report(stream: &str, outcome: StreamOutcome) -> StreamReport<String> {
+    fn report(stream: &str, outcome: StreamOutcome) -> StreamReport {
         StreamReport {
-            stream: stream.to_owned(),
+            stream: StreamKey::from_slice(stream.as_bytes()),
             outcome,
         }
     }
@@ -623,9 +626,9 @@ mod tests {
     assert_impl_all!(StreamOutcome: Send, Sync, Copy, Clone);
     assert_impl_all!(Atomicity: Send, Sync, Copy, Clone);
     assert_impl_all!(AbortReason: Send, Sync, Clone);
-    assert_impl_all!(StreamReport<String>: Send, Sync, Clone);
-    assert_impl_all!(ImportReport<String>: Send, Sync, Clone);
-    assert_impl_all!(ImportError<std::io::Error, String>: Send, Sync);
+    assert_impl_all!(StreamReport: Send, Sync, Clone);
+    assert_impl_all!(ImportReport: Send, Sync, Clone);
+    assert_impl_all!(ImportError<std::io::Error>: Send, Sync);
 
     // ── Atomicity: equality + Copy semantics ────────────────────────────────
 
@@ -691,7 +694,7 @@ mod tests {
 
     #[test]
     fn empty_report_is_vacuously_all_complete_with_no_unfinished() {
-        let report: ImportReport<String> = ImportReport::new(Vec::new());
+        let report: ImportReport = ImportReport::new(Vec::new());
         assert!(report.streams().is_empty());
         assert!(report.all_complete());
         assert_eq!(report.unfinished().count(), 0);
@@ -731,12 +734,24 @@ mod tests {
         let report = ImportReport::new(streams);
 
         // streams() preserves first-seen order and full set.
-        let all_ids: Vec<&str> = report.streams().iter().map(|s| s.stream.as_str()).collect();
-        assert_eq!(all_ids, ["done-1", "corrupt", "done-2", "mismatch"]);
+        let all_ids: Vec<&[u8]> = report
+            .streams()
+            .iter()
+            .map(|s| s.stream.as_bytes())
+            .collect();
+        assert_eq!(
+            all_ids,
+            [
+                b"done-1".as_ref(),
+                b"corrupt".as_ref(),
+                b"done-2".as_ref(),
+                b"mismatch".as_ref()
+            ]
+        );
 
         // unfinished() is EXACTLY the two non-Complete streams, in order.
-        let unfinished_ids: Vec<&str> = report.unfinished().map(|s| s.stream.as_str()).collect();
-        assert_eq!(unfinished_ids, ["corrupt", "mismatch"]);
+        let unfinished_ids: Vec<&[u8]> = report.unfinished().map(|s| s.stream.as_bytes()).collect();
+        assert_eq!(unfinished_ids, [b"corrupt".as_ref(), b"mismatch".as_ref()]);
 
         assert!(!report.all_complete());
     }
@@ -768,29 +783,30 @@ mod tests {
 
     #[test]
     fn import_error_malformed_display_is_exact() {
-        let err: ImportError<std::io::Error, String> = ImportError::Malformed("bad magic");
+        let err: ImportError<std::io::Error> = ImportError::Malformed("bad magic");
         assert_eq!(err.to_string(), "malformed chunk: bad magic");
     }
 
     #[test]
-    fn import_error_aborted_display_formats_stream_debug_and_reason() {
-        let err: ImportError<std::io::Error, String> = ImportError::Aborted {
-            stream: "phone:task-123".to_owned(),
+    fn import_error_aborted_display_formats_stream_and_reason() {
+        let err: ImportError<std::io::Error> = ImportError::Aborted {
+            stream: StreamKey::from_slice(b"phone:task-123"),
             reason: AbortReason::Mismatch {
                 expected: v(2),
                 got: v(5),
             },
         };
-        // {stream:?} → quoted Debug of String; reason via its Display.
+        // {stream} → StreamKey's Display (the UTF-8 string, unquoted); reason
+        // via its own Display.
         assert_eq!(
             err.to_string(),
-            "chunk aborted at stream \"phone:task-123\": version mismatch (expected 2, got 5)",
+            "chunk aborted at stream phone:task-123: version mismatch (expected 2, got 5)",
         );
     }
 
     #[test]
     fn import_error_version_overflow_display_is_exact() {
-        let err: ImportError<std::io::Error, String> = ImportError::VersionOverflow;
+        let err: ImportError<std::io::Error> = ImportError::VersionOverflow;
         assert_eq!(err.to_string(), "version overflow");
     }
 
@@ -806,7 +822,7 @@ mod tests {
         #[error("store failed")]
         struct DummyStore(#[source] RootCause);
 
-        let err: ImportError<DummyStore, String> = ImportError::Store(DummyStore(RootCause));
+        let err: ImportError<DummyStore> = ImportError::Store(DummyStore(RootCause));
 
         // transparent → Display equals the inner store error's Display.
         assert_eq!(err.to_string(), "store failed");
@@ -822,14 +838,14 @@ mod tests {
         // Error-chain shape pin: `Store` is the ONLY source-forwarding variant.
         // `Aborted` deliberately interpolates its `reason` into the message
         // (not `#[source]`), so it terminates the chain too.
-        let malformed: ImportError<std::io::Error, String> = ImportError::Malformed("x");
+        let malformed: ImportError<std::io::Error> = ImportError::Malformed("x");
         assert!(malformed.source().is_none());
 
-        let overflow: ImportError<std::io::Error, String> = ImportError::VersionOverflow;
+        let overflow: ImportError<std::io::Error> = ImportError::VersionOverflow;
         assert!(overflow.source().is_none());
 
-        let aborted: ImportError<std::io::Error, String> = ImportError::Aborted {
-            stream: "s".to_owned(),
+        let aborted: ImportError<std::io::Error> = ImportError::Aborted {
+            stream: StreamKey::from_slice(b"s"),
             reason: AbortReason::Corrupt,
         };
         assert!(aborted.source().is_none());
@@ -837,23 +853,8 @@ mod tests {
 
     // ── AtomicAppend helpers and tests ───────────────────────────────────────
 
-    #[derive(Debug, Clone, Hash, PartialEq, Eq)]
-    struct Tid(String);
-    impl std::fmt::Display for Tid {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            f.write_str(&self.0)
-        }
-    }
-    impl AsRef<[u8]> for Tid {
-        fn as_ref(&self) -> &[u8] {
-            self.0.as_bytes()
-        }
-    }
-    impl nexus::Id for Tid {
-        const BYTE_LEN: usize = 0;
-    }
-    fn tid(s: &str) -> Tid {
-        Tid(s.to_owned())
+    fn sk(s: &str) -> StreamKey {
+        StreamKey::from_slice(s.as_bytes())
     }
 
     fn pending(ver: u64, payload: &[u8]) -> PendingEnvelope {
@@ -864,15 +865,15 @@ mod tests {
             .build()
     }
 
-    fn planned(target: &str, expected: Option<u64>, versions: &[u64]) -> PlannedAppend<Tid> {
+    fn planned(target: &str, expected: Option<u64>, versions: &[u64]) -> PlannedAppend {
         PlannedAppend {
-            target: tid(target),
+            target: sk(target),
             expected_version: expected.and_then(Version::new),
             events: versions.iter().map(|n| pending(*n, b"p")).collect(),
         }
     }
 
-    async fn head_len(store: &crate::testing::InMemoryStore, id: &Tid) -> usize {
+    async fn head_len(store: &crate::testing::InMemoryStore, id: &StreamKey) -> usize {
         store
             .read_stream(id, Version::INITIAL)
             .await
@@ -888,8 +889,8 @@ mod tests {
         let store = crate::testing::InMemoryStore::new();
         let writes = vec![planned("a", None, &[1, 2]), planned("b", None, &[1])];
         store.atomic_append_many(&writes).await.expect("commits");
-        assert_eq!(head_len(&store, &tid("a")).await, 2);
-        assert_eq!(head_len(&store, &tid("b")).await, 1);
+        assert_eq!(head_len(&store, &sk("a")).await, 2);
+        assert_eq!(head_len(&store, &sk("b")).await, 1);
     }
 
     #[tokio::test]
@@ -898,7 +899,7 @@ mod tests {
         let store = crate::testing::InMemoryStore::new();
         // Pre-seed "b" to v1 so the second write (expecting fresh) conflicts.
         store
-            .append(&tid("b"), None, &[pending(1, b"seed")])
+            .append(&sk("b"), None, &[pending(1, b"seed")])
             .await
             .expect("seed");
 
@@ -918,8 +919,8 @@ mod tests {
             AtomicAppendError::Store(_) => panic!("expected Conflict, got Store"),
         }
         // Atomicity: NOTHING landed — "a" must still be empty.
-        assert_eq!(head_len(&store, &tid("a")).await, 0, "rolled back");
-        assert_eq!(head_len(&store, &tid("b")).await, 1, "unchanged");
+        assert_eq!(head_len(&store, &sk("a")).await, 0, "rolled back");
+        assert_eq!(head_len(&store, &sk("b")).await, 1, "unchanged");
     }
 
     // ── per-section planner ──────────────────────────────────────────────────
@@ -1076,11 +1077,11 @@ mod tests {
 
     // ── EventImporter PerStream behavioral tests ─────────────────────────────
 
-    fn identity_route(origin: &[u8]) -> Tid {
-        Tid(String::from_utf8(origin.to_vec()).expect("utf8 origin"))
+    fn identity_route(origin: &[u8]) -> StreamKey {
+        StreamKey::from_slice(origin)
     }
 
-    async fn versions(store: &crate::testing::InMemoryStore, id: &Tid) -> Vec<u64> {
+    async fn versions(store: &crate::testing::InMemoryStore, id: &StreamKey) -> Vec<u64> {
         store
             .read_stream(id, Version::INITIAL)
             .await
@@ -1105,8 +1106,8 @@ mod tests {
 
         assert!(report.all_complete());
         assert_eq!(report.streams().len(), 2);
-        assert_eq!(versions(&store, &tid("a")).await, vec![1, 2, 3]);
-        assert_eq!(versions(&store, &tid("b")).await, vec![1, 2]);
+        assert_eq!(versions(&store, &sk("a")).await, vec![1, 2, 3]);
+        assert_eq!(versions(&store, &sk("b")).await, vec![1, 2]);
         assert_eq!(
             report.streams()[0].outcome,
             StreamOutcome::Complete { version: v(3) }
@@ -1119,7 +1120,7 @@ mod tests {
         let store = crate::testing::InMemoryStore::new();
         for n in 1..=3 {
             store
-                .append(&tid("a"), Version::new(n - 1), &[pending(n, b"seed")])
+                .append(&sk("a"), Version::new(n - 1), &[pending(n, b"seed")])
                 .await
                 .expect("seed");
         }
@@ -1136,7 +1137,7 @@ mod tests {
                 got: v(2)
             }
         );
-        assert_eq!(versions(&store, &tid("a")).await, vec![1, 2, 3]);
+        assert_eq!(versions(&store, &sk("a")).await, vec![1, 2, 3]);
     }
 
     #[tokio::test]
@@ -1156,11 +1157,7 @@ mod tests {
                 got: v(4)
             }
         );
-        assert_eq!(
-            versions(&store, &tid("a")).await,
-            vec![1, 2],
-            "v4 held back"
-        );
+        assert_eq!(versions(&store, &sk("a")).await, vec![1, 2], "v4 held back");
     }
 
     #[tokio::test]
@@ -1182,7 +1179,7 @@ mod tests {
                 reached: Some(v(2))
             }
         );
-        assert_eq!(versions(&store, &tid("a")).await, vec![1, 2]);
+        assert_eq!(versions(&store, &sk("a")).await, vec![1, 2]);
     }
 
     #[tokio::test]
@@ -1198,7 +1195,7 @@ mod tests {
             report.streams()[0].outcome,
             StreamOutcome::Corrupt { reached: None }
         );
-        assert_eq!(versions(&store, &tid("a")).await, Vec::<u64>::new());
+        assert_eq!(versions(&store, &sk("a")).await, Vec::<u64>::new());
     }
 
     #[tokio::test]
@@ -1243,7 +1240,7 @@ mod tests {
 
         async fn append(
             &self,
-            id: &impl nexus::Id,
+            id: &StreamKey,
             expected_version: Option<Version>,
             envelopes: &[crate::envelope::PendingEnvelope],
         ) -> Result<(), AppendError<Self::Error>> {
@@ -1257,7 +1254,7 @@ mod tests {
 
         async fn read_stream(
             &self,
-            id: &impl nexus::Id,
+            id: &StreamKey,
             from: Version,
         ) -> Result<Self::Stream, Self::Error> {
             self.inner.read_stream(id, from).await
@@ -1272,9 +1269,9 @@ mod tests {
     }
 
     impl crate::import::AtomicAppend for FailingAppendStore {
-        async fn atomic_append_many<I: nexus::Id>(
+        async fn atomic_append_many(
             &self,
-            writes: &[crate::import::PlannedAppend<I>],
+            writes: &[crate::import::PlannedAppend],
         ) -> Result<(), crate::import::AtomicAppendError<Self::Error>> {
             self.inner.atomic_append_many(writes).await
         }
@@ -1297,7 +1294,7 @@ mod tests {
             .expect_err("store error must surface");
         assert!(matches!(err, ImportError::Store(_)));
         // No cross-stream rollback: section "a" stayed committed.
-        assert_eq!(versions(&store.inner, &tid("a")).await, vec![1, 2]);
+        assert_eq!(versions(&store.inner, &sk("a")).await, vec![1, 2]);
     }
 
     // ── EventImporter WholeChunk behavioral tests ────────────────────────────
@@ -1315,8 +1312,8 @@ mod tests {
             .await
             .expect("import ok");
         assert!(report.all_complete());
-        assert_eq!(versions(&store, &tid("a")).await, vec![1, 2]);
-        assert_eq!(versions(&store, &tid("b")).await, vec![1]);
+        assert_eq!(versions(&store, &sk("a")).await, vec![1, 2]);
+        assert_eq!(versions(&store, &sk("b")).await, vec![1]);
     }
 
     #[tokio::test]
@@ -1333,14 +1330,14 @@ mod tests {
             .expect_err("aborts");
         match err {
             ImportError::Aborted { stream, reason } => {
-                assert_eq!(stream, tid("b"));
+                assert_eq!(stream, sk("b"));
                 assert_eq!(reason, AbortReason::Corrupt);
             }
             other => panic!("expected Aborted, got {other:?}"),
         }
         // Atomicity: NOTHING landed — even the clean section "a" must be empty.
-        assert_eq!(versions(&store, &tid("a")).await, Vec::<u64>::new());
-        assert_eq!(versions(&store, &tid("b")).await, Vec::<u64>::new());
+        assert_eq!(versions(&store, &sk("a")).await, Vec::<u64>::new());
+        assert_eq!(versions(&store, &sk("b")).await, Vec::<u64>::new());
     }
 
     #[tokio::test]
@@ -1354,7 +1351,7 @@ mod tests {
             .expect_err("aborts");
         match err {
             ImportError::Aborted { stream, reason } => {
-                assert_eq!(stream, tid("a"));
+                assert_eq!(stream, sk("a"));
                 assert_eq!(
                     reason,
                     AbortReason::Mismatch {
@@ -1365,7 +1362,7 @@ mod tests {
             }
             other => panic!("expected Aborted, got {other:?}"),
         }
-        assert_eq!(versions(&store, &tid("a")).await, Vec::<u64>::new());
+        assert_eq!(versions(&store, &sk("a")).await, Vec::<u64>::new());
     }
 
     #[tokio::test]
@@ -1374,7 +1371,7 @@ mod tests {
         let store = crate::testing::InMemoryStore::new();
         for n in 1..=2 {
             store
-                .append(&tid("a"), Version::new(n - 1), &[pending(n, b"seed")])
+                .append(&sk("a"), Version::new(n - 1), &[pending(n, b"seed")])
                 .await
                 .expect("seed");
         }
@@ -1385,7 +1382,7 @@ mod tests {
             .expect_err("aborts");
         match err {
             ImportError::Aborted { stream, reason } => {
-                assert_eq!(stream, tid("a"));
+                assert_eq!(stream, sk("a"));
                 // store head 2 → wanted v3 next; offered v1.
                 assert_eq!(
                     reason,
@@ -1397,7 +1394,7 @@ mod tests {
             }
             other => panic!("expected Aborted, got {other:?}"),
         }
-        assert_eq!(versions(&store, &tid("a")).await, vec![1, 2], "unchanged");
+        assert_eq!(versions(&store, &sk("a")).await, vec![1, 2], "unchanged");
     }
 
     #[tokio::test]
@@ -1411,7 +1408,7 @@ mod tests {
             .expect_err("aborts");
         assert!(matches!(
             err,
-            ImportError::Aborted { ref stream, reason: AbortReason::Corrupt } if *stream == tid("a")
+            ImportError::Aborted { ref stream, reason: AbortReason::Corrupt } if *stream == sk("a")
         ));
     }
 
@@ -1422,7 +1419,7 @@ mod tests {
         // Pre-seed "b" to v1 so the SECOND write conflicts (index 1), while "a"
         // (index 0) would be fine — exercises index > 0 in the Conflict arm.
         store
-            .append(&tid("b"), None, &[pending(1, b"seed")])
+            .append(&sk("b"), None, &[pending(1, b"seed")])
             .await
             .expect("seed");
         let sections = vec![
@@ -1437,7 +1434,7 @@ mod tests {
             ImportError::Aborted { stream, reason } => {
                 assert_eq!(
                     stream,
-                    tid("b"),
+                    sk("b"),
                     "must report the conflicting SECOND section"
                 );
                 // "b" head is 1 → wanted v2 next; offered v1.
@@ -1452,8 +1449,8 @@ mod tests {
             other => panic!("expected Aborted, got {other:?}"),
         }
         // All-or-nothing: the clean section "a" must NOT have landed.
-        assert_eq!(versions(&store, &tid("a")).await, Vec::<u64>::new());
-        assert_eq!(versions(&store, &tid("b")).await, vec![1], "unchanged");
+        assert_eq!(versions(&store, &sk("a")).await, Vec::<u64>::new());
+        assert_eq!(versions(&store, &sk("b")).await, vec![1], "unchanged");
     }
 
     #[tokio::test]
@@ -1468,8 +1465,8 @@ mod tests {
         assert!(report.all_complete());
         // The empty section produces NO report entry; only "b".
         assert_eq!(report.streams().len(), 1);
-        assert_eq!(report.streams()[0].stream, tid("b"));
-        assert_eq!(versions(&store, &tid("b")).await, vec![1, 2]);
+        assert_eq!(report.streams()[0].stream, sk("b"));
+        assert_eq!(versions(&store, &sk("b")).await, vec![1, 2]);
     }
 
     // ── Defensive boundary: non-injective route (two origins → one target) ────
@@ -1484,14 +1481,14 @@ mod tests {
             section("o1", vec![evt(1), evt(2)]),
             section("o2", vec![evt(1), evt(2)]),
         ];
-        let to_same = |_origin: &[u8]| tid("T");
+        let to_same = |_origin: &[u8]| sk("T");
         let err = store
             .import(&sections, to_same, Atomicity::WholeChunk)
             .await
             .expect_err("non-injective route must abort");
         assert!(matches!(err, ImportError::Aborted { .. }));
         // All-or-nothing + no corruption: T is empty, definitely not [1,2,1,2].
-        assert_eq!(versions(&store, &tid("T")).await, Vec::<u64>::new());
+        assert_eq!(versions(&store, &sk("T")).await, Vec::<u64>::new());
     }
 
     #[tokio::test]
@@ -1504,13 +1501,13 @@ mod tests {
             section("o1", vec![evt(1), evt(2)]),
             section("o2", vec![evt(1), evt(2)]),
         ];
-        let to_same = |_origin: &[u8]| tid("T");
+        let to_same = |_origin: &[u8]| sk("T");
         let report = store
             .import(&sections, to_same, Atomicity::PerStream)
             .await
             .expect("import ok");
         assert_eq!(
-            versions(&store, &tid("T")).await,
+            versions(&store, &sk("T")).await,
             vec![1, 2],
             "no [1,2,1,2] corruption — second section rejected, not appended"
         );
@@ -1563,7 +1560,7 @@ mod tests {
     async fn export_section(store: &crate::testing::InMemoryStore, origin: &str) -> StreamSection {
         use crate::export::EventExporter;
         let blocks = store
-            .export_stream(&tid(origin), Version::INITIAL)
+            .export_stream(&sk(origin), Version::INITIAL)
             .await
             .expect("export opens")
             .map(|r| ImportBlock::Event(r.expect("no read error")))
@@ -1579,12 +1576,12 @@ mod tests {
         let source = crate::testing::InMemoryStore::new();
         for n in 1..=3 {
             source
-                .append(&tid("acct-1"), Version::new(n - 1), &[pending(n, b"a")])
+                .append(&sk("acct-1"), Version::new(n - 1), &[pending(n, b"a")])
                 .await
                 .expect("seed a");
         }
         source
-            .append(&tid("acct-2"), None, &[pending(1, b"b")])
+            .append(&sk("acct-2"), None, &[pending(1, b"b")])
             .await
             .expect("seed b");
 
@@ -1599,7 +1596,7 @@ mod tests {
         // global_seqs than the source — makes the restamp observable (a bug that
         // copied the source global_seq verbatim would now be caught).
         target
-            .append(&tid("warmup"), None, &[pending(1, b"warmup")])
+            .append(&sk("warmup"), None, &[pending(1, b"warmup")])
             .await
             .expect("warmup seed");
         let report = target
@@ -1612,14 +1609,14 @@ mod tests {
         // metadata/schema for every event of every stream.
         for origin in ["acct-1", "acct-2"] {
             let src: Vec<PersistedEnvelope> = source
-                .read_stream(&tid(origin), Version::INITIAL)
+                .read_stream(&sk(origin), Version::INITIAL)
                 .await
                 .expect("read")
                 .map(|r| r.expect("ok"))
                 .collect()
                 .await;
             let dst: Vec<PersistedEnvelope> = target
-                .read_stream(&tid(origin), Version::INITIAL)
+                .read_stream(&sk(origin), Version::INITIAL)
                 .await
                 .expect("read")
                 .map(|r| r.expect("ok"))
@@ -1664,7 +1661,7 @@ mod tests {
                 got: v(1)
             }
         );
-        assert_eq!(versions(&store, &tid("a")).await, vec![1, 2, 3], "no dupes");
+        assert_eq!(versions(&store, &sk("a")).await, vec![1, 2, 3], "no dupes");
     }
 
     #[tokio::test]
@@ -1682,7 +1679,7 @@ mod tests {
             .expect_err("re-import aborts");
         match err {
             ImportError::Aborted { stream, reason } => {
-                assert_eq!(stream, tid("a"));
+                assert_eq!(stream, sk("a"));
                 assert_eq!(
                     reason,
                     AbortReason::Mismatch {
@@ -1693,7 +1690,7 @@ mod tests {
             }
             other => panic!("expected Aborted, got {other:?}"),
         }
-        assert_eq!(versions(&store, &tid("a")).await, vec![1, 2], "no dupes");
+        assert_eq!(versions(&store, &sk("a")).await, vec![1, 2], "no dupes");
     }
 
     // ── Linearizability: concurrent import vs direct writer (CLAUDE rule 7 §4) ─
@@ -1717,7 +1714,7 @@ mod tests {
             for vn in 1..=n {
                 // Conflicts are expected once the importer wins; ignore them.
                 let _ = writer_store
-                    .append(&tid("race"), Version::new(vn - 1), &[pending(vn, b"w")])
+                    .append(&sk("race"), Version::new(vn - 1), &[pending(vn, b"w")])
                     .await;
             }
         });
@@ -1748,7 +1745,7 @@ mod tests {
         }
 
         // Whatever the interleaving, the final stream is a gapless prefix from 1.
-        let final_versions = versions(&store, &tid("race")).await;
+        let final_versions = versions(&store, &sk("race")).await;
         for (expected, got) in (1u64..).zip(final_versions.iter()) {
             assert_eq!(*got, expected, "stream must be a gapless prefix from 1");
         }
@@ -1785,7 +1782,7 @@ mod tests {
                 .expect("runtime");
             rt.block_on(async {
                 let store = crate::testing::InMemoryStore::new();
-                let id = tid("m");
+                let id = sk("m");
                 // Model: next expected version (1 = fresh).
                 let mut next: u64 = 1;
 

--- a/crates/nexus-store/src/lib.rs
+++ b/crates/nexus-store/src/lib.rs
@@ -106,6 +106,7 @@ pub mod snapshot;
 pub mod state;
 pub mod store;
 pub mod stream;
+pub mod stream_id;
 #[cfg(feature = "subscription")]
 pub mod subscription;
 #[cfg(feature = "subscription")]
@@ -166,6 +167,7 @@ pub use state::{
 };
 pub use store::{GlobalSeq, RawEventStore, Store};
 pub use stream::EventStream;
+pub use stream_id::StreamKey;
 // Re-export the `Stream` trait from `futures-core` (the small, near-frozen
 // definitional crate) rather than `futures`. `futures::Stream` *is* this trait,
 // so our public `EventStream` / `subscribe*` surface is married to

--- a/crates/nexus-store/src/repository.rs
+++ b/crates/nexus-store/src/repository.rs
@@ -20,6 +20,7 @@ use crate::codec::{Decode, Encode};
 use crate::envelope::{PersistedEnvelope, pending_envelope};
 use crate::error::{AppendError, LoadWithError, StoreError};
 use crate::store::{RawEventStore, Store};
+use crate::stream_id::StreamKey;
 use crate::upcasting::EventMorsel;
 use crate::value::SchemaVersion;
 
@@ -261,7 +262,7 @@ where
 
         let raw_stream = store
             .raw()
-            .read_stream(root.id(), from)
+            .read_stream(&StreamKey::from_slice(root.id().as_ref()), from)
             .await
             .map_err(StoreError::Adapter)?;
 
@@ -354,7 +355,7 @@ impl<S, C, A> EventStore<S, C, A> {
 
         let raw_stream = store
             .raw()
-            .read_stream(root.id(), Version::INITIAL)
+            .read_stream(&StreamKey::from_slice(root.id().as_ref()), Version::INITIAL)
             .await
             .map_err(|e| LoadWithError::Store(StoreError::Adapter(e)))?;
 
@@ -479,7 +480,11 @@ where
 
     store
         .raw()
-        .append(aggregate.id(), expected_version, &envelopes)
+        .append(
+            &StreamKey::from_slice(aggregate.id().as_ref()),
+            expected_version,
+            &envelopes,
+        )
         .await
         .map_err(|err| match err {
             AppendError::Conflict {
@@ -562,7 +567,7 @@ where
 
         let raw_stream = store
             .raw()
-            .read_stream(root.id(), from)
+            .read_stream(&StreamKey::from_slice(root.id().as_ref()), from)
             .await
             .map_err(StoreError::Adapter)?;
 
@@ -647,7 +652,7 @@ impl<S, C, A> ZeroCopyEventStore<S, C, A> {
 
         let raw_stream = store
             .raw()
-            .read_stream(root.id(), Version::INITIAL)
+            .read_stream(&StreamKey::from_slice(root.id().as_ref()), Version::INITIAL)
             .await
             .map_err(|e| LoadWithError::Store(StoreError::Adapter(e)))?;
 
@@ -771,7 +776,11 @@ where
 
     store
         .raw()
-        .append(aggregate.id(), expected_version, &envelopes)
+        .append(
+            &StreamKey::from_slice(aggregate.id().as_ref()),
+            expected_version,
+            &envelopes,
+        )
         .await
         .map_err(|err| match err {
             AppendError::Conflict {

--- a/crates/nexus-store/src/store.rs
+++ b/crates/nexus-store/src/store.rs
@@ -2,11 +2,12 @@ use core::fmt;
 use std::num::NonZeroU64;
 use std::sync::Arc;
 
-use nexus::{Id, Version};
+use nexus::Version;
 
 use crate::envelope::PendingEnvelope;
 use crate::error::AppendError;
 use crate::stream::EventStream;
+use crate::stream_id::StreamKey;
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Store<S> — Arc-wrapped handle to a RawEventStore backend
@@ -64,11 +65,11 @@ impl<S> Store<S> {
     ///
     /// ```ignore
     /// use futures::TryStreamExt;
-    /// use nexus_store::{RawEventStore, Store};
+    /// use nexus_store::{RawEventStore, Store, StreamKey};
     ///
     /// async fn count_events<S: RawEventStore>(
     ///     store: &Store<S>,
-    ///     id: &impl nexus::Id,
+    ///     id: &StreamKey,
     ///     from: nexus::Version,
     /// ) -> Result<usize, MyError> {
     ///     let stream = store.raw().read_stream(id, from).await.map_err(MyError::Adapter)?;
@@ -175,7 +176,7 @@ pub trait RawEventStore: Send + Sync {
     /// the read path via `PersistedEnvelope::global_seq`.
     fn append(
         &self,
-        id: &impl Id,
+        id: &StreamKey,
         expected_version: Option<Version>,
         envelopes: &[PendingEnvelope],
     ) -> impl std::future::Future<Output = Result<(), AppendError<Self::Error>>> + Send;
@@ -204,7 +205,7 @@ pub trait RawEventStore: Send + Sync {
     /// cursor rather than fixed-size batches.
     fn read_stream(
         &self,
-        id: &impl Id,
+        id: &StreamKey,
         from: Version,
     ) -> impl std::future::Future<Output = Result<Self::Stream, Self::Error>> + Send;
 
@@ -277,14 +278,18 @@ impl<S: RawEventStore> RawEventStore for Store<S> {
 
     async fn append(
         &self,
-        id: &impl Id,
+        id: &StreamKey,
         expected_version: Option<Version>,
         envelopes: &[PendingEnvelope],
     ) -> Result<(), AppendError<Self::Error>> {
         self.raw().append(id, expected_version, envelopes).await
     }
 
-    async fn read_stream(&self, id: &impl Id, from: Version) -> Result<Self::Stream, Self::Error> {
+    async fn read_stream(
+        &self,
+        id: &StreamKey,
+        from: Version,
+    ) -> Result<Self::Stream, Self::Error> {
         self.raw().read_stream(id, from).await
     }
 

--- a/crates/nexus-store/src/stream_id.rs
+++ b/crates/nexus-store/src/stream_id.rs
@@ -1,0 +1,128 @@
+//! `StreamKey` — the store's stream-key type: validated raw bytes with a
+//! human-readable label.
+
+use core::fmt;
+
+use bytes::Bytes;
+
+/// The identifier of an event stream, as the store keys it: raw bytes.
+///
+/// The store is byte-level — at append/read it needs only a stream's **key
+/// bytes** and a **label** for diagnostics, never a domain aggregate identity.
+/// So the byte-level operations ([`RawEventStore::read_stream`](crate::RawEventStore::read_stream)
+/// / [`append`](crate::RawEventStore::append),
+/// [`export_stream`](crate::export::EventExporter::export_stream),
+/// [`list_streams`](crate::export::StreamLister::list_streams), and the
+/// [`import`](crate::import::EventImporter::import) target) speak `StreamKey`,
+/// not the kernel's [`Id`](nexus::Id) — honestly separating "a stream key" from
+/// "a domain identity" (issue #245). A consumer's typed domain id lives at the
+/// repository layer; the repository translates it to a `StreamKey` (its job).
+///
+/// Like the wire-field newtypes in [`value`](crate::value) (`EventType`,
+/// `Payload`, `Metadata`), `StreamKey` is a [`Bytes`]-backed newtype — so a
+/// stream key can never be confused with a payload or metadata buffer, and it
+/// carries a [`Display`](fmt::Display) the raw bytes cannot. A **non-UTF-8** id
+/// round-trips losslessly (unlike the former `from_utf8_lossy` reconstruction).
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct StreamKey(Bytes);
+
+impl StreamKey {
+    /// Build a `StreamKey` from any owned byte source (zero-copy for `Bytes` /
+    /// `Vec<u8>` / `String` / `&'static` slices and strs).
+    #[must_use]
+    pub fn from_bytes(bytes: impl Into<Bytes>) -> Self {
+        Self(bytes.into())
+    }
+
+    /// Build a `StreamKey` by copying a borrowed byte slice — the convenient
+    /// shape for an `import` route (`Fn(&[u8]) -> StreamKey`), for translating a
+    /// domain `id.as_ref()` at the repository boundary, or for any `&[u8]` key.
+    #[must_use]
+    pub fn from_slice(bytes: &[u8]) -> Self {
+        Self(Bytes::copy_from_slice(bytes))
+    }
+
+    /// The raw id bytes.
+    #[must_use]
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+
+    /// Consume into the backing `Bytes` (zero-copy).
+    #[must_use]
+    pub fn into_bytes(self) -> Bytes {
+        self.0
+    }
+}
+
+impl From<Bytes> for StreamKey {
+    fn from(bytes: Bytes) -> Self {
+        Self(bytes)
+    }
+}
+
+impl AsRef<[u8]> for StreamKey {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+/// A `StreamKey` is itself a valid [`Id`](nexus::Id): it already carries every
+/// supertrait the trait requires (clone, send/sync, debug, hash, eq, display,
+/// `AsRef<[u8]>`, `'static`). This is purely additive — the byte-level store
+/// API stays concrete (`&StreamKey`), but a raw key can now flow through the
+/// typed convenience layers (`Subscription::subscribe`, a repository whose
+/// `Aggregate::Id` is `StreamKey`) without a domain-id newtype. `BYTE_LEN` is
+/// `0` by the workspace convention for variable-length ids.
+impl nexus::Id for StreamKey {
+    const BYTE_LEN: usize = 0;
+}
+
+/// The string when the bytes are valid UTF-8, else `0x…` lowercase hex —
+/// faithful for binary ids, readable for the common string id, always
+/// unambiguous.
+impl fmt::Display for StreamKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Ok(s) = core::str::from_utf8(&self.0) {
+            return f.write_str(s);
+        }
+        f.write_str("0x")?;
+        for byte in &self.0 {
+            write!(f, "{byte:02x}")?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, reason = "test code")]
+mod tests {
+    use super::StreamKey;
+    use bytes::Bytes;
+
+    #[test]
+    fn round_trips_bytes_including_non_utf8() {
+        let raw = Bytes::from_static(&[0x00, 0xff, 0x42]);
+        let key = StreamKey::from_bytes(raw.clone());
+        assert_eq!(key.as_bytes(), &[0x00, 0xff, 0x42]);
+        assert_eq!(key.clone().into_bytes(), raw);
+        assert_eq!(StreamKey::from_slice(&[0x00, 0xff, 0x42]), key);
+    }
+
+    #[test]
+    fn display_is_the_string_for_utf8_ids() {
+        assert_eq!(
+            StreamKey::from_slice(b"account-123").to_string(),
+            "account-123"
+        );
+        assert_eq!(StreamKey::from_slice(b"").to_string(), "");
+    }
+
+    #[test]
+    fn display_is_hex_for_non_utf8_ids() {
+        assert_eq!(
+            StreamKey::from_slice(&[0x00, 0xff, 0x42]).to_string(),
+            "0x00ff42"
+        );
+    }
+}

--- a/crates/nexus-store/src/subscription_cursor.rs
+++ b/crates/nexus-store/src/subscription_cursor.rs
@@ -151,15 +151,16 @@ mod tests {
     use tokio::time::timeout;
 
     use super::*;
-    use crate::catchup::{AllCatchup, Catchup, OwnedSubId, StreamCatchup};
+    use crate::catchup::{AllCatchup, Catchup, StreamCatchup};
     use crate::envelope::pending_envelope;
     use crate::store::{GlobalSeq, RawEventStore};
+    use crate::stream_id::StreamKey;
     use crate::testing::InMemoryStore;
 
     const MUST_DELIVER: Duration = Duration::from_secs(5);
 
     /// Append events with versions `lo..=hi` to stream `id`.
-    async fn seed_range(store: &InMemoryStore, id: &OwnedSubId, lo: u64, hi: u64) {
+    async fn seed_range(store: &InMemoryStore, id: &StreamKey, lo: u64, hi: u64) {
         for v in lo..=hi {
             let env = pending_envelope(Version::new(v).unwrap())
                 .event_type("E")
@@ -174,7 +175,7 @@ mod tests {
     #[tokio::test]
     async fn catch_up_yields_backlog_in_order() {
         let store = Arc::new(InMemoryStore::new());
-        let id = OwnedSubId::new(b"s");
+        let id = StreamKey::from_slice(b"s");
         seed_range(&store, &id, 1, 5).await;
 
         let catchup = StreamCatchup::new(Arc::clone(&store), b"s").unwrap();
@@ -196,7 +197,7 @@ mod tests {
     #[tokio::test]
     async fn live_tail_sees_post_subscribe_append() {
         let store = Arc::new(InMemoryStore::new());
-        let id = OwnedSubId::new(b"s");
+        let id = StreamKey::from_slice(b"s");
         seed_range(&store, &id, 1, 1).await;
 
         let catchup = StreamCatchup::new(Arc::clone(&store), b"s").unwrap();
@@ -214,7 +215,7 @@ mod tests {
         // Append version 2 after the cursor is parked.
         let writer = Arc::clone(&store);
         let appender = tokio::spawn(async move {
-            seed_range(&writer, &OwnedSubId::new(b"s"), 2, 2).await;
+            seed_range(&writer, &StreamKey::from_slice(b"s"), 2, 2).await;
         });
 
         let second = timeout(MUST_DELIVER, cursor.next())
@@ -236,7 +237,7 @@ mod tests {
     async fn chunk_boundary_no_duplicate_no_gap() {
         let total = u64::try_from(CATCHUP_CHUNK).unwrap() + 3;
         let store = Arc::new(InMemoryStore::new());
-        let id = OwnedSubId::new(b"s");
+        let id = StreamKey::from_slice(b"s");
         seed_range(&store, &id, 1, total).await;
 
         let catchup = StreamCatchup::new(Arc::clone(&store), b"s").unwrap();
@@ -261,8 +262,8 @@ mod tests {
     async fn all_catchup_yields_global_order_then_live_append() {
         let store = Arc::new(InMemoryStore::new());
         // Interleave across two streams so global_seq spans both: a@1, b@1, a@2.
-        seed_range(&store, &OwnedSubId::new(b"a"), 1, 1).await;
-        seed_range(&store, &OwnedSubId::new(b"b"), 1, 1).await;
+        seed_range(&store, &StreamKey::from_slice(b"a"), 1, 1).await;
+        seed_range(&store, &StreamKey::from_slice(b"b"), 1, 1).await;
         // a@2 builds on a's head (expected version 1).
         let env = pending_envelope(Version::new(2).unwrap())
             .event_type("E")
@@ -270,7 +271,7 @@ mod tests {
             .unwrap()
             .build();
         store
-            .append(&OwnedSubId::new(b"a"), Version::new(1), &[env])
+            .append(&StreamKey::from_slice(b"a"), Version::new(1), &[env])
             .await
             .unwrap();
 
@@ -303,7 +304,7 @@ mod tests {
                 .unwrap()
                 .build();
             writer
-                .append(&OwnedSubId::new(b"b"), Version::new(1), &[env])
+                .append(&StreamKey::from_slice(b"b"), Version::new(1), &[env])
                 .await
                 .unwrap();
         });
@@ -381,7 +382,7 @@ mod tests {
     async fn scan_item_error_is_surfaced_in_order() {
         // Read back a real PersistedEnvelope to feed the mock's Ok item.
         let store = Arc::new(InMemoryStore::new());
-        seed_range(&store, &OwnedSubId::new(b"s"), 1, 1).await;
+        seed_range(&store, &StreamKey::from_slice(b"s"), 1, 1).await;
         let ok_env = store
             .read_all(GlobalSeq::INITIAL)
             .await

--- a/crates/nexus-store/src/testing.rs
+++ b/crates/nexus-store/src/testing.rs
@@ -9,8 +9,9 @@ use crate::wake::WakeSource;
 use crate::wire::{self, FrameOffsets};
 use bytes::Bytes;
 use nexus::ErrorId;
-use nexus::Id;
 use nexus::Version;
+
+use crate::stream_id::StreamKey;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::collections::VecDeque;
@@ -319,7 +320,7 @@ impl RawEventStore for InMemoryStore {
 
     async fn append(
         &self,
-        id: &impl Id,
+        id: &StreamKey,
         expected_version: Option<Version>,
         envelopes: &[PendingEnvelope],
     ) -> Result<(), AppendError<Self::Error>> {
@@ -404,7 +405,11 @@ impl RawEventStore for InMemoryStore {
         Ok(())
     }
 
-    async fn read_stream(&self, id: &impl Id, from: Version) -> Result<Self::Stream, Self::Error> {
+    async fn read_stream(
+        &self,
+        id: &StreamKey,
+        from: Version,
+    ) -> Result<Self::Stream, Self::Error> {
         let state = ReadState {
             streams: Arc::clone(&self.streams),
             stream_id: id.to_string(),
@@ -544,14 +549,16 @@ impl WakeSource for InMemoryStore {
 /// is acceptable; a real adapter (fjall, postgres) streams them lazily.
 #[cfg(feature = "export")]
 impl crate::export::StreamLister for InMemoryStore {
-    type StreamList = futures::stream::Iter<std::vec::IntoIter<Result<Bytes, InMemoryStoreError>>>;
+    type StreamList = futures::stream::Iter<
+        std::vec::IntoIter<Result<crate::stream_id::StreamKey, InMemoryStoreError>>,
+    >;
 
     async fn list_streams(&self) -> Result<Self::StreamList, Self::Error> {
-        let ids: Vec<Result<Bytes, InMemoryStoreError>> = {
+        let ids: Vec<Result<crate::stream_id::StreamKey, InMemoryStoreError>> = {
             let guard = self.streams.lock().await;
             guard
                 .keys()
-                .map(|k| Ok(Bytes::copy_from_slice(k.as_bytes())))
+                .map(|k| Ok(crate::stream_id::StreamKey::from_slice(k.as_bytes())))
                 .collect()
         };
         Ok(futures::stream::iter(ids))
@@ -570,9 +577,9 @@ impl crate::export::StreamLister for InMemoryStore {
 /// `append`'s lock order (`streams` → `next_global_seq` → `global_index`).
 #[cfg(feature = "import")]
 impl crate::import::AtomicAppend for InMemoryStore {
-    async fn atomic_append_many<I: Id>(
+    async fn atomic_append_many(
         &self,
-        writes: &[crate::import::PlannedAppend<I>],
+        writes: &[crate::import::PlannedAppend],
     ) -> Result<(), crate::import::AtomicAppendError<Self::Error>> {
         use crate::import::AtomicAppendError;
 
@@ -714,22 +721,6 @@ mod bounded_read_tests {
     use crate::envelope::pending_envelope;
     use futures::StreamExt;
 
-    #[derive(Debug, Clone, Hash, PartialEq, Eq)]
-    struct Tid(String);
-    impl std::fmt::Display for Tid {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            f.write_str(&self.0)
-        }
-    }
-    impl AsRef<[u8]> for Tid {
-        fn as_ref(&self) -> &[u8] {
-            self.0.as_bytes()
-        }
-    }
-    impl nexus::Id for Tid {
-        const BYTE_LEN: usize = 0;
-    }
-
     fn env(v: u64) -> PendingEnvelope {
         pending_envelope(Version::new(v).unwrap())
             .event_type("E")
@@ -738,7 +729,7 @@ mod bounded_read_tests {
             .build()
     }
 
-    async fn seed(store: &InMemoryStore, id: &Tid, count: u64) {
+    async fn seed(store: &InMemoryStore, id: &StreamKey, count: u64) {
         for v in 1..=count {
             let expected = Version::new(v - 1);
             store.append(id, expected, &[env(v)]).await.unwrap();
@@ -748,7 +739,7 @@ mod bounded_read_tests {
     #[tokio::test]
     async fn read_yields_all_events_across_refills() {
         let store = InMemoryStore::with_batch_size(BatchSize::new(4).unwrap());
-        let id = Tid("s".into());
+        let id = StreamKey::from_slice(b"s");
         seed(&store, &id, 14).await;
 
         let mut stream = store.read_stream(&id, Version::INITIAL).await.unwrap();
@@ -762,7 +753,7 @@ mod bounded_read_tests {
     #[tokio::test]
     async fn read_terminates_at_exact_batch_boundary() {
         let store = InMemoryStore::with_batch_size(BatchSize::new(4).unwrap());
-        let id = Tid("s".into());
+        let id = StreamKey::from_slice(b"s");
         seed(&store, &id, 4).await;
 
         let mut stream = store.read_stream(&id, Version::INITIAL).await.unwrap();
@@ -776,7 +767,7 @@ mod bounded_read_tests {
     #[tokio::test]
     async fn read_empty_stream_yields_nothing() {
         let store = InMemoryStore::with_batch_size(BatchSize::new(4).unwrap());
-        let id = Tid("missing".into());
+        let id = StreamKey::from_slice(b"missing");
         let mut stream = store.read_stream(&id, Version::INITIAL).await.unwrap();
         assert!(stream.next().await.is_none());
     }
@@ -784,7 +775,7 @@ mod bounded_read_tests {
     #[tokio::test]
     async fn read_from_midpoint_resumes_correctly() {
         let store = InMemoryStore::with_batch_size(BatchSize::new(3).unwrap());
-        let id = Tid("s".into());
+        let id = StreamKey::from_slice(b"s");
         seed(&store, &id, 10).await;
         let mut stream = store
             .read_stream(&id, Version::new(6).unwrap())
@@ -805,7 +796,7 @@ mod bounded_read_tests {
     #[tokio::test]
     async fn read_stays_none_after_exhaustion() {
         let store = InMemoryStore::with_batch_size(BatchSize::new(4).unwrap());
-        let id = Tid("s".into());
+        let id = StreamKey::from_slice(b"s");
         seed(&store, &id, 5).await;
         let mut stream = store.read_stream(&id, Version::INITIAL).await.unwrap();
         let mut count = 0u64;
@@ -832,24 +823,8 @@ mod global_read_tests {
     use crate::envelope::pending_envelope;
     use futures::StreamExt;
 
-    #[derive(Debug, Clone, Hash, PartialEq, Eq)]
-    struct Tid(String);
-    impl std::fmt::Display for Tid {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            f.write_str(&self.0)
-        }
-    }
-    impl AsRef<[u8]> for Tid {
-        fn as_ref(&self) -> &[u8] {
-            self.0.as_bytes()
-        }
-    }
-    impl nexus::Id for Tid {
-        const BYTE_LEN: usize = 0;
-    }
-
-    fn tid(s: &str) -> Tid {
-        Tid(s.to_owned())
+    fn sk(s: &str) -> StreamKey {
+        StreamKey::from_slice(s.as_bytes())
     }
 
     async fn append_one(
@@ -865,7 +840,7 @@ mod global_read_tests {
             .unwrap()
             .build();
         store
-            .append(&tid(id), expected.and_then(Version::new), &[env])
+            .append(&sk(id), expected.and_then(Version::new), &[env])
             .await
             .unwrap();
     }
@@ -986,22 +961,6 @@ mod bounded_subscription_tests {
     use crate::envelope::pending_envelope;
     use futures::StreamExt;
 
-    #[derive(Debug, Clone, Hash, PartialEq, Eq)]
-    struct Tid(String);
-    impl std::fmt::Display for Tid {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            f.write_str(&self.0)
-        }
-    }
-    impl AsRef<[u8]> for Tid {
-        fn as_ref(&self) -> &[u8] {
-            self.0.as_bytes()
-        }
-    }
-    impl nexus::Id for Tid {
-        const BYTE_LEN: usize = 0;
-    }
-
     fn env(v: u64) -> PendingEnvelope {
         pending_envelope(Version::new(v).unwrap())
             .event_type("E")
@@ -1014,7 +973,7 @@ mod bounded_subscription_tests {
     async fn subscription_drains_many_batches_then_sees_new_event() {
         // batch_size 4; pre-seed 40 (10× batch_size backlog, 10 full refills), then push 1 live.
         let store = Store::new(InMemoryStore::with_batch_size(BatchSize::new(4).unwrap()));
-        let id = Tid("s".into());
+        let id = StreamKey::from_slice(b"s");
         for v in 1..=40 {
             store
                 .raw()
@@ -1055,29 +1014,13 @@ mod wake_source_tests {
     use std::time::Duration;
     use tokio::time::timeout;
 
-    #[derive(Debug, Clone, Hash, PartialEq, Eq)]
-    struct Tid(String);
-    impl std::fmt::Display for Tid {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            f.write_str(&self.0)
-        }
-    }
-    impl AsRef<[u8]> for Tid {
-        fn as_ref(&self) -> &[u8] {
-            self.0.as_bytes()
-        }
-    }
-    impl nexus::Id for Tid {
-        const BYTE_LEN: usize = 0;
-    }
-
     /// An `append` to a stream must wake a per-stream registration armed before
     /// the append — proving `InMemoryStore`'s `WakeSource` impl routes through
     /// the same `StreamNotifiers` that `append` wakes after a commit.
     #[tokio::test]
     async fn inmemory_wakes_registration_on_append() {
         let store = InMemoryStore::new();
-        let id = Tid("s".into());
+        let id = StreamKey::from_slice(b"s");
         let reg = WakeSource::register(&store, Some(id.as_ref())).unwrap();
         let wait = reg.arm();
         let env = pending_envelope(Version::INITIAL)

--- a/crates/nexus-store/tests/adversarial_property_tests.rs
+++ b/crates/nexus-store/tests/adversarial_property_tests.rs
@@ -117,25 +117,6 @@ fn label(s: &str) -> ErrorId {
     ErrorId::from_display(&s)
 }
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
-struct StreamName(String);
-impl fmt::Display for StreamName {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.0)
-    }
-}
-impl AsRef<[u8]> for StreamName {
-    fn as_ref(&self) -> &[u8] {
-        self.0.as_bytes()
-    }
-}
-impl nexus::Id for StreamName {
-    const BYTE_LEN: usize = 0;
-}
-fn sn(s: &str) -> StreamName {
-    StreamName(s.to_owned())
-}
-
 // ============================================================================
 // Test Domain Types (minimal aggregate for integration tests)
 // ============================================================================
@@ -294,9 +275,12 @@ fn build_envelopes_from(start_version: u64, payloads: &[Vec<u8>]) -> Vec<Pending
         .collect()
 }
 
-async fn read_all_payloads(store: &InMemoryStore, stream_id: &StreamName) -> Vec<Vec<u8>> {
+async fn read_all_payloads(
+    store: &InMemoryStore,
+    stream_id: &nexus_store::StreamKey,
+) -> Vec<Vec<u8>> {
     let mut stream = store
-        .read_stream(stream_id, Version::INITIAL)
+        .read_stream(&stream_id, Version::INITIAL)
         .await
         .unwrap();
     let mut payloads = Vec::new();
@@ -307,9 +291,9 @@ async fn read_all_payloads(store: &InMemoryStore, stream_id: &StreamName) -> Vec
     payloads
 }
 
-async fn read_all_versions(store: &InMemoryStore, stream_id: &StreamName) -> Vec<u64> {
+async fn read_all_versions(store: &InMemoryStore, stream_id: &nexus_store::StreamKey) -> Vec<u64> {
     let mut stream = store
-        .read_stream(stream_id, Version::INITIAL)
+        .read_stream(&stream_id, Version::INITIAL)
         .await
         .unwrap();
     let mut versions = Vec::new();
@@ -324,10 +308,10 @@ async fn read_all_versions(store: &InMemoryStore, stream_id: &StreamName) -> Vec
 // Strategies
 // ============================================================================
 
-fn stream_id_strategy() -> impl Strategy<Value = StreamName> {
+fn stream_id_strategy() -> impl Strategy<Value = nexus_store::StreamKey> {
     prop::string::string_regex("[a-z][a-z0-9_-]{0,29}")
         .unwrap()
-        .prop_map(StreamName)
+        .prop_map(|s| nexus_store::StreamKey::from_slice(s.as_bytes()))
 }
 
 fn payloads_strategy() -> impl Strategy<Value = Vec<Vec<u8>>> {
@@ -570,6 +554,7 @@ proptest! {
             );
             let result = store.append(
                 &stream_id,
+
                 Version::new(wrong_version),
                 &new_envelopes,
             ).await;
@@ -776,8 +761,8 @@ proptest! {
             let envelopes_a = build_envelopes(&payloads_a);
             let envelopes_b = build_envelopes(&payloads_b);
 
-            store.append(&id_a, None, &envelopes_a).await.unwrap();
-            store.append(&id_b, None, &envelopes_b).await.unwrap();
+            store.append(&nexus_store::StreamKey::from_slice(id_a.as_ref()), None, &envelopes_a).await.unwrap();
+            store.append(&nexus_store::StreamKey::from_slice(id_b.as_ref()), None, &envelopes_b).await.unwrap();
 
             let read_a = read_all_payloads(&store, &id_a).await;
             let read_b = read_all_payloads(&store, &id_b).await;
@@ -1090,7 +1075,11 @@ async fn attack_event_store_transforms_applied_on_load() {
             .build(),
     ];
     raw_store
-        .append(&sn("test-1"), None, &envelopes)
+        .append(
+            &nexus_store::StreamKey::from_slice("test-1".as_bytes()),
+            None,
+            &envelopes,
+        )
         .await
         .unwrap();
 
@@ -1157,7 +1146,7 @@ proptest! {
             for op in &ops {
                 match op {
                     ModelOp::Append { stream_id, payloads } => {
-                        let id = StreamName(stream_id.clone());
+                        let id = nexus_store::StreamKey::from_slice(stream_id.clone().as_bytes());
                         let model_stream = model.entry(stream_id.clone()).or_default();
                         let start_version = u64::try_from(model_stream.len()).unwrap();
                         let expected_version = Version::new(start_version);
@@ -1167,13 +1156,13 @@ proptest! {
                             payloads,
                         );
 
-                        let result = store.append(&id, expected_version, &envelopes).await;
+                        let result = store.append(&nexus_store::StreamKey::from_slice(id.as_ref()), expected_version, &envelopes).await;
                         prop_assert!(result.is_ok(), "append should succeed for model-valid operation");
 
                         model_stream.extend(payloads.iter().cloned());
                     }
                     ModelOp::Read { stream_id } => {
-                        let id = StreamName(stream_id.clone());
+                        let id = nexus_store::StreamKey::from_slice(stream_id.clone().as_bytes());
                         let expected = model.get(stream_id).cloned().unwrap_or_default();
                         let actual = read_all_payloads(&store, &id).await;
 
@@ -1225,6 +1214,7 @@ proptest! {
 
                 store.append(
                     &stream_id,
+
                     Version::new(total_events),
                     &envelopes,
                 ).await.unwrap();
@@ -1262,7 +1252,7 @@ proptest! {
         raw_stream_id in "[a-zA-Z0-9_./-]{0,100}",
     ) {
         // Any string can be used as an Id now. Test that evil IDs don't crash.
-        let stream_id = StreamName(raw_stream_id);
+        let stream_id = nexus_store::StreamKey::from_slice(raw_stream_id.as_bytes());
 
         let rt = tokio::runtime::Runtime::new().unwrap();
         rt.block_on(async {
@@ -1416,7 +1406,7 @@ proptest! {
                 let sid = stream_id.clone();
                 let expected = payloads.clone();
                 handles.push(tokio::spawn(async move {
-                    let mut stream = store.read_stream(&sid, Version::INITIAL).await.unwrap();
+                    let mut stream = store.read_stream(&nexus_store::StreamKey::from_slice(sid.as_ref()), Version::INITIAL).await.unwrap();
                     let mut read = Vec::new();
                     while let Some(__i) = stream.next().await { let env = __i.unwrap();
                         read.push(env.payload().to_vec());
@@ -1646,7 +1636,7 @@ proptest! {
 
             // Create many streams with many events
             for stream_idx in 0..num_streams {
-                let stream_id = StreamName(format!("stress-{}", stream_idx));
+                let stream_id = nexus_store::StreamKey::from_slice(format!("stress-{}", stream_idx).as_bytes());
                 let payloads: Vec<Vec<u8>> = (0..events_per_stream)
                     .map(|i| {
                         let mut p = vec![stream_idx as u8];
@@ -1661,7 +1651,7 @@ proptest! {
 
             // Verify each stream independently
             for stream_idx in 0..num_streams {
-                let stream_id = StreamName(format!("stress-{}", stream_idx));
+                let stream_id = nexus_store::StreamKey::from_slice(format!("stress-{}", stream_idx).as_bytes());
                 let read = read_all_payloads(&store, &stream_id).await;
                 prop_assert_eq!(
                     read.len(), events_per_stream,
@@ -1706,7 +1696,13 @@ async fn attack_concurrent_writers_exactly_one_wins() {
                 .expect("valid payload")
                 .build();
 
-            store.append(&sn("race-stream"), None, &[envelope]).await
+            store
+                .append(
+                    &nexus_store::StreamKey::from_slice("race-stream".as_bytes()),
+                    None,
+                    &[envelope],
+                )
+                .await
         }));
     }
 
@@ -1728,7 +1724,8 @@ async fn attack_concurrent_writers_exactly_one_wins() {
     );
 
     // The stream should have exactly 1 event
-    let payloads = read_all_payloads(&store, &sn("race-stream")).await;
+    let payloads =
+        read_all_payloads(&store, &nexus_store::StreamKey::from_slice(b"race-stream")).await;
     assert_eq!(payloads.len(), 1, "stream must have exactly 1 event");
 }
 
@@ -1912,19 +1909,19 @@ proptest! {
         rt.block_on(async {
             // Store A: write X first, then Y
             let store_a = InMemoryStore::new();
-            let sid_x = sn("x");
-            let sid_y = sn("y");
+            let sid_x = nexus_store::StreamKey::from_slice(b"x");
+            let sid_y = nexus_store::StreamKey::from_slice(b"y");
             let env_x = build_envelopes(&payloads_x);
             let env_y = build_envelopes(&payloads_y);
-            store_a.append(&sid_x, None, &env_x).await.unwrap();
-            store_a.append(&sid_y, None, &env_y).await.unwrap();
+            store_a.append(&nexus_store::StreamKey::from_slice(sid_x.as_ref()), None, &env_x).await.unwrap();
+            store_a.append(&nexus_store::StreamKey::from_slice(sid_y.as_ref()), None, &env_y).await.unwrap();
 
             // Store B: write Y first, then X
             let store_b = InMemoryStore::new();
             let env_x2 = build_envelopes(&payloads_x);
             let env_y2 = build_envelopes(&payloads_y);
-            store_b.append(&sid_y, None, &env_y2).await.unwrap();
-            store_b.append(&sid_x, None, &env_x2).await.unwrap();
+            store_b.append(&nexus_store::StreamKey::from_slice(sid_y.as_ref()), None, &env_y2).await.unwrap();
+            store_b.append(&nexus_store::StreamKey::from_slice(sid_x.as_ref()), None, &env_x2).await.unwrap();
 
             // Both stores should yield identical data for each stream
             let a_x = read_all_payloads(&store_a, &sid_x).await;

--- a/crates/nexus-store/tests/bounded_batch_proptest.rs
+++ b/crates/nexus-store/tests/bounded_batch_proptest.rs
@@ -9,30 +9,12 @@
 
 use futures::StreamExt;
 use nexus::Version;
+use nexus_store::StreamKey;
 use nexus_store::batch::BatchSize;
 use nexus_store::envelope::pending_envelope;
 use nexus_store::store::RawEventStore;
 use nexus_store::testing::InMemoryStore;
 use proptest::prelude::*;
-
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
-struct Tid(String);
-
-impl std::fmt::Display for Tid {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&self.0)
-    }
-}
-
-impl AsRef<[u8]> for Tid {
-    fn as_ref(&self) -> &[u8] {
-        self.0.as_bytes()
-    }
-}
-
-impl nexus::Id for Tid {
-    const BYTE_LEN: usize = 0;
-}
 
 fn batch_strategy() -> impl Strategy<Value = usize> {
     prop_oneof![
@@ -63,7 +45,7 @@ proptest! {
         let rt = tokio::runtime::Runtime::new().unwrap();
         rt.block_on(async {
             let store = InMemoryStore::with_batch_size(BatchSize::new(batch).unwrap());
-            let id = Tid("s".into());
+            let id = StreamKey::from_slice(b"s");
             for v in 1..=len {
                 let env = pending_envelope(Version::new(v).unwrap())
                     .event_type("E")

--- a/crates/nexus-store/tests/bug_hunt_tests.rs
+++ b/crates/nexus-store/tests/bug_hunt_tests.rs
@@ -35,7 +35,6 @@ use nexus_store::error::StoreError;
 use nexus_store::pending_envelope;
 use nexus_store::store::{GlobalSeq, RawEventStore};
 use std::collections::HashMap;
-use std::fmt;
 use tokio::sync::Mutex;
 
 fn build_persisted(
@@ -67,25 +66,6 @@ type TestStoreError = StoreError<InMemoryStoreError, std::io::Error, std::io::Er
 
 fn label(s: &str) -> ErrorId {
     ErrorId::from_display(&s)
-}
-
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
-struct TestId(String);
-impl fmt::Display for TestId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.0)
-    }
-}
-impl AsRef<[u8]> for TestId {
-    fn as_ref(&self) -> &[u8] {
-        self.0.as_bytes()
-    }
-}
-impl nexus::Id for TestId {
-    const BYTE_LEN: usize = 0;
-}
-fn tid(s: &str) -> TestId {
-    TestId(s.to_owned())
 }
 
 // ============================================================================
@@ -145,7 +125,7 @@ impl RawEventStore for ProbeStore {
 
     async fn append(
         &self,
-        id: &impl nexus::Id,
+        id: &nexus_store::StreamKey,
         expected_version: Option<Version>,
         envelopes: &[PendingEnvelope],
     ) -> Result<(), AppendError<Self::Error>> {
@@ -175,7 +155,7 @@ impl RawEventStore for ProbeStore {
 
     async fn read_stream(
         &self,
-        id: &impl nexus::Id,
+        id: &nexus_store::StreamKey,
         from: Version,
     ) -> Result<Self::Stream, Self::Error> {
         let events = self
@@ -289,7 +269,13 @@ async fn append_rejects_backwards_versions() {
             .build(),
     ];
 
-    let result = store.append(&tid("s1"), None, &envelopes).await;
+    let result = store
+        .append(
+            &nexus_store::StreamKey::from_slice("s1".as_bytes()),
+            None,
+            &envelopes,
+        )
+        .await;
     assert!(
         result.is_err(),
         "Adapter must reject non-sequential versions"
@@ -350,7 +336,7 @@ proptest! {
                 })
                 .collect();
 
-            let result = store.append(&tid("s1"), None, &envelopes).await;
+            let result = store.append(&nexus_store::StreamKey::from_slice("s1".as_bytes()), None, &envelopes).await;
 
             // Check if versions are actually sequential from 1
             let is_sequential = versions.iter().enumerate().all(|(i, &v)| v == (i as u64) + 1);

--- a/crates/nexus-store/tests/inmemory_conformance.rs
+++ b/crates/nexus-store/tests/inmemory_conformance.rs
@@ -11,38 +11,18 @@
 
 use std::num::NonZeroU32;
 
-use nexus::Id;
 use nexus_store::envelope::pending_envelope;
 use nexus_store::store::RawEventStore;
 use nexus_store::testing::InMemoryStore;
 use nexus_store::value::SchemaVersion;
-use nexus_store::{PendingEnvelope, Version};
+use nexus_store::{PendingEnvelope, StreamKey, Version};
 use nexus_store_testing::{ConformanceRow, assert_event_stream_conformance};
-
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
-struct StreamName(&'static str);
-
-impl std::fmt::Display for StreamName {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.0)
-    }
-}
-
-impl AsRef<[u8]> for StreamName {
-    fn as_ref(&self) -> &[u8] {
-        self.0.as_bytes()
-    }
-}
-
-impl Id for StreamName {
-    const BYTE_LEN: usize = 0;
-}
 
 #[tokio::test]
 async fn inmemory_event_stream_conforms() {
     assert_event_stream_conformance(|rows: Vec<ConformanceRow>| async move {
         let store = InMemoryStore::new();
-        let stream_id = StreamName("conformance");
+        let stream_id = StreamKey::from_slice(b"conformance");
 
         if !rows.is_empty() {
             let envelopes: Vec<PendingEnvelope> = rows

--- a/crates/nexus-store/tests/inmemory_store_tests.rs
+++ b/crates/nexus-store/tests/inmemory_store_tests.rs
@@ -3,50 +3,18 @@
 #![allow(clippy::panic, reason = "tests")]
 
 use futures::StreamExt;
-use nexus::{Id, Version};
+use nexus::Version;
 use nexus_store::AppendError;
+use nexus_store::StreamKey;
 use nexus_store::pending_envelope;
 use nexus_store::store::{GlobalSeq, RawEventStore};
 use nexus_store::testing::InMemoryStore;
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
-struct TestId(&'static str);
-impl std::fmt::Display for TestId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.0)
-    }
-}
-impl AsRef<[u8]> for TestId {
-    fn as_ref(&self) -> &[u8] {
-        self.0.as_bytes()
-    }
-}
-impl Id for TestId {
-    const BYTE_LEN: usize = 0;
-}
-
-/// An owned-`String` id so tests can build labels longer than the 64-byte
-/// `ErrorId` cap (the static-str [`TestId`] above can't carry a 200-byte id).
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
-struct LongId(String);
-impl std::fmt::Display for LongId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&self.0)
-    }
-}
-impl AsRef<[u8]> for LongId {
-    fn as_ref(&self) -> &[u8] {
-        self.0.as_bytes()
-    }
-}
-impl Id for LongId {
-    const BYTE_LEN: usize = 0;
-}
-
 #[tokio::test]
 async fn append_conflict_truncates_overlong_stream_id_with_ellipsis() {
     let store = InMemoryStore::new();
-    let long = LongId("y".repeat(200));
+    // An overlong id so the conflict label exceeds the 64-byte `ErrorId` cap.
+    let long = StreamKey::from_slice("y".repeat(200).as_bytes());
     let env = pending_envelope(Version::new(1).unwrap())
         .event_type("E")
         .payload(b"p".to_vec())
@@ -80,12 +48,12 @@ async fn append_and_read_back() {
         .expect("valid payload")
         .build();
     store
-        .append(&TestId("stream-1"), None, &[envelope])
+        .append(&StreamKey::from_slice(b"stream-1"), None, &[envelope])
         .await
         .unwrap();
 
     let mut stream = store
-        .read_stream(&TestId("stream-1"), Version::INITIAL)
+        .read_stream(&StreamKey::from_slice(b"stream-1"), Version::INITIAL)
         .await
         .unwrap();
     let env = stream.next().await.unwrap().unwrap();
@@ -117,11 +85,14 @@ async fn read_from_version_filters_correctly() {
             .expect("valid payload")
             .build(),
     ];
-    store.append(&TestId("s1"), None, &envelopes).await.unwrap();
+    store
+        .append(&StreamKey::from_slice(b"s1"), None, &envelopes)
+        .await
+        .unwrap();
 
     // Read from version 2 -- should get events 2 and 3.
     let mut stream = store
-        .read_stream(&TestId("s1"), Version::new(2).unwrap())
+        .read_stream(&StreamKey::from_slice(b"s1"), Version::new(2).unwrap())
         .await
         .unwrap();
 
@@ -156,7 +127,10 @@ async fn append_assigns_monotonic_global_seq_across_batches_and_streams() {
             .expect("valid payload")
             .build(),
     ];
-    store.append(&TestId("a"), None, &batch_a).await.unwrap();
+    store
+        .append(&StreamKey::from_slice(b"a"), None, &batch_a)
+        .await
+        .unwrap();
 
     // Second append: a single event on a *different* stream "b". Continues
     // from where stream "a" left off — seq 3, not reset to 1.
@@ -167,11 +141,14 @@ async fn append_assigns_monotonic_global_seq_across_batches_and_streams() {
             .expect("valid payload")
             .build(),
     ];
-    store.append(&TestId("b"), None, &batch_b).await.unwrap();
+    store
+        .append(&StreamKey::from_slice(b"b"), None, &batch_b)
+        .await
+        .unwrap();
 
     // Read stream "a" back: seq 1 then seq 2.
     let mut stream_a = store
-        .read_stream(&TestId("a"), Version::INITIAL)
+        .read_stream(&StreamKey::from_slice(b"a"), Version::INITIAL)
         .await
         .unwrap();
     let a1 = stream_a.next().await.unwrap().unwrap();
@@ -185,7 +162,7 @@ async fn append_assigns_monotonic_global_seq_across_batches_and_streams() {
     // Read stream "b" back: seq 3, proving the counter is store-global and
     // does not reset per stream.
     let mut stream_b = store
-        .read_stream(&TestId("b"), Version::INITIAL)
+        .read_stream(&StreamKey::from_slice(b"b"), Version::INITIAL)
         .await
         .unwrap();
     let b1 = stream_b.next().await.unwrap().unwrap();

--- a/crates/nexus-store/tests/integration_tests.rs
+++ b/crates/nexus-store/tests/integration_tests.rs
@@ -18,26 +18,10 @@
 #![allow(clippy::panic, reason = "tests use panic for error propagation")]
 
 use futures::StreamExt;
-use nexus::{Id, Version};
+use nexus::Version;
 use nexus_store::pending_envelope;
 use nexus_store::store::RawEventStore;
 use nexus_store::testing::{InMemoryStore, InMemoryStream};
-
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
-struct TestId(&'static str);
-impl std::fmt::Display for TestId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.0)
-    }
-}
-impl AsRef<[u8]> for TestId {
-    fn as_ref(&self) -> &[u8] {
-        self.0.as_bytes()
-    }
-}
-impl Id for TestId {
-    const BYTE_LEN: usize = 0;
-}
 
 // =============================================================================
 // Helpers
@@ -84,20 +68,31 @@ async fn multi_batch_append_then_read_all() {
     // Batch 1: events with versions 1, 2, 3
     let batch1 = make_envelopes(1, 3);
     store
-        .append(&TestId("multi-batch-stream"), None, &batch1)
+        .append(
+            &nexus_store::StreamKey::from_slice("multi-batch-stream".as_bytes()),
+            None,
+            &batch1,
+        )
         .await
         .unwrap();
 
     // Batch 2: events with versions 4, 5, 6 — expected_version = 3
     let batch2 = make_envelopes(4, 3);
     store
-        .append(&TestId("multi-batch-stream"), Version::new(3), &batch2)
+        .append(
+            &nexus_store::StreamKey::from_slice("multi-batch-stream".as_bytes()),
+            Version::new(3),
+            &batch2,
+        )
         .await
         .unwrap();
 
     // Read all from the beginning (version 1 / INITIAL)
     let mut cursor = store
-        .read_stream(&TestId("multi-batch-stream"), Version::INITIAL)
+        .read_stream(
+            &nexus_store::StreamKey::from_slice("multi-batch-stream".as_bytes()),
+            Version::INITIAL,
+        )
         .await
         .unwrap();
     let events = collect_stream(&mut cursor).await;
@@ -113,13 +108,20 @@ async fn read_stream_from_version_filters_earlier() {
 
     let envelopes = make_envelopes(1, 5);
     store
-        .append(&TestId("filter-stream"), None, &envelopes)
+        .append(
+            &nexus_store::StreamKey::from_slice("filter-stream".as_bytes()),
+            None,
+            &envelopes,
+        )
         .await
         .unwrap();
 
     // Read starting from version 3
     let mut cursor = store
-        .read_stream(&TestId("filter-stream"), Version::new(3).unwrap())
+        .read_stream(
+            &nexus_store::StreamKey::from_slice("filter-stream".as_bytes()),
+            Version::new(3).unwrap(),
+        )
         .await
         .unwrap();
     let events = collect_stream(&mut cursor).await;
@@ -137,21 +139,33 @@ async fn concurrent_append_detects_conflict() {
     // Seed with 1 event
     let seed = make_envelopes(1, 1);
     store
-        .append(&TestId("conflict-stream"), None, &seed)
+        .append(
+            &nexus_store::StreamKey::from_slice("conflict-stream".as_bytes()),
+            None,
+            &seed,
+        )
         .await
         .unwrap();
 
     // Writer A: append event 2 with expected_version=1
     let writer_a = make_envelopes(2, 1);
     let result_a = store
-        .append(&TestId("conflict-stream"), Version::new(1), &writer_a)
+        .append(
+            &nexus_store::StreamKey::from_slice("conflict-stream".as_bytes()),
+            Version::new(1),
+            &writer_a,
+        )
         .await;
     assert!(result_a.is_ok(), "writer A should succeed");
 
     // Writer B: also tries with expected_version=1 (stale), should conflict
     let writer_b = make_envelopes(2, 1);
     let result_b = store
-        .append(&TestId("conflict-stream"), Version::new(1), &writer_b)
+        .append(
+            &nexus_store::StreamKey::from_slice("conflict-stream".as_bytes()),
+            Version::new(1),
+            &writer_b,
+        )
         .await;
     assert!(result_b.is_err(), "writer B should get a conflict error");
 
@@ -165,7 +179,10 @@ async fn concurrent_append_detects_conflict() {
 
     // Verify the stream only has the 2 events (seed + writer A)
     let mut cursor = store
-        .read_stream(&TestId("conflict-stream"), Version::INITIAL)
+        .read_stream(
+            &nexus_store::StreamKey::from_slice("conflict-stream".as_bytes()),
+            Version::INITIAL,
+        )
         .await
         .unwrap();
     let events = collect_stream(&mut cursor).await;
@@ -180,12 +197,19 @@ async fn large_batch_append_and_sequential_readback() {
 
     let envelopes = make_envelopes(1, count);
     store
-        .append(&TestId("large-batch-stream"), None, &envelopes)
+        .append(
+            &nexus_store::StreamKey::from_slice("large-batch-stream".as_bytes()),
+            None,
+            &envelopes,
+        )
         .await
         .unwrap();
 
     let mut cursor = store
-        .read_stream(&TestId("large-batch-stream"), Version::INITIAL)
+        .read_stream(
+            &nexus_store::StreamKey::from_slice("large-batch-stream".as_bytes()),
+            Version::INITIAL,
+        )
         .await
         .unwrap();
     let events = collect_stream(&mut cursor).await;
@@ -222,13 +246,20 @@ async fn read_from_future_version_returns_empty() {
     let store = InMemoryStore::new();
     let envelopes = make_envelopes(1, 3);
     store
-        .append(&TestId("future-version-stream"), None, &envelopes)
+        .append(
+            &nexus_store::StreamKey::from_slice("future-version-stream".as_bytes()),
+            None,
+            &envelopes,
+        )
         .await
         .unwrap();
 
     // Read from version 100 — no events exist at that version
     let mut cursor = store
-        .read_stream(&TestId("future-version-stream"), Version::new(100).unwrap())
+        .read_stream(
+            &nexus_store::StreamKey::from_slice("future-version-stream".as_bytes()),
+            Version::new(100).unwrap(),
+        )
         .await
         .unwrap();
     assert!(

--- a/crates/nexus-store/tests/property_tests.rs
+++ b/crates/nexus-store/tests/property_tests.rs
@@ -30,36 +30,16 @@
 )]
 
 use std::convert::Infallible;
-use std::fmt;
 
 use futures::StreamExt;
 use nexus::Version;
+use nexus_store::StreamKey;
 use nexus_store::envelope::PendingEnvelope;
 use nexus_store::pending_envelope;
 use nexus_store::store::RawEventStore;
 use nexus_store::testing::InMemoryStore;
 
 use proptest::prelude::*;
-
-// ============================================================================
-// Test ID type
-// ============================================================================
-
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
-struct TestId(String);
-impl fmt::Display for TestId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.0)
-    }
-}
-impl AsRef<[u8]> for TestId {
-    fn as_ref(&self) -> &[u8] {
-        self.0.as_bytes()
-    }
-}
-impl nexus::Id for TestId {
-    const BYTE_LEN: usize = 0;
-}
 
 // ============================================================================
 // Helper: build envelopes from payloads
@@ -90,10 +70,10 @@ fn build_envelopes(payloads: &[Vec<u8>]) -> Vec<PendingEnvelope> {
 // Property-based tests
 // ============================================================================
 
-fn stream_id_strategy() -> impl Strategy<Value = TestId> {
+fn stream_id_strategy() -> impl Strategy<Value = StreamKey> {
     prop::string::string_regex("[a-z][a-z0-9-]{0,19}")
         .unwrap()
-        .prop_map(TestId)
+        .prop_map(|s| StreamKey::from_slice(s.as_bytes()))
 }
 
 fn payloads_strategy() -> impl Strategy<Value = Vec<Vec<u8>>> {

--- a/crates/nexus-store/tests/repository_qa_tests.rs
+++ b/crates/nexus-store/tests/repository_qa_tests.rs
@@ -860,7 +860,11 @@ async fn d4_zero_copy_event_store_with_payload_mutating_upcaster() {
         .expect("valid payload")
         .build(); // schema_version defaults to 1
     raw_store
-        .append(&CounterId("counter-1".into()), None, &[legacy])
+        .append(
+            &nexus_store::StreamKey::from_slice("counter-1".as_bytes()),
+            None,
+            &[legacy],
+        )
         .await
         .unwrap();
 
@@ -897,7 +901,11 @@ async fn d4_upcaster_must_not_double_apply_to_new_events() {
         .expect("valid payload")
         .build(); // schema_version defaults to 1
     raw_store
-        .append(&CounterId("counter-1".into()), None, &[legacy])
+        .append(
+            &nexus_store::StreamKey::from_slice("counter-1".as_bytes()),
+            None,
+            &[legacy],
+        )
         .await
         .unwrap();
 
@@ -1478,12 +1486,19 @@ async fn d11_schema_version_always_one() {
             .build(),
     ];
     store
-        .append(&CounterId("counter-1".into()), None, &envelopes)
+        .append(
+            &nexus_store::StreamKey::from_slice("counter-1".as_bytes()),
+            None,
+            &envelopes,
+        )
         .await
         .unwrap();
 
     let mut stream = store
-        .read_stream(&CounterId("counter-1".into()), Version::INITIAL)
+        .read_stream(
+            &nexus_store::StreamKey::from_slice("counter-1".as_bytes()),
+            Version::INITIAL,
+        )
         .await
         .unwrap();
     let env1 = stream.next().await.unwrap().unwrap();

--- a/crates/nexus-store/tests/security_tests.rs
+++ b/crates/nexus-store/tests/security_tests.rs
@@ -27,7 +27,7 @@
 #![allow(clippy::str_to_string, reason = "tests use to_string/to_owned freely")]
 
 use futures::StreamExt;
-use nexus::{ErrorId, Id, Version};
+use nexus::{ErrorId, Version};
 use nexus_store::InMemoryStoreError;
 use nexus_store::error::StoreError;
 use nexus_store::pending_envelope;
@@ -39,22 +39,6 @@ type TestStoreError = StoreError<InMemoryStoreError, std::io::Error, std::io::Er
 
 fn label(s: &str) -> ErrorId {
     ErrorId::from_display(&s)
-}
-
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
-struct TestId(&'static str);
-impl std::fmt::Display for TestId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.0)
-    }
-}
-impl AsRef<[u8]> for TestId {
-    fn as_ref(&self) -> &[u8] {
-        self.0.as_bytes()
-    }
-}
-impl Id for TestId {
-    const BYTE_LEN: usize = 0;
 }
 
 // =============================================================================
@@ -81,13 +65,22 @@ fn c2_builder_accepts_empty_event_type() {
 async fn h1_append_empty_envelopes_is_noop_or_error() {
     let store = InMemoryStore::new();
     // Appending zero events should either be rejected or be a safe no-op
-    let result = store.append(&TestId("s1"), None, &[]).await;
+    let result = store
+        .append(
+            &nexus_store::StreamKey::from_slice("s1".as_bytes()),
+            None,
+            &[],
+        )
+        .await;
     // This should succeed (no-op) but version should not change
     assert!(result.is_ok());
 
     // Read should return empty stream
     let mut stream = store
-        .read_stream(&TestId("s1"), Version::INITIAL)
+        .read_stream(
+            &nexus_store::StreamKey::from_slice("s1".as_bytes()),
+            Version::INITIAL,
+        )
         .await
         .unwrap();
     assert!(
@@ -130,7 +123,13 @@ async fn h5_append_with_non_sequential_versions() {
     ];
 
     // This should fail — versions must be sequential
-    let result = store.append(&TestId("s1"), None, &envelopes).await;
+    let result = store
+        .append(
+            &nexus_store::StreamKey::from_slice("s1".as_bytes()),
+            None,
+            &envelopes,
+        )
+        .await;
     // Currently the test adapter accepts this — it should NOT
     // The EventStore facade (when built) should validate this
     assert!(
@@ -160,7 +159,13 @@ async fn h5_append_with_duplicate_versions() {
             .build(), // dup!
     ];
 
-    let result = store.append(&TestId("s1"), None, &envelopes).await;
+    let result = store
+        .append(
+            &nexus_store::StreamKey::from_slice("s1".as_bytes()),
+            None,
+            &envelopes,
+        )
+        .await;
     assert!(result.is_err(), "Append should reject duplicate versions");
 }
 
@@ -213,7 +218,10 @@ fn m2_pending_envelope_no_partial_eq() {
 async fn read_nonexistent_stream_returns_empty() {
     let store = InMemoryStore::new();
     let mut stream = store
-        .read_stream(&TestId("does-not-exist"), Version::INITIAL)
+        .read_stream(
+            &nexus_store::StreamKey::from_slice("does-not-exist".as_bytes()),
+            Version::INITIAL,
+        )
         .await
         .unwrap();
     assert!(
@@ -245,12 +253,29 @@ async fn streams_are_isolated() {
             .build(),
     ];
 
-    store.append(&TestId("stream-a"), None, &e1).await.unwrap();
-    store.append(&TestId("stream-b"), None, &e2).await.unwrap();
+    store
+        .append(
+            &nexus_store::StreamKey::from_slice("stream-a".as_bytes()),
+            None,
+            &e1,
+        )
+        .await
+        .unwrap();
+    store
+        .append(
+            &nexus_store::StreamKey::from_slice("stream-b".as_bytes()),
+            None,
+            &e2,
+        )
+        .await
+        .unwrap();
 
     // Read stream-a — should only see EventA
     let mut stream = store
-        .read_stream(&TestId("stream-a"), Version::INITIAL)
+        .read_stream(
+            &nexus_store::StreamKey::from_slice("stream-a".as_bytes()),
+            Version::INITIAL,
+        )
         .await
         .unwrap();
     let envelope = stream.next().await.unwrap().unwrap();
@@ -261,7 +286,10 @@ async fn streams_are_isolated() {
 
     // Read stream-b — should only see EventB
     let mut stream = store
-        .read_stream(&TestId("stream-b"), Version::INITIAL)
+        .read_stream(
+            &nexus_store::StreamKey::from_slice("stream-b".as_bytes()),
+            Version::INITIAL,
+        )
         .await
         .unwrap();
     let envelope = stream.next().await.unwrap().unwrap();

--- a/crates/nexus-store/tests/subscription_tests.rs
+++ b/crates/nexus-store/tests/subscription_tests.rs
@@ -53,7 +53,14 @@ async fn append_one(
     event_type: &'static str,
 ) {
     let envelope = make_envelope(version, event_type);
-    store.raw().append(id, expected, &[envelope]).await.unwrap();
+    store
+        .append(
+            &nexus_store::StreamKey::from_slice(id.as_ref()),
+            expected,
+            &[envelope],
+        )
+        .await
+        .unwrap();
 }
 
 /// Timeout duration for operations that should complete quickly.

--- a/crates/nexus-store/tests/wire_alignment_tests.rs
+++ b/crates/nexus-store/tests/wire_alignment_tests.rs
@@ -22,53 +22,12 @@
     reason = "tests inline const ET_LENGTHS at the only use site"
 )]
 
-use std::fmt;
-
 use bytes::Bytes;
 use futures::StreamExt;
-use nexus::{Id, Version};
+use nexus::Version;
 use nexus_store::store::RawEventStore;
 use nexus_store::testing::InMemoryStore;
-use nexus_store::{PendingEnvelope, pending_envelope};
-
-#[derive(Clone)]
-struct TestId(String);
-
-impl fmt::Display for TestId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.0)
-    }
-}
-
-impl fmt::Debug for TestId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "TestId({:?})", self.0)
-    }
-}
-
-impl AsRef<[u8]> for TestId {
-    fn as_ref(&self) -> &[u8] {
-        self.0.as_bytes()
-    }
-}
-
-impl core::hash::Hash for TestId {
-    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
-        self.0.hash(state);
-    }
-}
-
-impl PartialEq for TestId {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-
-impl Eq for TestId {}
-
-impl Id for TestId {
-    const BYTE_LEN: usize = 0;
-}
+use nexus_store::{PendingEnvelope, StreamKey, pending_envelope};
 
 const ALIGN: usize = 16;
 
@@ -97,7 +56,7 @@ fn assert_payload_aligned(env: &nexus_store::PersistedEnvelope) {
 #[tokio::test]
 async fn sequence_payloads_are_aligned_across_a_single_stream() {
     let store = InMemoryStore::new();
-    let id = TestId("seq".into());
+    let id = StreamKey::from_slice(b"seq");
     let envelopes: Vec<_> = (1..=20).map(|n| build_envelope(n, "E", 42)).collect();
     store.append(&id, None, &envelopes).await.unwrap();
 
@@ -118,7 +77,7 @@ async fn sequence_payloads_are_aligned_across_a_single_stream() {
 #[tokio::test]
 async fn lifecycle_clone_then_read_preserves_alignment() {
     let store = std::sync::Arc::new(InMemoryStore::new());
-    let id = TestId("lc".into());
+    let id = StreamKey::from_slice(b"lc");
     store
         .append(&id, None, &[build_envelope(1, "E", 7)])
         .await
@@ -147,7 +106,7 @@ async fn boundary_event_type_lengths_around_alignment_boundary_all_aligned() {
     // We exercise event_type lengths around the 16-byte boundaries to
     // confirm the padding logic is correct at the seam.
     let store = InMemoryStore::new();
-    let id = TestId("boundary".into());
+    let id = StreamKey::from_slice(b"boundary");
     // Padding kicks in at header_len % 16 != 0. We pick a range of
     // event_type lengths that put the header at various positions inside
     // a 16-byte window.
@@ -179,7 +138,7 @@ async fn linearizability_concurrent_writer_aligned_payloads() {
     use tokio::sync::Barrier;
 
     let store = Arc::new(InMemoryStore::new());
-    let id = TestId("lin".into());
+    let id = StreamKey::from_slice(b"lin");
 
     // Pre-seed one event so the reader has something to consume.
     store

--- a/examples/fjall-end-to-end/src/lib.rs
+++ b/examples/fjall-end-to-end/src/lib.rs
@@ -70,7 +70,7 @@ use nexus_store::export::{EventExporter, StreamLister};
 use nexus_store::import::{Atomicity, EventImporter, StreamOutcome};
 use nexus_store::repository::Repository;
 use nexus_store::store::{RawEventStore, Store};
-use nexus_store::{PersistedEnvelope, Subscription};
+use nexus_store::{PersistedEnvelope, StreamKey, Subscription};
 
 use domain::{AccountEvent, AccountId, AccountState, BankAccount, Deposit, OpenAccount, Withdraw};
 
@@ -276,34 +276,29 @@ pub struct RoundTripOutcome {
     pub malformed_detected: bool,
 }
 
-/// Map a section's origin id bytes back to the same target id (the ids are
-/// UTF-8 account names).
-fn identity_route(origin: &[u8]) -> AccountId {
-    AccountId(String::from_utf8_lossy(origin).into_owned())
-}
-
 /// Build a CBOR backup chunk from every stream in `store`, via the handle's own
 /// `list_streams` + `export_stream` — the production export path, directly on
 /// the `Store` handle (no `.raw()`, #247). Streams are sorted for a
 /// deterministic layout.
+///
+/// `list_streams` yields [`StreamKey`]s, which flow straight back into
+/// `export_stream` — no domain-id reconstruction, no `from_utf8` round-trip
+/// (#245).
 async fn build_chunk(store: &Store<FjallStore>) -> Result<Vec<u8>, BoxErr> {
-    let mut ids: Vec<Vec<u8>> = store
+    let mut ids: Vec<StreamKey> = store
         .list_streams()
         .await?
-        .map(|r| r.map(|b| b.to_vec()))
         .collect::<Vec<_>>()
         .await
         .into_iter()
         .collect::<Result<_, _>>()?;
-    ids.sort();
+    ids.sort_by(|a, b| a.as_bytes().cmp(b.as_bytes()));
 
     let mut chunk = Vec::new();
     chunk.extend_from_slice(&encode_header(None)?);
-    for id_bytes in ids {
-        chunk.extend_from_slice(&encode_section_heading(&id_bytes)?);
-        let mut events = store
-            .export_stream(&identity_route(&id_bytes), Version::INITIAL)
-            .await?;
+    for id in ids {
+        chunk.extend_from_slice(&encode_section_heading(id.as_bytes())?);
+        let mut events = store.export_stream(&id, Version::INITIAL).await?;
         while let Some(item) = events.next().await {
             chunk.extend_from_slice(&encode_block(&item?)?);
         }
@@ -348,7 +343,7 @@ pub async fn run_export_import(work_dir: &Path) -> Result<RoundTripOutcome, BoxE
     let dst = FjallStore::builder(work_dir.join("dst"))
         .open()?
         .into_store();
-    dst.import(&sections, identity_route, Atomicity::WholeChunk)
+    dst.import(&sections, StreamKey::from_slice, Atomicity::WholeChunk)
         .await?;
 
     // 4. Rehydrate each aggregate from the destination and compare to source.
@@ -375,7 +370,11 @@ pub async fn run_export_import(work_dir: &Path) -> Result<RoundTripOutcome, BoxE
         .open()?
         .into_store();
     let report = probe
-        .import(&corrupt_sections, identity_route, Atomicity::PerStream)
+        .import(
+            &corrupt_sections,
+            StreamKey::from_slice,
+            Atomicity::PerStream,
+        )
         .await?;
     let corrupt_outcome = report
         .streams()

--- a/examples/projection-tokio/tests/loop_tests.rs
+++ b/examples/projection-tokio/tests/loop_tests.rs
@@ -181,7 +181,13 @@ async fn append_events(store: &Store<InMemoryStore>, stream_id: &TestId, events:
     let codec = TestEventCodec;
     let raw = store.raw();
     let current_len = {
-        let stream = raw.read_stream(stream_id, Version::INITIAL).await.unwrap();
+        let stream = raw
+            .read_stream(
+                &nexus_store::StreamKey::from_slice(stream_id.as_ref()),
+                Version::INITIAL,
+            )
+            .await
+            .unwrap();
         stream.count().await
     };
     let base_version = u64::try_from(current_len).unwrap();
@@ -201,7 +207,13 @@ async fn append_events(store: &Store<InMemoryStore>, stream_id: &TestId, events:
         .collect();
 
     let expected = Version::new(base_version).filter(|_| base_version > 0);
-    raw.append(stream_id, expected, &envelopes).await.unwrap();
+    raw.append(
+        &nexus_store::StreamKey::from_slice(stream_id.as_ref()),
+        expected,
+        &envelopes,
+    )
+    .await
+    .unwrap();
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -815,7 +827,11 @@ async fn runner_returns_event_codec_error_on_bad_payload() {
         .build();
     store
         .raw()
-        .append(&stream_id, None, &[bad_envelope])
+        .append(
+            &nexus_store::StreamKey::from_slice(stream_id.as_ref()),
+            None,
+            &[bad_envelope],
+        )
         .await
         .unwrap();
 

--- a/examples/store-and-kernel/src/main.rs
+++ b/examples/store-and-kernel/src/main.rs
@@ -24,7 +24,7 @@ use futures::StreamExt;
 use nexus::*;
 use nexus_store::store::RawEventStore;
 use nexus_store::testing::InMemoryStore;
-use nexus_store::{Decode, Encode, pending_envelope};
+use nexus_store::{Decode, Encode, StreamKey, pending_envelope};
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
@@ -245,7 +245,7 @@ async fn load_events(
     id: &AccountId,
 ) -> Vec<VersionedEvent<AccountEvent>> {
     let mut stream = store
-        .read_stream(id, Version::INITIAL)
+        .read_stream(&StreamKey::from_slice(id.as_ref()), Version::INITIAL)
         .await
         .expect("read_stream should succeed");
 
@@ -330,7 +330,11 @@ async fn main() {
     all_envelopes.append(&mut even_more);
 
     store
-        .append(&alice_id, None, &all_envelopes)
+        .append(
+            &StreamKey::from_slice(alice_id.as_ref()),
+            None,
+            &all_envelopes,
+        )
         .await
         .expect("append should succeed");
 
@@ -369,7 +373,11 @@ async fn main() {
     let base = account.version().map_or(0, |v| v.as_u64());
     let envelopes = encode_decided(&codec, &decided, base);
     store
-        .append(&alice_id, expected_version, &envelopes)
+        .append(
+            &StreamKey::from_slice(alice_id.as_ref()),
+            expected_version,
+            &envelopes,
+        )
         .await
         .expect("append should succeed");
 

--- a/examples/store-inmemory/src/main.rs
+++ b/examples/store-inmemory/src/main.rs
@@ -30,7 +30,7 @@ use nexus_store::Store;
 use nexus_store::store::RawEventStore;
 use nexus_store::testing::InMemoryStore;
 use nexus_store::upcasting::EventMorsel;
-use nexus_store::{Decode, Encode, pending_envelope};
+use nexus_store::{Decode, Encode, StreamKey, pending_envelope};
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
@@ -240,7 +240,7 @@ async fn main() {
     // --- Step 4: Append to the store ---
     println!("Step 4: Append envelopes to InMemoryStore");
     store
-        .append(&stream_id, None, &envelopes)
+        .append(&StreamKey::from_slice(stream_id.as_ref()), None, &envelopes)
         .await
         .expect("append should succeed");
     println!(
@@ -275,7 +275,11 @@ async fn main() {
             .build();
 
         store
-            .append(&stream_id, Version::new(3), &[legacy_envelope])
+            .append(
+                &StreamKey::from_slice(stream_id.as_ref()),
+                Version::new(3),
+                &[legacy_envelope],
+            )
             .await
             .expect("append legacy event should succeed");
         println!("  Inserted legacy event at version 4");
@@ -285,7 +289,7 @@ async fn main() {
     // --- Step 5: Read back from the store ---
     println!("Step 5: Read events back from InMemoryStore");
     let mut event_stream = store
-        .read_stream(&stream_id, Version::INITIAL)
+        .read_stream(&StreamKey::from_slice(stream_id.as_ref()), Version::INITIAL)
         .await
         .expect("read should succeed");
 
@@ -359,7 +363,7 @@ async fn main() {
         .build();
     typed_store
         .raw()
-        .append(&TodoId("todo-2".to_owned()), None, &[envelope])
+        .append(&StreamKey::from_slice(b"todo-2"), None, &[envelope])
         .await
         .expect("append should succeed");
 
@@ -375,7 +379,7 @@ async fn main() {
     }
     let raw_stream = typed_store
         .raw()
-        .read_stream(&TodoId("todo-2".to_owned()), Version::INITIAL)
+        .read_stream(&StreamKey::from_slice(b"todo-2"), Version::INITIAL)
         .await
         .expect("read_stream should succeed");
     let codec_ref = &codec;


### PR DESCRIPTION
Closes #245.

## Problem

The byte-level store API took `&impl nexus::Id`, which falsely implied the store cared about *domain* identity — it only ever needs key bytes. Worse, the `list_streams` ↔ `export_stream` seam was inconsistent: `list_streams` yielded raw bytes but `export_stream` demanded `impl Id`, forcing a `from_utf8_lossy` reconstruction that **silently corrupted non-UTF-8 ids**.

## Change

Introduce a concrete **`StreamKey`** (a `Bytes`-backed newtype, mirroring the `value.rs` wire-field newtypes) and make every byte-level op speak it: `RawEventStore::{append,read_stream}`, `EventExporter::export_stream`, `StreamLister`, and the `EventImporter::import` route/target. Non-UTF-8 ids round-trip losslessly; `StreamKey: Display` renders the UTF-8 string, else `0x` lowercase hex.

- **`StreamKey: nexus::Id`** — additive: a raw key flows through the typed convenience layers (`subscribe`, a repository whose `Id` is `StreamKey`) while the byte API stays concrete `&StreamKey`.
- Drops the id generic from `AtomicAppend` / `PlannedAppend` / `StreamReport` / `ImportReport` / `ImportError` (each loses a type parameter).
- Deletes `OwnedSubId` — a duplicate of `StreamKey`'s role in the subscription catchup; the cursor now holds a `StreamKey` directly.
- The repository translates `A::Id` → `StreamKey` at its load/save boundary.
- `import(.., StreamKey::from_slice, ..)` — the identity route is now a constructor reference; the example's `identity_route` (and its lossy reconstruction) is gone.

Removes the per-test `struct XxxId(String) + Display + AsRef + impl Id` boilerplate every raw-store consumer carried just to name a stream. **Net −281 lines.**

## Breaking change

`RawEventStore::append`/`read_stream`, `EventExporter::export_stream`, `StreamLister::StreamList`, `EventImporter::import`, and the `AtomicAppend`/`PlannedAppend`/`StreamReport`/`ImportReport`/`ImportError` types now use the concrete `nexus_store::StreamKey` instead of `&impl Id` / an id type parameter.

## Verification

`nix flake check` green (clippy, fmt, deny, doc, hakari, nextest). nexus-store + nexus-fjall suites pass (incl. the 4 cross-cutting categories: sequence, lifecycle, defensive-boundary, linearizability). The 4 examples — including the `fjall-end-to-end` #227 canary — updated and compiling; the canary's import wiring collapsed to `StreamKey::from_slice`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)