### PR TITLE
feat(kernel)!: blanket Id impl, drop the never-read BYTE_LEN const (#252)

### DIFF
--- a/crates/nexus-fjall/src/subscription_id.rs
+++ b/crates/nexus-fjall/src/subscription_id.rs
@@ -1,13 +1,15 @@
 //! Private module: the `pub` items below are crate-local by containment (no
 //! external API leak). It exists so the per-stream `scan.rs` strategy has an
-//! owned [`OwnedStreamId`] satisfying the [`Id`] `'static` bound across the
-//! re-reads the generic subscription loop performs.
+//! owned [`OwnedStreamId`] satisfying the [`Id`](nexus::Id) `'static` bound
+//! across the re-reads the generic subscription loop performs.
 
-use nexus::Id;
 use nexus_store::StreamKey;
 
-/// Owned byte-key wrapper to satisfy the [`Id`] trait's `'static` bound
-/// when re-reading from the store during subscription refills.
+/// Owned byte-key wrapper to satisfy the [`Id`](nexus::Id) trait's `'static`
+/// bound when re-reading from the store during subscription refills.
+///
+/// It is an `Id` for free via the blanket impl — it carries `Clone`, `Debug`,
+/// `Hash`, `Eq`, `Display`, and `AsRef<[u8]>` below, with no `impl Id` block.
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub struct OwnedStreamId(Vec<u8>);
 
@@ -31,8 +33,4 @@ impl AsRef<[u8]> for OwnedStreamId {
     fn as_ref(&self) -> &[u8] {
         &self.0
     }
-}
-
-impl Id for OwnedStreamId {
-    const BYTE_LEN: usize = 0;
 }

--- a/crates/nexus-macros/tests/adversarial_input.rs
+++ b/crates/nexus-macros/tests/adversarial_input.rs
@@ -21,9 +21,6 @@ impl AsRef<[u8]> for AId {
         &self.0
     }
 }
-impl Id for AId {
-    const BYTE_LEN: usize = 8;
-}
 
 #[derive(Debug, thiserror::Error)]
 #[error("e")]

--- a/crates/nexus-macros/tests/aggregate_derive.rs
+++ b/crates/nexus-macros/tests/aggregate_derive.rs
@@ -22,9 +22,6 @@ impl AsRef<[u8]> for TodoId {
         &self.0
     }
 }
-impl Id for TodoId {
-    const BYTE_LEN: usize = 8;
-}
 
 #[derive(Debug, Clone)]
 struct TodoCreated {

--- a/crates/nexus-macros/tests/cross_crate_test/src/lib.rs
+++ b/crates/nexus-macros/tests/cross_crate_test/src/lib.rs
@@ -26,10 +26,6 @@ impl AsRef<[u8]> for TaskId {
     }
 }
 
-impl Id for TaskId {
-    const BYTE_LEN: usize = 8;
-}
-
 // --- Events (derive macro from external crate) ---
 #[derive(Debug, Clone, DomainEvent)]
 pub enum TaskEvent {

--- a/crates/nexus-macros/tests/expand_roundtrip.rs
+++ b/crates/nexus-macros/tests/expand_roundtrip.rs
@@ -29,9 +29,6 @@ impl AsRef<[u8]> for RtId {
         &self.0
     }
 }
-impl Id for RtId {
-    const BYTE_LEN: usize = 8;
-}
 
 #[derive(Debug, Clone, PartialEq)]
 enum RtEvent {

--- a/crates/nexus-macros/tests/macro_attrs_preserved.rs
+++ b/crates/nexus-macros/tests/macro_attrs_preserved.rs
@@ -20,9 +20,6 @@ impl AsRef<[u8]> for AttrId {
         &self.0
     }
 }
-impl Id for AttrId {
-    const BYTE_LEN: usize = 8;
-}
 
 #[derive(Debug, Clone)]
 #[allow(

