### PR TITLE
ci: gate clippy on --all-targets and run snapshot tests (#262)

### DIFF
--- a/crates/nexus-store/Cargo.toml
+++ b/crates/nexus-store/Cargo.toml
@@ -67,7 +67,12 @@ workspace-hack = { version = "0.1", path = "../workspace-hack" }
 criterion = { workspace = true }
 futures = { workspace = true }
 insta = { workspace = true }
-nexus-store = { path = ".", features = ["testing", "export", "import", "cbor"] }
+# Self dev-dependency unifies feature-gated integration tests into the
+# default-feature nextest gate (which builds no explicit features). Without
+# `snapshot-json` the `snapshot`-gated test files (snapshot_tests.rs,
+# snapshot_integration_tests.rs) never compiled or ran in CI — nothing in the
+# default workspace graph enables `snapshot`. See issue #262.
+nexus-store = { path = ".", features = ["testing", "export", "import", "cbor", "snapshot-json"] }
 nexus-store-testing = { version = "0.1.0", path = "../nexus-store-testing" }
 proptest = { workspace = true }
 serde = { workspace = true }

--- a/crates/nexus-store/src/cbor.rs
+++ b/crates/nexus-store/src/cbor.rs
@@ -1274,7 +1274,7 @@ mod tests {
 
     #[tokio::test]
     async fn try_extend_surfaces_read_error_distinctly() {
-        let boom = std::io::Error::new(std::io::ErrorKind::Other, "boom");
+        let boom = std::io::Error::other("boom");
         let events = vec![Ok(persisted(1, 1, "E", None, b"x1")), Err(boom)];
         let mut w = ChunkWriter::new(Vec::new(), None).expect("new");
         let err = w

--- a/crates/nexus-store/src/export.rs
+++ b/crates/nexus-store/src/export.rs
@@ -513,6 +513,11 @@ mod tests {
 
     #[tokio::test]
     async fn store_handle_lists_and_exports_without_raw() {
+        // Substitutable: generic `StreamLister`/`EventExporter`-bounded code
+        // accepts the handle directly (the structural win of #247).
+        fn assert_lister<L: StreamLister>(_: &L) {}
+        fn assert_exporter<E: EventExporter>(_: &E) {}
+
         // The handle itself appends, lists, and exports — never `.raw()`.
         let store = Store::new(InMemoryStore::new());
         store
@@ -531,7 +536,7 @@ mod tests {
             .collect();
         assert_eq!(
             ids,
-            [b"acct-1".to_vec()].into_iter().collect::<HashSet<_>>()
+            std::iter::once(b"acct-1".to_vec()).collect::<HashSet<_>>()
         );
 
         let exported: Vec<PersistedEnvelope> = store
@@ -544,10 +549,7 @@ mod tests {
         assert_eq!(exported.len(), 1);
         assert_eq!(exported[0].version(), Version::INITIAL);
 
-        // Substitutable: generic `StreamLister`/`EventExporter`-bounded code
-        // accepts the handle directly (the structural win of #247).
-        fn assert_lister<L: StreamLister>(_: &L) {}
-        fn assert_exporter<E: EventExporter>(_: &E) {}
+        // The generic bounds above accept the handle directly (the #247 win).
         assert_lister(&store);
         assert_exporter(&store);
     }

--- a/crates/nexus-store/src/import.rs
+++ b/crates/nexus-store/src/import.rs
@@ -1509,6 +1509,11 @@ mod tests {
 
     #[tokio::test]
     async fn store_handle_imports_without_raw() {
+        // Substitutable: generic `EventImporter`/`AtomicAppend`-bounded code
+        // accepts the handle directly (the structural win of #247).
+        fn assert_importer<I: EventImporter>(_: &I) {}
+        fn assert_atomic<A: AtomicAppend>(_: &A) {}
+
         // The handle itself imports and atomic-appends — never `.raw()`.
         let store = Store::new(crate::testing::InMemoryStore::new());
         let sections = vec![section("a", vec![evt(1), evt(2)])];
@@ -1526,10 +1531,7 @@ mod tests {
             .await
             .expect("atomic append via the handle");
 
-        // Substitutable: generic `EventImporter`/`AtomicAppend`-bounded code
-        // accepts the handle directly (the structural win of #247).
-        fn assert_importer<I: EventImporter>(_: &I) {}
-        fn assert_atomic<A: AtomicAppend>(_: &A) {}
+        // The generic bounds above accept the handle directly (the #247 win).
         assert_importer(&store);
         assert_atomic(&store);
     }

--- a/crates/nexus-store/src/wire.rs
+++ b/crates/nexus-store/src/wire.rs
@@ -920,7 +920,7 @@ mod tests {
             let v = &frame.value;
 
             let mut sv_buf = [0u8; 4];
-            sv_buf.copy_from_slice(&v[SCHEMA_VERSION_OFFSET..SCHEMA_VERSION_OFFSET + 4]);
+            sv_buf.copy_from_slice(&v[SCHEMA_VERSION_OFFSET..EVENT_TYPE_LEN_OFFSET]);
             prop_assert_eq!(u32::from_le_bytes(sv_buf), schema_version.get());
 
             let mut et_len_buf = [0u8; 2];
@@ -1017,7 +1017,7 @@ mod tests {
         // (version byte 2) so the V2 fixed-field offsets/header size apply.
         let mut buf = vec![0u8; HEADER_FIXED_SIZE];
         buf[VERSION_OFFSET] = 2;
-        buf[SCHEMA_VERSION_OFFSET..SCHEMA_VERSION_OFFSET + 4].copy_from_slice(&1u32.to_le_bytes());
+        buf[SCHEMA_VERSION_OFFSET..EVENT_TYPE_LEN_OFFSET].copy_from_slice(&1u32.to_le_bytes());
         buf[EVENT_TYPE_LEN_OFFSET..EVENT_TYPE_LEN_OFFSET + 2]
             .copy_from_slice(&100u16.to_le_bytes());
         buf[META_LEN_OFFSET..META_LEN_OFFSET + 4].copy_from_slice(&META_LEN_ABSENT.to_le_bytes());
@@ -1032,7 +1032,7 @@ mod tests {
         // Header claims meta_len = 100 but no metadata bytes follow. V2 frame.
         let mut buf = vec![0u8; HEADER_FIXED_SIZE];
         buf[VERSION_OFFSET] = 2;
-        buf[SCHEMA_VERSION_OFFSET..SCHEMA_VERSION_OFFSET + 4].copy_from_slice(&1u32.to_le_bytes());
+        buf[SCHEMA_VERSION_OFFSET..EVENT_TYPE_LEN_OFFSET].copy_from_slice(&1u32.to_le_bytes());
         buf[EVENT_TYPE_LEN_OFFSET..EVENT_TYPE_LEN_OFFSET + 2].copy_from_slice(&0u16.to_le_bytes());
         buf[META_LEN_OFFSET..META_LEN_OFFSET + 4].copy_from_slice(&100u32.to_le_bytes());
         assert!(matches!(
@@ -1054,7 +1054,7 @@ mod tests {
         // bytes by hand-zeroing the header field.
         let frame = encode_frame(sv1(), &et("X"), &pl(b"p"), None).expect("encode");
         let mut bytes_vec = frame.value.to_vec();
-        bytes_vec[SCHEMA_VERSION_OFFSET..SCHEMA_VERSION_OFFSET + 4].fill(0);
+        bytes_vec[SCHEMA_VERSION_OFFSET..EVENT_TYPE_LEN_OFFSET].fill(0);
         let tampered = Bytes::from(bytes_vec);
         assert!(matches!(
             decode_frame(&tampered),
@@ -1226,7 +1226,7 @@ mod tests {
         // in little-endian. Asserting all three catches mis-offset bugs
         // a spot check would miss.
         assert_eq!(
-            &buf[SCHEMA_VERSION_OFFSET..SCHEMA_VERSION_OFFSET + 4],
+            &buf[SCHEMA_VERSION_OFFSET..EVENT_TYPE_LEN_OFFSET],
             &0x090A_0B0Cu32.to_le_bytes(),
         );
         assert_eq!(
@@ -1585,7 +1585,7 @@ mod tests {
         let sv_one = SchemaVersion::INITIAL;
         let frame = encode_frame(sv_one, &et_v, &payload, None).expect("valid frame for tamper");
         let mut bytes_vec = frame.value.to_vec();
-        bytes_vec[SCHEMA_VERSION_OFFSET..SCHEMA_VERSION_OFFSET + 4].fill(0);
+        bytes_vec[SCHEMA_VERSION_OFFSET..EVENT_TYPE_LEN_OFFSET].fill(0);
         let tampered = Bytes::from(bytes_vec);
         let err = decode_frame(&tampered).expect_err("schema_version=0 on wire rejected");
         assert!(matches!(err, DecodeError::CorruptSchemaVersion));

--- a/crates/nexus-store/tests/adversarial_property_tests.rs
+++ b/crates/nexus-store/tests/adversarial_property_tests.rs
@@ -271,7 +271,7 @@ async fn read_all_payloads(
     stream_id: &nexus_store::StreamKey,
 ) -> Vec<Vec<u8>> {
     let mut stream = store
-        .read_stream(&stream_id, Version::INITIAL)
+        .read_stream(stream_id, Version::INITIAL)
         .await
         .unwrap();
     let mut payloads = Vec::new();
@@ -284,7 +284,7 @@ async fn read_all_payloads(
 
 async fn read_all_versions(store: &InMemoryStore, stream_id: &nexus_store::StreamKey) -> Vec<u64> {
     let mut stream = store
-        .read_stream(&stream_id, Version::INITIAL)
+        .read_stream(stream_id, Version::INITIAL)
         .await
         .unwrap();
     let mut versions = Vec::new();
@@ -1066,7 +1066,7 @@ async fn attack_event_store_transforms_applied_on_load() {
     ];
     raw_store
         .append(
-            &nexus_store::StreamKey::from_slice("test-1".as_bytes()),
+            &nexus_store::StreamKey::from_slice(b"test-1"),
             None,
             &envelopes,
         )
@@ -1688,7 +1688,7 @@ async fn attack_concurrent_writers_exactly_one_wins() {
 
             store
                 .append(
-                    &nexus_store::StreamKey::from_slice("race-stream".as_bytes()),
+                    &nexus_store::StreamKey::from_slice(b"race-stream"),
                     None,
                     &[envelope],
                 )

--- a/crates/nexus-store/tests/bug_hunt_tests.rs
+++ b/crates/nexus-store/tests/bug_hunt_tests.rs
@@ -258,11 +258,7 @@ async fn append_rejects_backwards_versions() {
     ];
 
     let result = store
-        .append(
-            &nexus_store::StreamKey::from_slice("s1".as_bytes()),
-            None,
-            &envelopes,
-        )
+        .append(&nexus_store::StreamKey::from_slice(b"s1"), None, &envelopes)
         .await;
     assert!(
         result.is_err(),
@@ -324,7 +320,7 @@ proptest! {
                 })
                 .collect();
 
-            let result = store.append(&nexus_store::StreamKey::from_slice("s1".as_bytes()), None, &envelopes).await;
+            let result = store.append(&nexus_store::StreamKey::from_slice(b"s1"), None, &envelopes).await;
 
             // Check if versions are actually sequential from 1
             let is_sequential = versions.iter().enumerate().all(|(i, &v)| v == (i as u64) + 1);

--- a/crates/nexus-store/tests/integration_tests.rs
+++ b/crates/nexus-store/tests/integration_tests.rs
@@ -69,7 +69,7 @@ async fn multi_batch_append_then_read_all() {
     let batch1 = make_envelopes(1, 3);
     store
         .append(
-            &nexus_store::StreamKey::from_slice("multi-batch-stream".as_bytes()),
+            &nexus_store::StreamKey::from_slice(b"multi-batch-stream"),
             None,
             &batch1,
         )
@@ -80,7 +80,7 @@ async fn multi_batch_append_then_read_all() {
     let batch2 = make_envelopes(4, 3);
     store
         .append(
-            &nexus_store::StreamKey::from_slice("multi-batch-stream".as_bytes()),
+            &nexus_store::StreamKey::from_slice(b"multi-batch-stream"),
             Version::new(3),
             &batch2,
         )
@@ -90,7 +90,7 @@ async fn multi_batch_append_then_read_all() {
     // Read all from the beginning (version 1 / INITIAL)
     let mut cursor = store
         .read_stream(
-            &nexus_store::StreamKey::from_slice("multi-batch-stream".as_bytes()),
+            &nexus_store::StreamKey::from_slice(b"multi-batch-stream"),
             Version::INITIAL,
         )
         .await
@@ -109,7 +109,7 @@ async fn read_stream_from_version_filters_earlier() {
     let envelopes = make_envelopes(1, 5);
     store
         .append(
-            &nexus_store::StreamKey::from_slice("filter-stream".as_bytes()),
+            &nexus_store::StreamKey::from_slice(b"filter-stream"),
             None,
             &envelopes,
         )
@@ -119,7 +119,7 @@ async fn read_stream_from_version_filters_earlier() {
     // Read starting from version 3
     let mut cursor = store
         .read_stream(
-            &nexus_store::StreamKey::from_slice("filter-stream".as_bytes()),
+            &nexus_store::StreamKey::from_slice(b"filter-stream"),
             Version::new(3).unwrap(),
         )
         .await
@@ -140,7 +140,7 @@ async fn concurrent_append_detects_conflict() {
     let seed = make_envelopes(1, 1);
     store
         .append(
-            &nexus_store::StreamKey::from_slice("conflict-stream".as_bytes()),
+            &nexus_store::StreamKey::from_slice(b"conflict-stream"),
             None,
             &seed,
         )
@@ -151,7 +151,7 @@ async fn concurrent_append_detects_conflict() {
     let writer_a = make_envelopes(2, 1);
     let result_a = store
         .append(
-            &nexus_store::StreamKey::from_slice("conflict-stream".as_bytes()),
+            &nexus_store::StreamKey::from_slice(b"conflict-stream"),
             Version::new(1),
             &writer_a,
         )
@@ -162,7 +162,7 @@ async fn concurrent_append_detects_conflict() {
     let writer_b = make_envelopes(2, 1);
     let result_b = store
         .append(
-            &nexus_store::StreamKey::from_slice("conflict-stream".as_bytes()),
+            &nexus_store::StreamKey::from_slice(b"conflict-stream"),
             Version::new(1),
             &writer_b,
         )
@@ -180,7 +180,7 @@ async fn concurrent_append_detects_conflict() {
     // Verify the stream only has the 2 events (seed + writer A)
     let mut cursor = store
         .read_stream(
-            &nexus_store::StreamKey::from_slice("conflict-stream".as_bytes()),
+            &nexus_store::StreamKey::from_slice(b"conflict-stream"),
             Version::INITIAL,
         )
         .await
@@ -198,7 +198,7 @@ async fn large_batch_append_and_sequential_readback() {
     let envelopes = make_envelopes(1, count);
     store
         .append(
-            &nexus_store::StreamKey::from_slice("large-batch-stream".as_bytes()),
+            &nexus_store::StreamKey::from_slice(b"large-batch-stream"),
             None,
             &envelopes,
         )
@@ -207,7 +207,7 @@ async fn large_batch_append_and_sequential_readback() {
 
     let mut cursor = store
         .read_stream(
-            &nexus_store::StreamKey::from_slice("large-batch-stream".as_bytes()),
+            &nexus_store::StreamKey::from_slice(b"large-batch-stream"),
             Version::INITIAL,
         )
         .await
@@ -247,7 +247,7 @@ async fn read_from_future_version_returns_empty() {
     let envelopes = make_envelopes(1, 3);
     store
         .append(
-            &nexus_store::StreamKey::from_slice("future-version-stream".as_bytes()),
+            &nexus_store::StreamKey::from_slice(b"future-version-stream"),
             None,
             &envelopes,
         )
@@ -257,7 +257,7 @@ async fn read_from_future_version_returns_empty() {
     // Read from version 100 — no events exist at that version
     let mut cursor = store
         .read_stream(
-            &nexus_store::StreamKey::from_slice("future-version-stream".as_bytes()),
+            &nexus_store::StreamKey::from_slice(b"future-version-stream"),
             Version::new(100).unwrap(),
         )
         .await

--- a/crates/nexus-store/tests/repository_qa_tests.rs
+++ b/crates/nexus-store/tests/repository_qa_tests.rs
@@ -861,7 +861,7 @@ async fn d4_zero_copy_event_store_with_payload_mutating_upcaster() {
         .build(); // schema_version defaults to 1
     raw_store
         .append(
-            &nexus_store::StreamKey::from_slice("counter-1".as_bytes()),
+            &nexus_store::StreamKey::from_slice(b"counter-1"),
             None,
             &[legacy],
         )
@@ -899,7 +899,7 @@ async fn d4_upcaster_must_not_double_apply_to_new_events() {
         .build(); // schema_version defaults to 1
     raw_store
         .append(
-            &nexus_store::StreamKey::from_slice("counter-1".as_bytes()),
+            &nexus_store::StreamKey::from_slice(b"counter-1"),
             None,
             &[legacy],
         )
@@ -1484,7 +1484,7 @@ async fn d11_schema_version_always_one() {
     ];
     store
         .append(
-            &nexus_store::StreamKey::from_slice("counter-1".as_bytes()),
+            &nexus_store::StreamKey::from_slice(b"counter-1"),
             None,
             &envelopes,
         )
@@ -1493,7 +1493,7 @@ async fn d11_schema_version_always_one() {
 
     let mut stream = store
         .read_stream(
-            &nexus_store::StreamKey::from_slice("counter-1".as_bytes()),
+            &nexus_store::StreamKey::from_slice(b"counter-1"),
             Version::INITIAL,
         )
         .await

--- a/crates/nexus-store/tests/security_tests.rs
+++ b/crates/nexus-store/tests/security_tests.rs
@@ -66,21 +66,14 @@ async fn h1_append_empty_envelopes_is_noop_or_error() {
     let store = InMemoryStore::new();
     // Appending zero events should either be rejected or be a safe no-op
     let result = store
-        .append(
-            &nexus_store::StreamKey::from_slice("s1".as_bytes()),
-            None,
-            &[],
-        )
+        .append(&nexus_store::StreamKey::from_slice(b"s1"), None, &[])
         .await;
     // This should succeed (no-op) but version should not change
     assert!(result.is_ok());
 
     // Read should return empty stream
     let mut stream = store
-        .read_stream(
-            &nexus_store::StreamKey::from_slice("s1".as_bytes()),
-            Version::INITIAL,
-        )
+        .read_stream(&nexus_store::StreamKey::from_slice(b"s1"), Version::INITIAL)
         .await
         .unwrap();
     assert!(
@@ -124,11 +117,7 @@ async fn h5_append_with_non_sequential_versions() {
 
     // This should fail — versions must be sequential
     let result = store
-        .append(
-            &nexus_store::StreamKey::from_slice("s1".as_bytes()),
-            None,
-            &envelopes,
-        )
+        .append(&nexus_store::StreamKey::from_slice(b"s1"), None, &envelopes)
         .await;
     // Currently the test adapter accepts this — it should NOT
     // The EventStore facade (when built) should validate this
@@ -160,11 +149,7 @@ async fn h5_append_with_duplicate_versions() {
     ];
 
     let result = store
-        .append(
-            &nexus_store::StreamKey::from_slice("s1".as_bytes()),
-            None,
-            &envelopes,
-        )
+        .append(&nexus_store::StreamKey::from_slice(b"s1"), None, &envelopes)
         .await;
     assert!(result.is_err(), "Append should reject duplicate versions");
 }
@@ -219,7 +204,7 @@ async fn read_nonexistent_stream_returns_empty() {
     let store = InMemoryStore::new();
     let mut stream = store
         .read_stream(
-            &nexus_store::StreamKey::from_slice("does-not-exist".as_bytes()),
+            &nexus_store::StreamKey::from_slice(b"does-not-exist"),
             Version::INITIAL,
         )
         .await
@@ -254,26 +239,18 @@ async fn streams_are_isolated() {
     ];
 
     store
-        .append(
-            &nexus_store::StreamKey::from_slice("stream-a".as_bytes()),
-            None,
-            &e1,
-        )
+        .append(&nexus_store::StreamKey::from_slice(b"stream-a"), None, &e1)
         .await
         .unwrap();
     store
-        .append(
-            &nexus_store::StreamKey::from_slice("stream-b".as_bytes()),
-            None,
-            &e2,
-        )
+        .append(&nexus_store::StreamKey::from_slice(b"stream-b"), None, &e2)
         .await
         .unwrap();
 
     // Read stream-a — should only see EventA
     let mut stream = store
         .read_stream(
-            &nexus_store::StreamKey::from_slice("stream-a".as_bytes()),
+            &nexus_store::StreamKey::from_slice(b"stream-a"),
             Version::INITIAL,
         )
         .await
@@ -287,7 +264,7 @@ async fn streams_are_isolated() {
     // Read stream-b — should only see EventB
     let mut stream = store
         .read_stream(
-            &nexus_store::StreamKey::from_slice("stream-b".as_bytes()),
+            &nexus_store::StreamKey::from_slice(b"stream-b"),
             Version::INITIAL,
         )
         .await

--- a/flake.nix
+++ b/flake.nix
@@ -71,9 +71,14 @@
         checks = {
           nexus-clippy = craneLib.cargoClippy (commonArgs // {
             inherit cargoArtifacts;
-            # Whole-workspace clippy. nexus-framework is temporarily excluded
-            # until its projection-runner refactor clears its lint backlog.
-            cargoClippyExtraArgs = "--workspace --all-features --lib --exclude nexus-framework -- --deny warnings";
+            # Whole-workspace clippy across ALL targets (lib, tests, benches,
+            # examples) under the full feature set. `--all-targets` (not the
+            # old `--lib`) is load-bearing: test code is only compiled — and so
+            # only linted — when targets beyond the lib are built, and
+            # `--all-features` is only meaningful once those targets exist. The
+            # `--lib`-only gate let a test-code compile break slip in under
+            # `rkyv` (issue #262); this closes that hole.
+            cargoClippyExtraArgs = "--workspace --all-features --all-targets -- --deny warnings";
           });
 
           nexus-doc =


### PR DESCRIPTION
## Problem

The `nix flake check` gate ran clippy `--workspace --all-features --lib` and nextest on the default feature set, so it **never compiled test code under `--all-features`**. The `rkyv`-only test compile break in #262 slipped through for exactly this reason.

Investigating the ticket's "broader question" surfaced that the named one-liner was already fixed (#266), but two structural gate holes remained.

## Fixes

**1. clippy gate `--lib` → `--all-targets`.** Test/example/bench code is only linted when targets beyond the lib are built. Flipping the gate surfaced ~40 latent lints in `nexus-store` test code — `string_lit_as_bytes`, `needless_borrow`, `io_other_error`, `items_after_statements`, `range_plus_one`, `iter_on_single_items` — all fixed here. Also dropped the stale `--exclude nexus-framework` (that crate is retired; clippy warned it was "not found in workspace").

**2. Snapshot tests never *ran* in CI.** `snapshot_tests.rs` / `snapshot_integration_tests.rs` are gated on the `snapshot` feature, which nothing in the default workspace graph enables — so their 31 tests never executed. Added `snapshot-json` to the `nexus-store` self dev-dependency (the same unification pattern already used for `testing`/`export`/`import`/`cbor`) so the default-feature gate compiles and runs them.

## Verification

- `cargo clippy --workspace --all-features --all-targets` — clean (exit 0).
- The 31 snapshot tests: `31 passed, 0 skipped`.
- Full `nix flake check` passes (clippy, fmt, nextest, doc, deny, audit, hakari).

Closes #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)