--- a/crates/nexus-macros/tests/macro_compile_fail/aggregate_bad_error.rs
+++ b/crates/nexus-macros/tests/macro_compile_fail/aggregate_bad_error.rs
@@ -26,7 +26,6 @@ impl std::fmt::Display for MyId {
 impl AsRef<[u8]> for MyId {
     fn as_ref(&self) -> &[u8] { &self.0 }
 }
-impl Id for MyId { const BYTE_LEN: usize = 8; }
 
 // NotAnError does NOT implement std::error::Error
 #[derive(Debug)]

--- a/crates/nexus-macros/tests/macro_compile_fail/aggregate_bad_error.stderr
+++ b/crates/nexus-macros/tests/macro_compile_fail/aggregate_bad_error.stderr
@@ -1,13 +1,13 @@
 error[E0277]: the trait bound `NotAnError: std::error::Error` is not satisfied
-  --> tests/macro_compile_fail/aggregate_bad_error.rs:35:40
+  --> tests/macro_compile_fail/aggregate_bad_error.rs:34:40
    |
-35 | #[nexus::aggregate(state = St, error = NotAnError, id = MyId)]
+34 | #[nexus::aggregate(state = St, error = NotAnError, id = MyId)]
    |                                        ^^^^^^^^^^ unsatisfied trait bound
    |
 help: the trait `std::error::Error` is not implemented for `NotAnError`
-  --> tests/macro_compile_fail/aggregate_bad_error.rs:33:1
+  --> tests/macro_compile_fail/aggregate_bad_error.rs:32:1
    |
-33 | struct NotAnError;
+32 | struct NotAnError;
    | ^^^^^^^^^^^^^^^^^
 note: required by a bound in `nexus::Aggregate::Error`
   --> $WORKSPACE/crates/nexus/src/aggregate.rs

--- a/crates/nexus-macros/tests/macro_compile_fail/aggregate_bad_id.stderr
+++ b/crates/nexus-macros/tests/macro_compile_fail/aggregate_bad_id.stderr
@@ -1,9 +1,10 @@
-error[E0277]: the trait bound `u64: Id` is not satisfied
+error[E0277]: the trait bound `u64: AsRef<[u8]>` is not satisfied
   --> tests/macro_compile_fail/aggregate_bad_id.rs:23:54
    |
 23 | #[nexus::aggregate(state = St, error = MyError, id = u64)]
-   |                                                      ^^^ the trait `Id` is not implemented for `u64`
+   |                                                      ^^^ the trait `AsRef<[u8]>` is not implemented for `u64`
    |
+   = note: required for `<BadAggregate as Aggregate>::Id` to implement `Id`
 note: required by a bound in `nexus::Aggregate::Id`
   --> $WORKSPACE/crates/nexus/src/aggregate.rs
    |

--- a/crates/nexus-macros/tests/macro_compile_fail/aggregate_bad_state.rs
+++ b/crates/nexus-macros/tests/macro_compile_fail/aggregate_bad_state.rs
@@ -13,7 +13,6 @@ impl std::fmt::Display for MyId {
 impl AsRef<[u8]> for MyId {
     fn as_ref(&self) -> &[u8] { &self.0 }
 }
-impl Id for MyId { const BYTE_LEN: usize = 8; }
 
 // NotAState does NOT implement AggregateState
 #[derive(Default, Debug)]

--- a/crates/nexus-macros/tests/macro_compile_fail/aggregate_bad_state.stderr
+++ b/crates/nexus-macros/tests/macro_compile_fail/aggregate_bad_state.stderr
@@ -1,13 +1,21 @@
+warning: unused import: `nexus::*`
+ --> tests/macro_compile_fail/aggregate_bad_state.rs:3:5
+  |
+3 | use nexus::*;
+  |     ^^^^^^^^
+  |
+  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
+
 error[E0277]: the trait bound `NotAState: AggregateState` is not satisfied
-  --> tests/macro_compile_fail/aggregate_bad_state.rs:26:28
+  --> tests/macro_compile_fail/aggregate_bad_state.rs:25:28
    |
-26 | #[nexus::aggregate(state = NotAState, error = MyError, id = MyId)]
+25 | #[nexus::aggregate(state = NotAState, error = MyError, id = MyId)]
    |                            ^^^^^^^^^ unsatisfied trait bound
    |
 help: the trait `AggregateState` is not implemented for `NotAState`
-  --> tests/macro_compile_fail/aggregate_bad_state.rs:20:1
+  --> tests/macro_compile_fail/aggregate_bad_state.rs:19:1
    |
-20 | struct NotAState;
+19 | struct NotAState;
    | ^^^^^^^^^^^^^^^^
 note: required by a bound in `nexus::Aggregate::State`
   --> $WORKSPACE/crates/nexus/src/aggregate.rs

--- a/crates/nexus-macros/tests/macro_compile_fail/aggregate_missing_error.rs
+++ b/crates/nexus-macros/tests/macro_compile_fail/aggregate_missing_error.rs
@@ -26,7 +26,6 @@ impl std::fmt::Display for MyId {
 impl AsRef<[u8]> for MyId {
     fn as_ref(&self) -> &[u8] { &self.0 }
 }
-impl Id for MyId { const BYTE_LEN: usize = 8; }
 
 #[nexus::aggregate(state = St, id = MyId)]
 struct MissingError;

--- a/crates/nexus-macros/tests/macro_compile_fail/aggregate_missing_error.stderr
+++ b/crates/nexus-macros/tests/macro_compile_fail/aggregate_missing_error.stderr
@@ -1,5 +1,5 @@
 error: `error` is required
-  --> tests/macro_compile_fail/aggregate_missing_error.rs:32:8
+  --> tests/macro_compile_fail/aggregate_missing_error.rs:31:8
    |
-32 | struct MissingError;
+31 | struct MissingError;
    |        ^^^^^^^^^^^^

--- a/crates/nexus-macros/tests/macro_hygiene.rs
+++ b/crates/nexus-macros/tests/macro_hygiene.rs
@@ -21,9 +21,6 @@ impl AsRef<[u8]> for HId {
         &self.0
     }
 }
-impl Id for HId {
-    const BYTE_LEN: usize = 8;
-}
 
 #[derive(Debug, Clone)]
 enum HEvent {

--- a/crates/nexus-macros/tests/macro_property_tests.rs
+++ b/crates/nexus-macros/tests/macro_property_tests.rs
@@ -26,9 +26,6 @@ impl AsRef<[u8]> for PId {
         &self.0
     }
 }
-impl Id for PId {
-    const BYTE_LEN: usize = 8;
-}
 
 #[derive(Debug, Clone, PartialEq)]
 enum CountEvent {

--- a/crates/nexus-store/src/saga.rs
+++ b/crates/nexus-store/src/saga.rs
@@ -427,9 +427,7 @@ mod error_tests {
 #[cfg(test)]
 mod projected_intents_tests {
     use super::{ProjectedIntent, ProjectedIntents, ProjectedIntentsIntoIter};
-    use nexus::{
-        Aggregate, AggregateState, DomainEvent, Events, Id, Message, React, Saga, Version,
-    };
+    use nexus::{Aggregate, AggregateState, DomainEvent, Events, Message, React, Saga, Version};
 
     // Minimal saga purely to instantiate the generic collection.
     #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -443,9 +441,6 @@ mod projected_intents_tests {
         fn as_ref(&self) -> &[u8] {
             core::slice::from_ref(&self.0)
         }
-    }
-    impl Id for Sid {
-        const BYTE_LEN: usize = 1;
     }
 
     #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/nexus-store/src/stream_id.rs
+++ b/crates/nexus-store/src/stream_id.rs
@@ -67,16 +67,12 @@ impl AsRef<[u8]> for StreamKey {
     }
 }
 
-/// A `StreamKey` is itself a valid [`Id`](nexus::Id): it already carries every
-/// supertrait the trait requires (clone, send/sync, debug, hash, eq, display,
-/// `AsRef<[u8]>`, `'static`). This is purely additive — the byte-level store
-/// API stays concrete (`&StreamKey`), but a raw key can now flow through the
-/// typed convenience layers (`Subscription::subscribe`, a repository whose
-/// `Aggregate::Id` is `StreamKey`) without a domain-id newtype. `BYTE_LEN` is
-/// `0` by the workspace convention for variable-length ids.
-impl nexus::Id for StreamKey {
-    const BYTE_LEN: usize = 0;
-}
+// A `StreamKey` is itself a valid `nexus::Id` for free via the blanket impl: it
+// already carries every supertrait the trait requires (clone, send/sync, debug,
+// hash, eq, display below, `AsRef<[u8]>` above, `'static`). This is purely
+// additive — the byte-level store API stays concrete (`&StreamKey`), but a raw
+// key can flow through the typed convenience layers (`Subscription::subscribe`,
+// a repository whose `Aggregate::Id` is `StreamKey`) without a domain-id newtype.
 
 /// The string when the bytes are valid UTF-8, else `0x…` lowercase hex —
 /// faithful for binary ids, readable for the common string id, always

--- a/crates/nexus-store/tests/adversarial_property_tests.rs
+++ b/crates/nexus-store/tests/adversarial_property_tests.rs
@@ -162,9 +162,6 @@ impl AsRef<[u8]> for TestId {
         self.0.as_bytes()
     }
 }
-impl nexus::Id for TestId {
-    const BYTE_LEN: usize = 0;
-}
 
 #[derive(Debug, thiserror::Error)]
 #[error("test error")]

--- a/crates/nexus-store/tests/borrowing_codec_tests.rs
+++ b/crates/nexus-store/tests/borrowing_codec_tests.rs
@@ -120,9 +120,6 @@ impl AsRef<[u8]> for CounterId {
         self.0.as_bytes()
     }
 }
-impl Id for CounterId {
-    const BYTE_LEN: usize = 0;
-}
 
 #[derive(Debug, thiserror::Error)]
 #[error("counter error")]

--- a/crates/nexus-store/tests/event_store_tests.rs
+++ b/crates/nexus-store/tests/event_store_tests.rs
@@ -65,9 +65,6 @@ impl AsRef<[u8]> for TodoId {
         self.0.as_bytes()
     }
 }
-impl Id for TodoId {
-    const BYTE_LEN: usize = 0;
-}
 
 #[derive(Debug, thiserror::Error)]
 #[error("todo error")]

--- a/crates/nexus-store/tests/projection_tests.rs
+++ b/crates/nexus-store/tests/projection_tests.rs
@@ -37,10 +37,6 @@ impl AsRef<[u8]> for TestId {
     }
 }
 
-impl nexus::Id for TestId {
-    const BYTE_LEN: usize = 0;
-}
-
 // ── EveryNEvents ────────────────────────────────────────────────────
 
 #[test]

--- a/crates/nexus-store/tests/repository_qa_tests.rs
+++ b/crates/nexus-store/tests/repository_qa_tests.rs
@@ -117,10 +117,6 @@ impl AsRef<[u8]> for CounterId {
     }
 }
 
-impl Id for CounterId {
-    const BYTE_LEN: usize = 0;
-}
-
 #[derive(Debug, thiserror::Error)]
 #[error("counter error")]
 struct CounterError;

--- a/crates/nexus-store/tests/saga_repository_tests.rs
+++ b/crates/nexus-store/tests/saga_repository_tests.rs
@@ -19,8 +19,7 @@ use std::sync::Arc;
 use bytes::Bytes;
 use futures::future::join_all;
 use nexus::{
-    Aggregate, AggregateRoot, AggregateState, DomainEvent, Events, Id, Message, React, Saga,
-    Version,
+    Aggregate, AggregateRoot, AggregateState, DomainEvent, Events, Message, React, Saga, Version,
 };
 use nexus_store::testing::InMemoryStore;
 use nexus_store::{
@@ -48,9 +47,6 @@ impl AsRef<[u8]> for OrderId {
     fn as_ref(&self) -> &[u8] {
         &self.0
     }
-}
-impl Id for OrderId {
-    const BYTE_LEN: usize = 8;
 }
 
 // ── The saga's OWN events (its history) ──────────────────────────────────

--- a/crates/nexus-store/tests/serde_codec_tests.rs
+++ b/crates/nexus-store/tests/serde_codec_tests.rs
@@ -66,10 +66,6 @@ impl AsRef<[u8]> for TodoId {
     }
 }
 
-impl Id for TodoId {
-    const BYTE_LEN: usize = 0;
-}
-
 #[derive(Debug, thiserror::Error)]
 #[error("todo error")]
 struct TodoError;

--- a/crates/nexus-store/tests/snapshot_integration_tests.rs
+++ b/crates/nexus-store/tests/snapshot_integration_tests.rs
@@ -83,9 +83,6 @@ impl AsRef<[u8]> for CounterId {
         self.0.as_bytes()
     }
 }
-impl Id for CounterId {
-    const BYTE_LEN: usize = 0;
-}
 
 #[derive(Debug, thiserror::Error)]
 #[error("counter error")]

--- a/crates/nexus-store/tests/snapshot_tests.rs
+++ b/crates/nexus-store/tests/snapshot_tests.rs
@@ -18,7 +18,7 @@ use std::fmt;
 
 use std::num::{NonZeroU32, NonZeroU64};
 
-use nexus::{Id, Version};
+use nexus::Version;
 
 const SV1: NonZeroU32 = NonZeroU32::MIN;
 use nexus_store::state::{AfterEventTypes, EveryNEvents, PersistTrigger, SnapshotStore};
@@ -36,9 +36,6 @@ impl AsRef<[u8]> for TestId {
     fn as_ref(&self) -> &[u8] {
         self.0.as_bytes()
     }
-}
-impl Id for TestId {
-    const BYTE_LEN: usize = 0;
 }
 
 // ── EveryNEvents ────────────────────────────────────────────────────

--- a/crates/nexus-store/tests/subscription_tests.rs
+++ b/crates/nexus-store/tests/subscription_tests.rs
@@ -6,7 +6,7 @@
 use std::time::Duration;
 
 use futures::StreamExt;
-use nexus::{Id, Version};
+use nexus::Version;
 use nexus_store::store::RawEventStore;
 use nexus_store::testing::InMemoryStore;
 use nexus_store::{Store, Subscription, pending_envelope};
@@ -30,9 +30,6 @@ impl AsRef<[u8]> for TestId {
     fn as_ref(&self) -> &[u8] {
         self.0.as_bytes()
     }
-}
-impl Id for TestId {
-    const BYTE_LEN: usize = 0;
 }
 
 /// Helper: build a pending envelope with a given version and event type.

--- a/crates/nexus/benches/kernel_bench.rs
+++ b/crates/nexus/benches/kernel_bench.rs
@@ -14,7 +14,7 @@
 )]
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
-use nexus::{Aggregate, AggregateRoot, AggregateState, DomainEvent, Events, Id, Message};
+use nexus::{Aggregate, AggregateRoot, AggregateState, DomainEvent, Events, Message};
 use nexus::{Version, VersionedEvent};
 use std::fmt;
 use std::hint::black_box;
@@ -39,9 +39,6 @@ impl AsRef<[u8]> for BId {
     fn as_ref(&self) -> &[u8] {
         self.0.as_bytes()
     }
-}
-impl Id for BId {
-    const BYTE_LEN: usize = 0;
 }
 
 #[derive(Debug, Clone)]

--- a/crates/nexus/src/aggregate.rs
+++ b/crates/nexus/src/aggregate.rs
@@ -99,7 +99,6 @@ pub trait AggregateState: Send + Sync + Debug + 'static {
 /// # #[derive(Debug, Clone, Hash, PartialEq, Eq)] struct MyId(String);
 /// # impl std::fmt::Display for MyId { fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result { write!(f, "{}", self.0) } }
 /// # impl AsRef<[u8]> for MyId { fn as_ref(&self) -> &[u8] { self.0.as_bytes() } }
-/// # impl Id for MyId { const BYTE_LEN: usize = 0; }
 /// # #[derive(Debug, thiserror::Error)] #[error("e")] struct MyError;
 ///
 /// struct MyAggregate;
@@ -149,7 +148,6 @@ pub trait Aggregate: Sized {
 /// # #[derive(Debug, Clone, Hash, PartialEq, Eq)] struct TodoId(String);
 /// # impl std::fmt::Display for TodoId { fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result { write!(f, "{}", self.0) } }
 /// # impl AsRef<[u8]> for TodoId { fn as_ref(&self) -> &[u8] { self.0.as_bytes() } }
-/// # impl Id for TodoId { const BYTE_LEN: usize = 0; }
 /// # #[derive(Debug, thiserror::Error)] #[error("e")] struct TodoError;
 /// # struct Todo;
 /// # impl Aggregate for Todo { type State = TodoState; type Error = TodoError; type Id = TodoId; }
@@ -436,7 +434,6 @@ mod purist_dispatch_tests {
     use crate::event::DomainEvent;
     use crate::events;
     use crate::events::Events;
-    use crate::id::Id;
     use crate::message::Message;
     use crate::version::Version;
 
@@ -459,10 +456,6 @@ mod purist_dispatch_tests {
         fn as_ref(&self) -> &[u8] {
             &self.0
         }
-    }
-
-    impl Id for CtrId {
-        const BYTE_LEN: usize = 8;
     }
 
     #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/nexus/src/id.rs
+++ b/crates/nexus/src/id.rs
@@ -3,11 +3,30 @@ use std::hash::Hash;
 
 use crate::ErrorId;
 
+/// Marker for a type usable as a stream / aggregate id.
+///
+/// An id is anything that can be cloned, moved across threads, compared,
+/// hashed, printed, and — crucially — viewed as bytes for use as a storage
+/// key (`AsRef<[u8]>` is the stable byte representation; `Display` is for
+/// humans, never for serialization).
+///
+/// There is nothing to implement: a [blanket impl](#impl-Id-for-T) covers
+/// every type that already satisfies the supertraits, so a plain newtype
+///
+/// ```
+/// # use std::fmt;
+/// #[derive(Debug, Clone, Hash, PartialEq, Eq)]
+/// struct AccountId(String);
+/// impl fmt::Display for AccountId {
+///     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { f.write_str(&self.0) }
+/// }
+/// impl AsRef<[u8]> for AccountId {
+///     fn as_ref(&self) -> &[u8] { self.0.as_bytes() }
+/// }
+/// ```
+///
+/// *is* an `Id` — no `impl Id` block, no associated const.
 pub trait Id: Clone + Send + Sync + Debug + Hash + Eq + Display + AsRef<[u8]> + 'static {
-    /// Fixed byte length of this ID's storage representation.
-    /// All instances must return exactly this many bytes from `as_ref()`.
-    const BYTE_LEN: usize;
-
     /// Stack-allocated diagnostic label for error messages.
     ///
     /// If the display representation exceeds 64 bytes it is truncated on a
@@ -17,3 +36,7 @@ pub trait Id: Clone + Send + Sync + Debug + Hash + Eq + Display + AsRef<[u8]> + 
         ErrorId::from_display(self)
     }
 }
+
+/// Every type carrying the supertraits is an [`Id`] — declaring an id is a
+/// newtype plus `Display`/`AsRef<[u8]>`, with no hand-written `Id` impl.
+impl<T: Clone + Send + Sync + Debug + Hash + Eq + Display + AsRef<[u8]> + 'static> Id for T {}

--- a/crates/nexus/src/saga.rs
+++ b/crates/nexus/src/saga.rs
@@ -122,7 +122,6 @@ mod saga_dispatch_tests {
     use crate::event::DomainEvent;
     use crate::events;
     use crate::events::Events;
-    use crate::id::Id;
     use crate::message::Message;
     use crate::version::Version;
 
@@ -143,9 +142,6 @@ mod saga_dispatch_tests {
         fn as_ref(&self) -> &[u8] {
             &self.0
         }
-    }
-    impl Id for OrderId {
-        const BYTE_LEN: usize = 8;
     }
 
     // ── The saga's OWN events (its history) ──────────────────────────

--- a/crates/nexus/tests/aggregate_fixture_tests.rs
+++ b/crates/nexus/tests/aggregate_fixture_tests.rs
@@ -9,12 +9,12 @@
 )]
 
 use nexus::testing::AggregateFixture;
-use nexus::{AggregateState, DomainEvent, Events, Handle, Id, Message, events};
+use nexus::{AggregateState, DomainEvent, Events, Handle, Message, events};
 
 // ── Sample domain ────────────────────────────────────────────────
 // Store the id as fixed bytes so `as_ref` can borrow them (the kernel's
-// own `Id` tests use the same `[u8; N]` pattern). `Id` requires the
-// associated `const BYTE_LEN` — the fixed storage width of `as_ref()`.
+// own `Id` tests use the same `[u8; N]` pattern). `Id` is satisfied for
+// free via the blanket impl — no hand-written `impl Id`.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
 struct CounterId([u8; 8]);
 impl CounterId {
@@ -31,9 +31,6 @@ impl AsRef<[u8]> for CounterId {
     fn as_ref(&self) -> &[u8] {
         &self.0
     }
-}
-impl Id for CounterId {
-    const BYTE_LEN: usize = 8;
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/crates/nexus/tests/compile_fail/aggregate_error_not_std_error.rs
+++ b/crates/nexus/tests/compile_fail/aggregate_error_not_std_error.rs
@@ -44,8 +44,5 @@ impl std::fmt::Display for MyId {
 impl AsRef<[u8]> for MyId {
     fn as_ref(&self) -> &[u8] { self.0.as_bytes() }
 }
-impl Id for MyId {
-    const BYTE_LEN: usize = 0;
-}
 
 fn main() {}

--- a/crates/nexus/tests/compile_fail/id_missing_display.rs
+++ b/crates/nexus/tests/compile_fail/id_missing_display.rs
@@ -1,13 +1,19 @@
-/// Id trait requires Display. A type without Display cannot impl Id.
+//! `Id` requires `Display` (and `AsRef<[u8]>`). A type missing `Display` is
+//! therefore *not* covered by the blanket impl, so requiring `I: Id` fails.
 
 use nexus::Id;
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 struct BadId(u64);
-// Missing: impl Display for BadId
-
-impl Id for BadId {
-    const BYTE_LEN: usize = 8;
+impl AsRef<[u8]> for BadId {
+    fn as_ref(&self) -> &[u8] {
+        &[]
+    }
 }
+// Missing: impl std::fmt::Display for BadId
 
-fn main() {}
+fn requires_id<I: Id>() {}
+
+fn main() {
+    requires_id::<BadId>();
+}

--- a/crates/nexus/tests/compile_fail/id_missing_display.stderr
+++ b/crates/nexus/tests/compile_fail/id_missing_display.stderr
@@ -1,33 +1,17 @@
-error[E0277]: the trait bound `BadId: AsRef<[u8]>` is not satisfied
- --> tests/compile_fail/id_missing_display.rs:9:13
-  |
-9 | impl Id for BadId {
-  |             ^^^^^ unsatisfied trait bound
-  |
-help: the trait `AsRef<[u8]>` is not implemented for `BadId`
- --> tests/compile_fail/id_missing_display.rs:6:1
-  |
-6 | struct BadId(u64);
-  | ^^^^^^^^^^^^
-note: required by a bound in `Id`
- --> src/id.rs
-  |
-  | pub trait Id: Clone + Send + Sync + Debug + Hash + Eq + Display + AsRef<[u8]> + 'static {
-  |                                                                   ^^^^^^^^^^^ required by this bound in `Id`
-
-error[E0277]: `BadId` doesn't implement `std::fmt::Display`
- --> tests/compile_fail/id_missing_display.rs:9:13
-  |
-9 | impl Id for BadId {
-  |             ^^^^^ unsatisfied trait bound
-  |
+error[E0277]: the trait bound `BadId: Id` is not satisfied
+  --> tests/compile_fail/id_missing_display.rs:18:19
+   |
+18 |     requires_id::<BadId>();
+   |                   ^^^^^ unsatisfied trait bound
+   |
 help: the trait `std::fmt::Display` is not implemented for `BadId`
- --> tests/compile_fail/id_missing_display.rs:6:1
-  |
-6 | struct BadId(u64);
-  | ^^^^^^^^^^^^
-note: required by a bound in `Id`
- --> src/id.rs
-  |
-  | pub trait Id: Clone + Send + Sync + Debug + Hash + Eq + Display + AsRef<[u8]> + 'static {
-  |                                                         ^^^^^^^ required by this bound in `Id`
+  --> tests/compile_fail/id_missing_display.rs:7:1
+   |
+ 7 | struct BadId(u64);
+   | ^^^^^^^^^^^^
+   = note: required for `BadId` to implement `Id`
+note: required by a bound in `requires_id`
+  --> tests/compile_fail/id_missing_display.rs:15:19
+   |
+15 | fn requires_id<I: Id>() {}
+   |                   ^^ required by this bound in `requires_id`

--- a/crates/nexus/tests/compile_fail/version_no_from_u64.stderr
+++ b/crates/nexus/tests/compile_fail/version_no_from_u64.stderr
@@ -8,6 +8,3 @@ error[E0308]: mismatched types
   |
 note: associated function defined here
  --> $RUST/core/src/convert/mod.rs
-  |
-  |     fn from(value: T) -> Self;
-  |        ^^^^

--- a/crates/nexus/tests/compile_fail/wrong_event_type.rs
+++ b/crates/nexus/tests/compile_fail/wrong_event_type.rs
@@ -52,9 +52,6 @@ impl std::fmt::Display for UserId {
 impl AsRef<[u8]> for UserId {
     fn as_ref(&self) -> &[u8] { self.0.as_bytes() }
 }
-impl Id for UserId {
-    const BYTE_LEN: usize = 0;
-}
 
 fn main() {
     let mut user = AggregateRoot::<UserAggregate>::new(UserId::new(1));

--- a/crates/nexus/tests/compile_fail/wrong_event_type.stderr
+++ b/crates/nexus/tests/compile_fail/wrong_event_type.stderr
@@ -1,7 +1,7 @@
 error[E0308]: mismatched types
-  --> tests/compile_fail/wrong_event_type.rs:62:35
+  --> tests/compile_fail/wrong_event_type.rs:59:35
    |
-62 |     user.replay(Version::INITIAL, &OrderEvent::Placed);
+59 |     user.replay(Version::INITIAL, &OrderEvent::Placed);
    |          ------                   ^^^^^^^^^^^^^^^^^^^ expected `&UserEvent`, found `&OrderEvent`
    |          |
    |          arguments to this method are incorrect

--- a/crates/nexus/tests/kernel_tests/aggregate_root_tests.rs
+++ b/crates/nexus/tests/kernel_tests/aggregate_root_tests.rs
@@ -7,7 +7,6 @@ use nexus::AggregateState;
 use nexus::DomainEvent;
 use nexus::Events;
 use nexus::Handle;
-use nexus::Id;
 use nexus::KernelError;
 use nexus::Message;
 use nexus::Version;
@@ -30,9 +29,6 @@ impl AsRef<[u8]> for TestId {
     fn as_ref(&self) -> &[u8] {
         self.0.as_bytes()
     }
-}
-impl Id for TestId {
-    const BYTE_LEN: usize = 0;
 }
 
 #[derive(Debug, Clone)]

--- a/crates/nexus/tests/kernel_tests/edge_case_tests.rs
+++ b/crates/nexus/tests/kernel_tests/edge_case_tests.rs
@@ -16,7 +16,7 @@ use nexus::Events;
 use nexus::KernelError;
 use nexus::Message;
 use nexus::Version;
-use nexus::{Aggregate, Id, events};
+use nexus::{Aggregate, events};
 use std::fmt;
 
 // --- Minimal test domain ---
@@ -40,10 +40,6 @@ impl AsRef<[u8]> for TId {
     fn as_ref(&self) -> &[u8] {
         self.0.as_bytes()
     }
-}
-
-impl Id for TId {
-    const BYTE_LEN: usize = 0;
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/nexus/tests/kernel_tests/integration_test.rs
+++ b/crates/nexus/tests/kernel_tests/integration_test.rs
@@ -23,9 +23,6 @@ impl AsRef<[u8]> for UserId {
         self.0.as_bytes()
     }
 }
-impl Id for UserId {
-    const BYTE_LEN: usize = 0;
-}
 
 // --- Events (using derive macro!) ---
 #[derive(Debug, Clone)]

--- a/crates/nexus/tests/kernel_tests/newtype_aggregate_tests.rs
+++ b/crates/nexus/tests/kernel_tests/newtype_aggregate_tests.rs
@@ -24,9 +24,6 @@ impl AsRef<[u8]> for UserId {
         self.0.as_bytes()
     }
 }
-impl Id for UserId {
-    const BYTE_LEN: usize = 0;
-}
 
 #[derive(Debug, Clone)]
 struct UserCreated {

--- a/crates/nexus/tests/kernel_tests/property_tests.rs
+++ b/crates/nexus/tests/kernel_tests/property_tests.rs
@@ -38,9 +38,6 @@ impl AsRef<[u8]> for PId {
         self.0.as_bytes()
     }
 }
-impl Id for PId {
-    const BYTE_LEN: usize = 0;
-}
 
 #[derive(Debug, Clone, PartialEq)]
 enum CountEvent {

--- a/crates/nexus/tests/kernel_tests/replay_tests.rs
+++ b/crates/nexus/tests/kernel_tests/replay_tests.rs
@@ -7,7 +7,6 @@ use nexus::Aggregate;
 use nexus::AggregateRoot;
 use nexus::AggregateState;
 use nexus::DomainEvent;
-use nexus::Id;
 use nexus::KernelError;
 use nexus::Message;
 use nexus::Version;
@@ -30,9 +29,6 @@ impl AsRef<[u8]> for RId {
     fn as_ref(&self) -> &[u8] {
         self.0.as_bytes()
     }
-}
-impl Id for RId {
-    const BYTE_LEN: usize = 0;
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/nexus/tests/kernel_tests/saga_tests.rs
+++ b/crates/nexus/tests/kernel_tests/saga_tests.rs
@@ -5,8 +5,8 @@
 //! more than one own-event (`N > 0`).
 
 use nexus::{
-    Aggregate, AggregateRoot, AggregateState, DomainEvent, Events, Id, Message, React, Saga,
-    Version, events,
+    Aggregate, AggregateRoot, AggregateState, DomainEvent, Events, Message, React, Saga, Version,
+    events,
 };
 
 // ── Saga identity ────────────────────────────────────────────────────────────
@@ -30,10 +30,6 @@ impl AsRef<[u8]> for OrderId {
     fn as_ref(&self) -> &[u8] {
         &self.0
     }
-}
-
-impl Id for OrderId {
-    const BYTE_LEN: usize = 8;
 }
 
 // ── The saga's OWN events (its history) ─────────────────────────────────────

--- a/crates/nexus/tests/kernel_tests/security_tests.rs
+++ b/crates/nexus/tests/kernel_tests/security_tests.rs
@@ -26,9 +26,6 @@ impl AsRef<[u8]> for SId {
         self.0.as_bytes()
     }
 }
-impl Id for SId {
-    const BYTE_LEN: usize = 0;
-}
 
 #[derive(Debug, Clone, PartialEq)]
 enum SEvent {

--- a/crates/nexus/tests/kernel_tests/static_assertion_tests.rs
+++ b/crates/nexus/tests/kernel_tests/static_assertion_tests.rs
@@ -58,9 +58,10 @@ impl AsRef<[u8]> for StaticId {
         self.0.as_bytes()
     }
 }
-impl Id for StaticId {
-    const BYTE_LEN: usize = 0;
-}
+
+// #252: declaring an id is a newtype + `Display` + `AsRef<[u8]>` — the blanket
+// impl covers it with no hand-written `impl Id` and no associated const.
+assert_impl_all!(StaticId: Id);
 
 #[derive(Debug, Clone)]
 #[allow(dead_code, reason = "test-only event type used for static assertions")]

--- a/crates/nexus/tests/kernel_tests/traits_tests.rs
+++ b/crates/nexus/tests/kernel_tests/traits_tests.rs
@@ -14,9 +14,6 @@ impl AsRef<[u8]> for TestId {
         self.0.as_bytes()
     }
 }
-impl Id for TestId {
-    const BYTE_LEN: usize = 0;
-}
 
 // --- Test Events ---
 #[derive(Debug, Clone)]

--- a/crates/nexus/tests/saga_fixture_tests.rs
+++ b/crates/nexus/tests/saga_fixture_tests.rs
@@ -11,7 +11,7 @@
 )]
 
 use nexus::testing::SagaFixture;
-use nexus::{AggregateState, DomainEvent, Events, Id, Message, React, Saga, events};
+use nexus::{AggregateState, DomainEvent, Events, Message, React, Saga, events};
 
 // ── Saga identity ────────────────────────────────────────────────
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
@@ -30,9 +30,6 @@ impl AsRef<[u8]> for OrderId {
     fn as_ref(&self) -> &[u8] {
         &self.0
     }
-}
-impl Id for OrderId {
-    const BYTE_LEN: usize = 8;
 }
 
 // ── The saga's OWN events (its history) ──────────────────────────

--- a/examples/closing-the-books/src/main.rs
+++ b/examples/closing-the-books/src/main.rs
@@ -85,10 +85,6 @@ impl fmt::Display for CashierShiftId {
     }
 }
 
-impl Id for CashierShiftId {
-    const BYTE_LEN: usize = 0;
-}
-
 impl AsRef<[u8]> for CashierShiftId {
     fn as_ref(&self) -> &[u8] {
         self.urn.as_bytes()
@@ -241,10 +237,6 @@ impl fmt::Display for RegisterId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(&self.0)
     }
-}
-
-impl Id for RegisterId {
-    const BYTE_LEN: usize = 0;
 }
 
 impl AsRef<[u8]> for RegisterId {

--- a/examples/fjall-end-to-end/src/domain.rs
+++ b/examples/fjall-end-to-end/src/domain.rs
@@ -6,7 +6,7 @@
 
 use std::fmt;
 
-use nexus::{AggregateState, DomainEvent, Events, Handle, Id, events};
+use nexus::{AggregateState, DomainEvent, Events, Handle, events};
 use serde::{Deserialize, Serialize};
 
 // ── Id ──────────────────────────────────────────────────────────────────────
@@ -24,10 +24,6 @@ impl AsRef<[u8]> for AccountId {
     fn as_ref(&self) -> &[u8] {
         self.0.as_bytes()
     }
-}
-
-impl Id for AccountId {
-    const BYTE_LEN: usize = 0;
 }
 
 // ── Events (serde-encodable so the built-in JsonCodec can persist them) ──────

--- a/examples/inmemory/src/main.rs
+++ b/examples/inmemory/src/main.rs
@@ -38,10 +38,6 @@ impl fmt::Display for AccountId {
     }
 }
 
-impl Id for AccountId {
-    const BYTE_LEN: usize = 0;
-}
-
 impl AsRef<[u8]> for AccountId {
     fn as_ref(&self) -> &[u8] {
         self.0.as_bytes()

--- a/examples/projection-tokio/tests/loop_tests.rs
+++ b/examples/projection-tokio/tests/loop_tests.rs
@@ -63,10 +63,6 @@ impl AsRef<[u8]> for TestId {
     }
 }
 
-impl nexus::Id for TestId {
-    const BYTE_LEN: usize = 0;
-}
-
 #[derive(Debug, Clone, PartialEq)]
 struct CountState {
     count: u64,

--- a/examples/store-and-kernel/src/main.rs
+++ b/examples/store-and-kernel/src/main.rs
@@ -43,10 +43,6 @@ impl fmt::Display for AccountId {
     }
 }
 
-impl Id for AccountId {
-    const BYTE_LEN: usize = 0;
-}
-
 impl AsRef<[u8]> for AccountId {
     fn as_ref(&self) -> &[u8] {
         self.0.as_bytes()

--- a/examples/store-inmemory/src/main.rs
+++ b/examples/store-inmemory/src/main.rs
@@ -24,7 +24,6 @@
 )]
 
 use futures::{StreamExt, TryStreamExt};
-use nexus::Id;
 use nexus::Version;
 use nexus_store::Store;
 use nexus_store::store::RawEventStore;
@@ -45,10 +44,6 @@ impl fmt::Display for TodoId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(&self.0)
     }
-}
-
-impl Id for TodoId {
-    const BYTE_LEN: usize = 0;
 }
 
 impl AsRef<[u8]> for TodoId {


### PR DESCRIPTION
Closes #252.

## What

`Id` becomes a pure marker with a **blanket impl**: any type carrying the supertraits (`Clone + Send + Sync + Debug + Hash + Eq + Display + AsRef<[u8]> + 'static`) *is* an `Id`. Declaring a stream/aggregate id drops from ~12-15 lines of ceremony to a newtype + `Display` + `AsRef<[u8]>` — no hand-written `impl Id`, no `const BYTE_LEN`.

## Why BYTE_LEN had to go

- **Born dead in #150** — added alongside `AsRef<[u8]>`, presumably for a fixed-width key-packing optimization. fjall never used it (it length-prefixes keys: `[u16 id_len][id][u64 version]`), so it had no consumer.
- **Never read** anywhere in kernel, store, or fjall across the entire git history — every occurrence was a `const BYTE_LEN = N` declaration.
- **Its invariant was a lie** — the doc claimed "fixed `as_ref()` width," but every `String`-newtype id set `0` while returning variable-length bytes.
- Removing an associated item from a public trait is breaking, so it had to happen **before the 1.0 freeze** (rule 4: no unused associated items).

## Changes

- Kernel: `Id` = marker + blanket impl; `to_label` retained; docs rewritten with a copy-pasteable example
- Swept ~45 `impl Id { const BYTE_LEN }` blocks from src, tests, examples
- `StreamKey` / `OwnedStreamId` are now `Id` via the blanket; docs updated
- `id_missing_display` compile-fail rewritten to prove the bound is still enforced; `aggregate_bad_id.stderr` now surfaces the `AsRef<[u8]>` root cause (more informative than before)
- Static assertion added: a bare newtype is `Id` with zero boilerplate
- **net −128 lines across src + examples**

## Incidental

Cleared pre-existing `--all-targets` clippy debt in nexus-store test code (`string_lit_as_bytes`, `needless_borrow`, `range_plus_one`, `items_after_statements`, `io_other_error`) so the whole workspace is clean under `--all-features --all-targets`.

## Verification

`nix flake check` — all checks green (clippy, nextest, doc, fmt, toml-fmt, deny, hakari, audit). Independently confirmed clean under `cargo clippy --workspace --all-targets --all-features -- --deny warnings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)