### PR TITLE
feat(store): execute — one-call decide+save combinator (#251)

### DIFF
--- a/crates/nexus-fjall/tests/execute_lifecycle_tests.rs
+++ b/crates/nexus-fjall/tests/execute_lifecycle_tests.rs
@@ -1,0 +1,176 @@
+//! Lifecycle test (rule 7 category 2) for `CommandRepository::execute` on the
+//! real persistent `nexus-fjall` adapter: write → close → reopen → verify
+//! durable, plus a rejected command that must persist nothing across the
+//! reopen. `execute_tests.rs` in `nexus-store` already covers the
+//! sequence/protocol, defensive-boundary, and linearizability categories over
+//! `InMemoryStore`; this file is the fjall-specific durability proof that a
+//! persisted `Store<S>` handle actually loses its in-memory `AggregateRoot`
+//! state (and rebuilds it purely from disk) across a real close/reopen.
+
+#![allow(clippy::unwrap_used, reason = "tests")]
+#![allow(clippy::expect_used, reason = "tests")]
+#![allow(clippy::panic, reason = "panic in test match arms is an assertion")]
+#![allow(
+    clippy::shadow_reuse,
+    reason = "the spawn-closure clone-and-shadow pattern is idiomatic for tokio tests"
+)]
+#![allow(
+    clippy::missing_const_for_fn,
+    reason = "test-helper fns need not be const"
+)]
+
+use std::convert::Infallible;
+
+use bytes::Bytes;
+use nexus::{Aggregate, AggregateState, DomainEvent, Events, Handle, Message, Version, events};
+use nexus_fjall::FjallStore;
+use nexus_store::{
+    CommandRepository, Decode, Encode, ExecuteError, PersistedEnvelope, RawEventStore, Repository,
+};
+
+// ── Aggregate identity ────────────────────────────────────────────────────
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct CtrId([u8; 8]);
+impl CtrId {
+    fn new(n: u64) -> Self {
+        Self(n.to_le_bytes())
+    }
+}
+impl core::fmt::Display for CtrId {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}", u64::from_le_bytes(self.0))
+    }
+}
+impl AsRef<[u8]> for CtrId {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+// ── Events ────────────────────────────────────────────────────────────────
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum CtrEvent {
+    Added(u64),
+}
+impl Message for CtrEvent {}
+impl DomainEvent for CtrEvent {
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Added(_) => "Added",
+        }
+    }
+}
+
+// ── State ─────────────────────────────────────────────────────────────────
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CtrState {
+    total: u64,
+}
+impl AggregateState for CtrState {
+    type Event = CtrEvent;
+    fn initial() -> Self {
+        Self { total: 0 }
+    }
+    fn apply(mut self, event: &CtrEvent) -> Self {
+        match event {
+            CtrEvent::Added(n) => self.total += n,
+        }
+        self
+    }
+}
+
+#[derive(Debug, thiserror::Error, PartialEq)]
+enum CtrError {
+    #[error("cannot add zero")]
+    Zero,
+}
+
+// ── Marker + Handle ───────────────────────────────────────────────────────
+struct Counter;
+impl Aggregate for Counter {
+    type State = CtrState;
+    type Error = CtrError;
+    type Id = CtrId;
+}
+struct Add(u64);
+impl Handle<Add> for Counter {
+    fn handle(_state: &CtrState, cmd: Add) -> Result<Events<CtrEvent>, CtrError> {
+        if cmd.0 == 0 {
+            return Err(CtrError::Zero);
+        }
+        Ok(events![CtrEvent::Added(cmd.0)])
+    }
+}
+
+// ── Codec: encode the u64 LE ──────────────────────────────────────────────
+struct CtrCodec;
+impl Encode<CtrEvent> for CtrCodec {
+    type Error = Infallible;
+    fn encode(&self, event: &CtrEvent) -> Result<Bytes, Infallible> {
+        let CtrEvent::Added(n) = event;
+        Ok(Bytes::copy_from_slice(&n.to_le_bytes()))
+    }
+}
+impl Decode<CtrEvent> for CtrCodec {
+    type Output<'a> = CtrEvent;
+    type Error = Infallible;
+    fn decode<'a>(&'a self, env: &'a PersistedEnvelope) -> Result<Self::Output<'a>, Infallible> {
+        let mut buf = [0u8; 8];
+        buf.copy_from_slice(&env.payload()[..8]);
+        Ok(CtrEvent::Added(u64::from_le_bytes(buf)))
+    }
+}
+
+type Repo = nexus_store::EventStore<FjallStore, CtrCodec, Counter>;
+
+fn open_repo(path: &std::path::Path) -> Repo {
+    FjallStore::builder(path)
+        .open()
+        .expect("open fjall store")
+        .into_store()
+        .repository()
+        .codec(CtrCodec)
+        .build()
+}
+
+// ── Lifecycle: execute survives close + reopen; rejection persists nothing ─
+#[tokio::test]
+async fn lifecycle_execute_survives_reopen() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db_path = dir.path().join("db");
+
+    // Phase 1: open, execute two commands, close (scope end drops the store).
+    {
+        let repo = open_repo(&db_path);
+        let mut ctr = repo.load(CtrId::new(1)).await.unwrap();
+
+        let e1 = repo.execute(&mut ctr, Add(3)).await.unwrap();
+        assert_eq!(e1.iter().collect::<Vec<_>>(), vec![&CtrEvent::Added(3)]);
+
+        let e2 = repo.execute(&mut ctr, Add(4)).await.unwrap();
+        assert_eq!(e2.iter().collect::<Vec<_>>(), vec![&CtrEvent::Added(4)]);
+
+        assert_eq!(ctr.state().total, 7);
+        assert_eq!(ctr.version(), Version::new(2));
+    }
+
+    // Phase 2: reopen at the SAME path — durability assertion. If `execute`
+    // hadn't actually persisted, this would rehydrate to version None / total 0.
+    {
+        let repo = open_repo(&db_path);
+        let reloaded = repo.load(CtrId::new(1)).await.unwrap();
+        assert_eq!(reloaded.state().total, 7);
+        assert_eq!(reloaded.version(), Version::new(2));
+
+        // Phase 3: a rejected command against the reopened store must persist
+        // nothing — version stays at 2 across a second reload.
+        let mut ctr = repo.load(CtrId::new(1)).await.unwrap();
+        let err = repo.execute(&mut ctr, Add(0)).await.unwrap_err();
+        assert!(matches!(err, ExecuteError::Decide(CtrError::Zero)));
+        assert!(!err.is_conflict());
+
+        let after = repo.load(CtrId::new(1)).await.unwrap();
+        assert_eq!(after.state().total, 7);
+        assert_eq!(after.version(), Version::new(2));
+    }
+}

--- a/crates/nexus-store/src/conflict.rs
+++ b/crates/nexus-store/src/conflict.rs
@@ -1,0 +1,32 @@
+//! Shared optimistic-concurrency conflict predicate.
+//!
+//! Moved out of `saga.rs` so both [`SagaError`](crate::SagaError) and
+//! `ExecuteError` delegate to the same
+//! [`StoreError::is_conflict`](crate::StoreError::is_conflict) — one truth,
+//! two callers.
+
+use crate::error::StoreError;
+
+mod sealed {
+    pub trait Sealed {}
+}
+
+/// Predicate over a repository error: is this an optimistic-concurrency
+/// conflict (and therefore retryable by reloading + re-deciding)?
+///
+/// Sealed: implemented inside this crate for [`StoreError`] only. Lets error
+/// wrappers delegate without naming a concrete store error — `Snapshotting`'s
+/// `Repository::Error` is the inner `StoreError`, so one impl serves bare and
+/// snapshotted repositories alike.
+pub trait ConflictPredicate: sealed::Sealed {
+    /// `true` iff this error is an optimistic-concurrency conflict.
+    fn is_conflict(&self) -> bool;
+}
+
+impl<A, EncErr, DecErr> sealed::Sealed for StoreError<A, EncErr, DecErr> {}
+
+impl<A, EncErr, DecErr> ConflictPredicate for StoreError<A, EncErr, DecErr> {
+    fn is_conflict(&self) -> bool {
+        Self::is_conflict(self)
+    }
+}

--- a/crates/nexus-store/src/execute.rs
+++ b/crates/nexus-store/src/execute.rs
@@ -1,0 +1,115 @@
+//! Store-side command combinator — the aggregate analogue of
+//! [`SagaRepository`](crate::SagaRepository).
+//!
+//! [`CommandRepository::execute`] fuses `decide → save` into one call so the
+//! decided events can't be forgotten or misthreaded (#251). It adds no
+//! persistence machinery — it is the "imperative shell" over the pure
+//! [`AggregateRoot::handle`](nexus::AggregateRoot::handle) and the atomic
+//! [`Repository::save`](crate::Repository::save).
+//!
+//! See `docs/plans/2026-07-02-execute-command-combinator-design.md`.
+
+use core::future::Future;
+
+use nexus::{Aggregate, AggregateRoot, EventOf, Events, Handle};
+
+use crate::conflict::ConflictPredicate;
+use crate::repository::Repository;
+
+/// Error from a command `execute`. Two failure domains kept distinct
+/// (CLAUDE.md rule 3 — one variant = one domain).
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum ExecuteError<DecideErr, StoreErr> {
+    /// The aggregate rejected the command (a domain invariant). Nothing persisted.
+    #[error("command rejected: {0}")]
+    Decide(#[source] DecideErr),
+
+    /// `save` failed (adapter / codec / conflict / version overflow).
+    #[error(transparent)]
+    Store(StoreErr),
+}
+
+impl<DecideErr, StoreErr: ConflictPredicate> ExecuteError<DecideErr, StoreErr> {
+    /// `true` iff the save failed on an optimistic-concurrency conflict.
+    /// `Decide` is never a conflict (rule 3 — rejection is not retryable).
+    #[must_use]
+    pub fn is_conflict(&self) -> bool {
+        matches!(self, Self::Store(e) if e.is_conflict())
+    }
+}
+
+/// The command-facing port: `decide → save` as one callable transaction.
+///
+/// Extends [`Repository<A>`] and inherits its `load`/`save` unchanged. The one
+/// provided method rides on every repository via the blanket impl below — bare
+/// [`EventStore`](crate::EventStore) and the
+/// [`Snapshotting`](crate::snapshot::Snapshotting) decorator alike.
+pub trait CommandRepository<A: Aggregate>: Repository<A> {
+    /// Decide `command` against `root`, persist the decided events atomically,
+    /// advance `root`, and return the decided events for inspection.
+    ///
+    /// - `Ok(events)` — the command was accepted and its events are durable.
+    /// - `Err(ExecuteError::Decide)` — the aggregate rejected it; nothing persisted.
+    /// - `Err(ExecuteError::Store)` — the save failed (see [`ExecuteError::is_conflict`]).
+    ///
+    /// On a version conflict this returns `Err(ExecuteError::Store(..))` with
+    /// `is_conflict() == true` and does **not** retry — retry is the runtime's
+    /// job (CLAUDE.md rule 5), matching `SagaRepository::react_and_save`.
+    ///
+    /// # Errors
+    /// See the variants above.
+    #[allow(
+        clippy::type_complexity,
+        reason = "the decided-events-or-typed-error return is intrinsic to the contract; an \
+                  alias would hide the `impl Future`/`Send` capture the API depends on"
+    )]
+    fn execute<C, const N: usize>(
+        &self,
+        root: &mut AggregateRoot<A>,
+        command: C,
+    ) -> impl Future<Output = Result<Events<EventOf<A>, N>, ExecuteError<A::Error, Self::Error>>> + Send
+    where
+        A: Handle<C, N>,
+        C: Send,
+    {
+        async move {
+            let decided = root.handle::<C, N>(command).map_err(ExecuteError::Decide)?;
+            self.save(root, &decided)
+                .await
+                .map_err(ExecuteError::Store)?;
+            Ok(decided)
+        }
+    }
+}
+
+// Rides on every repository — bare `EventStore` AND the `Snapshotting`
+// decorator — with zero per-type code. Fully static dispatch.
+impl<A: Aggregate, R: Repository<A>> CommandRepository<A> for R {}
+
+#[cfg(test)]
+mod error_tests {
+    use super::ExecuteError;
+    use crate::error::StoreError;
+    use nexus::{ErrorId, Version};
+
+    type TestStoreError =
+        StoreError<std::io::Error, std::convert::Infallible, std::convert::Infallible>;
+    type TestExecuteError = ExecuteError<&'static str, TestStoreError>;
+
+    #[test]
+    fn conflict_store_error_is_conflict() {
+        let e: TestExecuteError = ExecuteError::Store(StoreError::Conflict {
+            stream_id: ErrorId::from_display(&"s"),
+            expected: Some(Version::INITIAL),
+            actual: None,
+        });
+        assert!(e.is_conflict());
+    }
+
+    #[test]
+    fn decide_error_is_not_conflict() {
+        let e: TestExecuteError = ExecuteError::Decide("rejected");
+        assert!(!e.is_conflict());
+    }
+}

--- a/crates/nexus-store/src/lib.rs
+++ b/crates/nexus-store/src/lib.rs
@@ -91,6 +91,7 @@ pub(crate) mod catchup;
 #[cfg(feature = "cbor")]
 pub mod cbor;
 pub mod codec;
+pub mod conflict;
 pub mod envelope;
 pub mod error;
 #[cfg(feature = "export")]
@@ -139,6 +140,7 @@ pub use codec::serde::json::{Json, JsonCodec};
 #[cfg(feature = "serde")]
 pub use codec::serde::{SerdeCodec, SerdeFormat};
 pub use codec::{Decode, Encode};
+pub use conflict::ConflictPredicate;
 pub use envelope::{
     EnvelopeError, ForDecodeError, PendingEnvelope, PersistedEnvelope, pending_envelope,
 };
@@ -156,8 +158,8 @@ pub use nexus::Version;
 pub use projection::Projector;
 pub use repository::{EventStore, Repository};
 pub use saga::{
-    ConflictPredicate, ProjectedIntent, ProjectedIntents, ProjectedIntentsIntoIter, Reaction,
-    SagaError, SagaRepository,
+    ProjectedIntent, ProjectedIntents, ProjectedIntentsIntoIter, Reaction, SagaError,
+    SagaRepository,
 };
 #[cfg(feature = "snapshot")]
 pub use snapshot::Snapshotting;

--- a/crates/nexus-store/src/lib.rs
+++ b/crates/nexus-store/src/lib.rs
@@ -94,6 +94,7 @@ pub mod codec;
 pub mod conflict;
 pub mod envelope;
 pub mod error;
+pub mod execute;
 #[cfg(feature = "export")]
 pub mod export;
 #[cfg(feature = "import")]
@@ -146,6 +147,7 @@ pub use envelope::{
 };
 pub use error::LoadWithError;
 pub use error::{AppendError, StoreError};
+pub use execute::{CommandRepository, ExecuteError};
 #[cfg(feature = "export")]
 pub use export::{EventExporter, StreamLister};
 #[cfg(feature = "import")]

--- a/crates/nexus-store/src/saga.rs
+++ b/crates/nexus-store/src/saga.rs
@@ -18,32 +18,8 @@ use core::option;
 use arrayvec::ArrayVec;
 use nexus::{AggregateRoot, DomainEvent, React, Saga, Version};
 
-use crate::error::StoreError;
+use crate::conflict::ConflictPredicate;
 use crate::repository::{Repository, first_persisted_version};
-
-mod sealed {
-    pub trait Sealed {}
-}
-
-/// Predicate over a repository error: is this an optimistic-concurrency
-/// conflict (and therefore retryable by reloading + re-reacting)?
-///
-/// Sealed: implemented inside this crate for [`StoreError`] only. Lets
-/// [`SagaError::is_conflict`] delegate without naming a concrete store error —
-/// `Snapshotting`'s `Repository::Error` is the inner `StoreError`, so one impl
-/// serves bare and snapshotted repositories alike.
-pub trait ConflictPredicate: sealed::Sealed {
-    /// `true` iff this error is an optimistic-concurrency conflict.
-    fn is_conflict(&self) -> bool;
-}
-
-impl<A, EncErr, DecErr> sealed::Sealed for StoreError<A, EncErr, DecErr> {}
-
-impl<A, EncErr, DecErr> ConflictPredicate for StoreError<A, EncErr, DecErr> {
-    fn is_conflict(&self) -> bool {
-        Self::is_conflict(self)
-    }
-}
 
 /// Error from a saga react+persist. Two failure domains plus a defensive
 /// overflow guard (CLAUDE.md rule 3 — one variant = one domain).

--- a/crates/nexus-store/tests/execute_tests.rs
+++ b/crates/nexus-store/tests/execute_tests.rs
@@ -1,0 +1,244 @@
+//! `CommandRepository::execute` integration tests — the mandatory
+//! cross-cutting categories (rule 7) over `InMemoryStore`, plus the
+//! equivalence-with-manual-two-step proof.
+
+#![allow(clippy::unwrap_used, reason = "tests")]
+#![allow(clippy::expect_used, reason = "tests")]
+#![allow(clippy::panic, reason = "panic in test match arms is an assertion")]
+#![allow(
+    clippy::shadow_reuse,
+    reason = "the spawn-closure clone-and-shadow pattern is idiomatic for tokio tests"
+)]
+#![allow(
+    clippy::missing_const_for_fn,
+    reason = "test-helper fns need not be const"
+)]
+
+use std::convert::Infallible;
+use std::sync::Arc;
+
+use bytes::Bytes;
+use futures::future::join_all;
+use nexus::{Aggregate, AggregateState, DomainEvent, Events, Handle, Message, Version, events};
+use nexus_store::testing::InMemoryStore;
+use nexus_store::{
+    CommandRepository, Decode, Encode, ExecuteError, PersistedEnvelope, Repository, Store,
+};
+use tokio::sync::Barrier;
+
+// ── Aggregate identity ────────────────────────────────────────────────────
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct CtrId([u8; 8]);
+impl CtrId {
+    fn new(n: u64) -> Self {
+        Self(n.to_le_bytes())
+    }
+}
+impl core::fmt::Display for CtrId {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}", u64::from_le_bytes(self.0))
+    }
+}
+impl AsRef<[u8]> for CtrId {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+// ── Events ────────────────────────────────────────────────────────────────
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum CtrEvent {
+    Added(u64),
+}
+impl Message for CtrEvent {}
+impl DomainEvent for CtrEvent {
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Added(_) => "Added",
+        }
+    }
+}
+
+// ── State ─────────────────────────────────────────────────────────────────
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CtrState {
+    total: u64,
+}
+impl AggregateState for CtrState {
+    type Event = CtrEvent;
+    fn initial() -> Self {
+        Self { total: 0 }
+    }
+    fn apply(mut self, event: &CtrEvent) -> Self {
+        match event {
+            CtrEvent::Added(n) => self.total += n,
+        }
+        self
+    }
+}
+
+#[derive(Debug, thiserror::Error, PartialEq)]
+enum CtrError {
+    #[error("cannot add zero")]
+    Zero,
+}
+
+// ── Marker + Handle ───────────────────────────────────────────────────────
+struct Counter;
+impl Aggregate for Counter {
+    type State = CtrState;
+    type Error = CtrError;
+    type Id = CtrId;
+}
+struct Add(u64);
+impl Handle<Add> for Counter {
+    fn handle(_state: &CtrState, cmd: Add) -> Result<Events<CtrEvent>, CtrError> {
+        if cmd.0 == 0 {
+            return Err(CtrError::Zero);
+        }
+        Ok(events![CtrEvent::Added(cmd.0)])
+    }
+}
+
+// ── Codec: encode the u64 LE ──────────────────────────────────────────────
+struct CtrCodec;
+impl Encode<CtrEvent> for CtrCodec {
+    type Error = Infallible;
+    fn encode(&self, event: &CtrEvent) -> Result<Bytes, Infallible> {
+        let CtrEvent::Added(n) = event;
+        Ok(Bytes::copy_from_slice(&n.to_le_bytes()))
+    }
+}
+impl Decode<CtrEvent> for CtrCodec {
+    type Output<'a> = CtrEvent;
+    type Error = Infallible;
+    fn decode<'a>(&'a self, env: &'a PersistedEnvelope) -> Result<Self::Output<'a>, Infallible> {
+        let mut buf = [0u8; 8];
+        buf.copy_from_slice(&env.payload()[..8]);
+        Ok(CtrEvent::Added(u64::from_le_bytes(buf)))
+    }
+}
+
+type Repo = nexus_store::EventStore<InMemoryStore, CtrCodec, Counter>;
+
+fn new_repo() -> Repo {
+    Store::new(InMemoryStore::new())
+        .repository()
+        .codec(CtrCodec)
+        .build()
+}
+
+// ── 1. Sequence/protocol ──────────────────────────────────────────────────
+#[tokio::test]
+async fn sequence_execute_chain_advances_version_and_state() {
+    let repo = new_repo();
+    let mut ctr = repo.load(CtrId::new(1)).await.unwrap();
+
+    let e1 = repo.execute(&mut ctr, Add(3)).await.unwrap();
+    assert_eq!(e1.iter().collect::<Vec<_>>(), vec![&CtrEvent::Added(3)]);
+    assert_eq!(ctr.version(), Version::new(1));
+    assert_eq!(ctr.state().total, 3);
+
+    let e2 = repo.execute(&mut ctr, Add(4)).await.unwrap();
+    assert_eq!(e2.iter().collect::<Vec<_>>(), vec![&CtrEvent::Added(4)]);
+    assert_eq!(ctr.version(), Version::new(2));
+    assert_eq!(ctr.state().total, 7);
+
+    let reloaded = repo.load(CtrId::new(1)).await.unwrap();
+    assert_eq!(reloaded.state().total, 7);
+    assert_eq!(reloaded.version(), Version::new(2));
+}
+
+// ── Defensive boundary: rejection persists nothing ────────────────────────
+#[tokio::test]
+async fn defensive_rejected_command_persists_nothing() {
+    let repo = new_repo();
+    let mut ctr = repo.load(CtrId::new(2)).await.unwrap();
+
+    let err = repo.execute(&mut ctr, Add(0)).await.unwrap_err();
+    assert!(matches!(err, ExecuteError::Decide(CtrError::Zero)));
+    assert!(!err.is_conflict());
+    assert_eq!(ctr.version(), None);
+    assert_eq!(ctr.state().total, 0);
+
+    let reloaded = repo.load(CtrId::new(2)).await.unwrap();
+    assert_eq!(reloaded.version(), None);
+}
+
+// ── Defensive boundary: stale root → conflict ─────────────────────────────
+#[tokio::test]
+async fn defensive_stale_root_conflicts() {
+    let repo = new_repo();
+    let mut a = repo.load(CtrId::new(3)).await.unwrap();
+    let mut b = repo.load(CtrId::new(3)).await.unwrap();
+
+    repo.execute(&mut a, Add(1)).await.unwrap();
+    let err = repo.execute(&mut b, Add(2)).await.unwrap_err();
+    assert!(err.is_conflict());
+    assert!(matches!(err, ExecuteError::Store(_)));
+}
+
+// ── Linearizability: concurrent execute, one wins ─────────────────────────
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn linearizable_concurrent_execute_one_winner() {
+    let repo = Arc::new(new_repo());
+    let id = CtrId::new(4);
+    let barrier = Arc::new(Barrier::new(2));
+
+    let tasks = [10u64, 20u64].into_iter().map(|n| {
+        let repo = Arc::clone(&repo);
+        let id = id.clone();
+        let barrier = Arc::clone(&barrier);
+        tokio::spawn(async move {
+            let mut ctr = repo.load(id).await.unwrap();
+            barrier.wait().await; // maximize overlap on the append
+            repo.execute(&mut ctr, Add(n)).await
+        })
+    });
+    let results: Vec<_> = join_all(tasks)
+        .await
+        .into_iter()
+        .map(|j| j.unwrap())
+        .collect();
+
+    let wins = results.iter().filter(|r| r.is_ok()).count();
+    let conflicts = results
+        .iter()
+        .filter(|r| r.as_ref().err().is_some_and(ExecuteError::is_conflict))
+        .count();
+    assert_eq!(wins, 1, "exactly one writer commits");
+    assert_eq!(
+        conflicts, 1,
+        "the loser surfaces a conflict, not a silent drop"
+    );
+
+    let final_ctr = repo.load(id).await.unwrap();
+    assert_eq!(final_ctr.version(), Version::new(1));
+    // Exactly one of the two commands landed — total is either 10 or 20,
+    // never both (30) and never neither (0).
+    assert!(
+        final_ctr.state().total == 10 || final_ctr.state().total == 20,
+        "expected exactly one command's effect, got {}",
+        final_ctr.state().total
+    );
+}
+
+// ── Equivalence: execute == manual handle + save ──────────────────────────
+#[tokio::test]
+async fn equivalence_execute_matches_manual_two_step() {
+    let manual = new_repo();
+    let mut m = manual.load(CtrId::new(5)).await.unwrap();
+    let decided = m.handle::<Add, 0>(Add(9)).unwrap();
+    manual.save(&mut m, &decided).await.unwrap();
+
+    let fused = new_repo();
+    let mut f = fused.load(CtrId::new(6)).await.unwrap();
+    let returned = fused.execute(&mut f, Add(9)).await.unwrap();
+
+    assert_eq!(
+        returned.iter().collect::<Vec<_>>(),
+        decided.iter().collect::<Vec<_>>()
+    );
+    assert_eq!(f.version(), m.version());
+    assert_eq!(f.state(), m.state());
+}

--- a/docs/plans/2026-07-02-execute-command-combinator-design.md
+++ b/docs/plans/2026-07-02-execute-command-combinator-design.md
@@ -1,0 +1,167 @@
+# `execute` — one call for decide-then-save
+
+**Issue:** #251
+**Status:** design — research is settled, we build the combinator
+**Date:** 2026-07-02
+
+---
+
+## The bug hiding in plain sight
+
+Here is what a developer writes for every single command:
+
+```rust
+let account = repo.load(id).await?;
+let decided  = account.handle(OpenAccount { owner })?;   // decide
+repo.save(&mut account, &decided).await?;                // save — pass the SAME events, and don't forget
+```
+
+Look at the middle two lines. That is a hand-off. The developer decides events in one line, then carries them by hand into the next. Any hand-off can be dropped.
+
+Two ways to drop this one:
+
+1. **Forget the save.** The events were decided and then thrown away. No error. No trace. The write just vanishes.
+2. **Save the wrong events.** Pass a stale `decided` from an earlier call, or hand-roll events the aggregate never agreed to. The store now holds a lie.
+
+This is not hypothetical. The repetition is why `examples/fjall-end-to-end` grew a `seed_account` helper — a band-aid over a design gap (#227).
+
+A hand-off the compiler does not check is a defect waiting for a bad day. Remove the hand-off.
+
+## Is a combinator the right shape? Yes. Here is the proof, not the opinion.
+
+The card demanded evidence, not taste (CLAUDE rule 0). The evidence is one-sided.
+
+**The Decider pattern already answers this.** Chassaing's decider is three pure functions *plus one runner* — the runner reads events, rebuilds state, runs decide, and appends. The stitching is one sanctioned function. Nobody assembles it by hand per command. ([thinkbeforecoding](https://thinkbeforecoding.com/post/2021/12/17/functional-event-sourcing-decider))
+
+**Functional Core, Imperative Shell says the same thing.** The pure core decides. The shell does the IO around it, and the core never knows the shell exists. The shell is written *once*. ([Chassaing, Functional Core Part 2](https://thinkbeforecoding.com/post/2018/02/01/functional-core-2))
+
+Now the punchline. Our hand-written `handle()` then `save()` **is that shell — leaked into every call site.** FCIS exists to stop exactly this leak. So the two-step is not the principled form. It is the anti-pattern the theory was built to prevent.
+
+The frameworks agree, but they are only witnesses, not authority: cqrs-es `execute`, Eventuous `CommandService`, Axon's unit-of-work — all fuse the call, all keep the decision pure. We do not need their vote.
+
+**We already decided this. Twice.**
+
+- `commit_persisted` (#212) fused `advance_version` and `apply_events`, then made the halves private. Reason given, in our own words: two steps a human threads is a desync bug, and the fix makes it *unrepresentable by construction*.
+- `react_and_save` fused the saga shell already.
+
+`handle` + `save` is the same bug, one floor up. Fixing it is consistency with ourselves. Leaving it is the thing that needs an excuse.
+
+## Why not the clever half-measure
+
+The card floated a second idea: keep two steps, but make `save` swallow the events as a move-only token so you cannot pass the wrong ones.
+
+It is weaker, and here is precisely why. Rust gives you *affine* types — a value is used at most once. It does not give you *linear* types — used exactly once. A move stops you passing a token twice. It does not force you to pass it at all. `#[must_use]` only warns on a dropped token; the program still compiles and still loses the write.
+
+So the token makes the bug *warned against*. Fusion makes it *impossible*. We do not settle for warned-against. Fuse it.
+
+And fusion costs us nothing. `execute` calls `handle` inside itself, so the pure decision stays public and stays testable. The explicit two-step survives as the escape hatch for the rare case where you must see the events before they land. Default is safe. The sharp tool is still in the drawer. That is the same split as `commit_persisted` versus the private advance/apply.
+
+## The design
+
+One combinator. It mirrors `SagaRepository` down to the seams.
+
+```rust
+/// Decide-then-save as one transaction. Extends `Repository<A>`; every
+/// repository gets it free (bare `EventStore` and the `Snapshotting` decorator).
+pub trait CommandRepository<A: Aggregate>: Repository<A> {
+    fn execute<C, const N: usize>(
+        &self,
+        root: &mut AggregateRoot<A>,
+        command: C,
+    ) -> impl Future<Output = Result<Events<EventOf<A>, N>, ExecuteError<A::Error, Self::Error>>> + Send
+    where
+        A: Handle<C, N>;
+}
+
+impl<A: Aggregate, R: Repository<A>> CommandRepository<A> for R {}
+```
+
+The whole body:
+
+```rust
+async move {
+    let decided = root.handle::<C, N>(command).map_err(ExecuteError::Decide)?;
+    self.save(root, &decided).await.map_err(ExecuteError::Store)?;
+    Ok(decided)
+}
+```
+
+Three lines. It invents nothing. `root.handle` is the pure decision that already exists. `self.save` already appends atomically and advances the root through `commit_persisted`. `execute` is the shell and only the shell.
+
+**It returns the decided events.** That keeps the one good thing the two-step had — you can inspect what was decided — while killing the bad thing: the caller never *supplies* events, so the caller cannot supply the wrong ones. The new version is already on `root.version()`, so no wrapper struct. Return the bare `Events`. (The saga side needs a `Reaction` wrapper only because it mints version-pinned intent tokens. Commands owe nobody that. Do not copy ceremony you do not need.)
+
+**Two errors, two domains. Never blur them (rule 3).**
+
+```rust
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive] // public error enum — the freeze carve-out (#209)
+pub enum ExecuteError<DecideErr, StoreErr> {
+    /// The aggregate refused the command. Nothing was written.
+    #[error("command rejected: {0}")]
+    Decide(#[source] DecideErr),
+
+    /// The save failed — adapter, codec, conflict, overflow.
+    #[error(transparent)]
+    Store(StoreErr),
+}
+
+impl<DecideErr, StoreErr: ConflictPredicate> ExecuteError<DecideErr, StoreErr> {
+    #[must_use]
+    pub fn is_conflict(&self) -> bool {
+        matches!(self, Self::Store(e) if e.is_conflict())
+    }
+}
+```
+
+No `VersionOverflow` variant. `save` already reports overflow inside its `Store` error. Adding it here would split one domain across two variants — the exact smell rule 3 forbids. (`react_and_save` needs it only because it does its own version math after the save. We do none.)
+
+`ConflictPredicate` already exists, sealed, in `saga.rs`. It moves to shared ground so `SagaError` and `ExecuteError` delegate to the one `StoreError::is_conflict`. One truth, two callers.
+
+## Conflict: hand it back, do not retry
+
+On a version conflict, `execute` returns `Err(ExecuteError::Store(..))` and `is_conflict()` is `true`. It stops there.
+
+The textbook decider retries — re-read, re-decide, re-save. We do not, on purpose. Internal retry assumes a single writer, and that assumption belongs to the runtime (Agency), not to a storage kernel (rule 5). `react_and_save` already draws this line. `execute` draws it in the same place. The caller reloads and retries if the caller knows it should.
+
+## Scope — and the discipline to stop there
+
+- **Only** `execute(&mut root, cmd)`. No load-and-execute combo. The gap in the card is the decide→save hand-off. `load` is already its own line, and keeping it separate protects the load-once-decide-many flow and the fixture. A load+execute fusion is a *different* card if anyone ever wants it. YAGNI.
+- `handle` and `save` do not change. `commit_persisted` does not change. The fixture does not change.
+- No new persistence machinery. If this design adds a transaction, a partition, or a byte to the wire, it is wrong.
+
+## Placement
+
+New file `crates/nexus-store/src/execute.rs`, shaped like `saga.rs`: the trait, `ExecuteError`, the blanket impl, the tests. Wire `mod execute;` into `lib.rs` and re-export like the saga module. Move `ConflictPredicate` and its `sealed` module out of `saga.rs` to shared ground; `saga.rs` imports it back. Sagas do not change behavior.
+
+## Tests — the four categories, first (rule 7)
+
+1. **Sequence.** `load → execute → execute → …` down a chain of commands. Assert the returned events and `root.version()` step correctly. Reload from scratch and assert identical state.
+2. **Lifecycle.** `execute` against `FjallStore`, close, reopen, load, prove the events are durable. Then prove a rejected command wrote *nothing*: reopen and the stream is untouched.
+3. **Defensive boundary.** A command the aggregate refuses → `ExecuteError::Decide`, store untouched. A stale root, behind the store → `ExecuteError::Store`, `is_conflict()` true.
+4. **Linearizability.** Two `execute` calls race on one id (spawn + barrier). One wins. The loser gets `is_conflict()`. The final stream holds only the winner's events.
+
+Then the equivalence test that earns the whole design: `execute` must produce byte-identical persisted state to the manual `handle` + `save`. If it does not, it is not a pure shell and the design is broken. And `is_conflict()`: `false` for `Decide`, `true` only for a conflicting `Store`.
+
+## Dogfood it — close #227 in the same stroke
+
+`examples/fjall-end-to-end/src/lib.rs` threads the two-step in `seed_account` and three more places. Collapse every
+
+```rust
+let decided = x.handle(cmd)?;
+repo.save(&mut x, &decided).await?;
+```
+
+into
+
+```rust
+repo.execute(&mut x, cmd).await?;
+```
+
+That proves the combinator on the real adapter and deletes the repetition that raised #227. Update the example prose to show `execute` as *the* way to run a command.
+
+## What this does not do
+
+- Does not retry. That is the runtime's job.
+- Does not fuse `load`. Different concern.
+- Does not touch `handle`, `save`, `commit_persisted`, or the fixture.
+- Does not add one byte of persistence machinery. It reuses `save` whole.

--- a/docs/plans/2026-07-02-execute-command-combinator-plan.md
+++ b/docs/plans/2026-07-02-execute-command-combinator-plan.md
@@ -1,0 +1,710 @@
+# `execute` Command Combinator — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `repo.execute(&mut root, cmd)` — one call that decides then saves — so the decide→save hand-off can't be forgotten or misthreaded (#251).
+
+**Architecture:** A blanket-implemented `CommandRepository<A>: Repository<A>` extension trait with one provided method `execute`, mirroring `SagaRepository::react_and_save`. `execute` calls the existing pure `AggregateRoot::handle` then the existing atomic `Repository::save`. No new persistence machinery. Two-domain `ExecuteError` (`Decide` | `Store`), conflict surfaced not retried.
+
+**Tech Stack:** Rust 2024, `nexus-store` crate, `thiserror`, `futures`, `tokio` (tests), `InMemoryStore`/`FjallStore` (test adapters).
+
+**Design doc:** `docs/plans/2026-07-02-execute-command-combinator-design.md`
+
+**Conventions:**
+- Run one test: `nix develop -c cargo test -p nexus-store -- <name>`.
+- Do **not** run `nix flake check` by hand — the pre-commit hook runs it on `git commit`. Just commit; let the hook gate.
+- `git add` any new source file before committing (the gate fails on untracked modules).
+- All `use` at top of file. No inline `use`. Strict clippy (`pedantic`/`nursery` denied).
+
+---
+
+## File Structure
+
+- **Create** `crates/nexus-store/src/conflict.rs` — `ConflictPredicate` + `sealed` module, moved verbatim from `saga.rs` so `SagaError` and `ExecuteError` share one impl.
+- **Create** `crates/nexus-store/src/execute.rs` — `CommandRepository` trait, blanket impl, `ExecuteError`, unit tests.
+- **Create** `crates/nexus-store/tests/execute_tests.rs` — the 4 cross-cutting categories over `InMemoryStore` + the equivalence test.
+- **Create** `crates/nexus-fjall/tests/execute_lifecycle_tests.rs` — the persistent-adapter lifecycle test (write → close → reopen → verify; rejection persists nothing).
+- **Modify** `crates/nexus-store/src/saga.rs` — delete the `ConflictPredicate`/`sealed` block, import from `crate::conflict`.
+- **Modify** `crates/nexus-store/src/lib.rs` — add `pub mod conflict;` and `pub mod execute;`; move `ConflictPredicate` re-export to `conflict`; add `CommandRepository`/`ExecuteError` re-exports.
+- **Modify** `examples/fjall-end-to-end/src/lib.rs` + `README.md` — replace every `handle`+`save` pair with `execute`; update prose.
+
+---
+
+## Task 1: Extract `ConflictPredicate` to a shared module (no behavior change)
+
+**Files:**
+- Create: `crates/nexus-store/src/conflict.rs`
+- Modify: `crates/nexus-store/src/saga.rs:24-46` (remove the block)
+- Modify: `crates/nexus-store/src/lib.rs:105` (add `pub mod conflict;`), `:158-161` (re-export move)
+
+- [ ] **Step 1: Create `conflict.rs` with the moved trait**
+
+```rust
+//! Shared optimistic-concurrency conflict predicate.
+//!
+//! Moved out of `saga.rs` so both [`SagaError`](crate::SagaError) and
+//! [`ExecuteError`](crate::ExecuteError) delegate to the same
+//! [`StoreError::is_conflict`](crate::StoreError::is_conflict) — one truth,
+//! two callers.
+
+use crate::error::StoreError;
+
+mod sealed {
+    pub trait Sealed {}
+}
+
+/// Predicate over a repository error: is this an optimistic-concurrency
+/// conflict (and therefore retryable by reloading + re-deciding)?
+///
+/// Sealed: implemented inside this crate for [`StoreError`] only. Lets error
+/// wrappers delegate without naming a concrete store error — `Snapshotting`'s
+/// `Repository::Error` is the inner `StoreError`, so one impl serves bare and
+/// snapshotted repositories alike.
+pub trait ConflictPredicate: sealed::Sealed {
+    /// `true` iff this error is an optimistic-concurrency conflict.
+    fn is_conflict(&self) -> bool;
+}
+
+impl<A, EncErr, DecErr> sealed::Sealed for StoreError<A, EncErr, DecErr> {}
+
+impl<A, EncErr, DecErr> ConflictPredicate for StoreError<A, EncErr, DecErr> {
+    fn is_conflict(&self) -> bool {
+        Self::is_conflict(self)
+    }
+}
+```
+
+- [ ] **Step 2: Remove the block from `saga.rs` and import from `crate::conflict`**
+
+In `crates/nexus-store/src/saga.rs`, delete the `mod sealed { ... }` block and both `ConflictPredicate` definitions/impls (the block at lines 24-46). Add to the top `use` cluster:
+
+```rust
+use crate::conflict::ConflictPredicate;
+```
+
+Leave `SagaError`'s `impl<SagaErr, StoreErr: ConflictPredicate>` and `is_conflict` exactly as they are — they now resolve `ConflictPredicate` via the import.
+
+- [ ] **Step 3: Wire the module and move the re-export in `lib.rs`**
+
+Add `pub mod conflict;` in the `pub mod` block (alphabetical, before `pub mod codec;` → put after `pub mod cbor;`). Change the saga re-export from:
+
+```rust
+pub use saga::{
+    ConflictPredicate, ProjectedIntent, ProjectedIntents, ProjectedIntentsIntoIter, Reaction,
+    SagaError, SagaRepository,
+};
+```
+
+to:
+
+```rust
+pub use conflict::ConflictPredicate;
+pub use saga::{
+    ProjectedIntent, ProjectedIntents, ProjectedIntentsIntoIter, Reaction, SagaError,
+    SagaRepository,
+};
+```
+
+- [ ] **Step 4: Verify nothing broke — saga tests still pass**
+
+Run: `nix develop -c cargo test -p nexus-store -- saga`
+Expected: PASS (the extraction is behavior-preserving; `ConflictPredicate` resolves at the new path).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/nexus-store/src/conflict.rs crates/nexus-store/src/saga.rs crates/nexus-store/src/lib.rs
+git commit -m "refactor(store): extract ConflictPredicate to shared conflict module"
+```
+
+---
+
+## Task 2: `ExecuteError` + its `is_conflict`, with a unit test
+
+**Files:**
+- Create: `crates/nexus-store/src/execute.rs`
+- Modify: `crates/nexus-store/src/lib.rs` (add `pub mod execute;`)
+
+- [ ] **Step 1: Create `execute.rs` with the error type only**
+
+```rust
+//! Store-side command combinator — the aggregate analogue of
+//! [`SagaRepository`](crate::SagaRepository).
+//!
+//! [`CommandRepository::execute`] fuses `decide → save` into one call so the
+//! decided events can't be forgotten or misthreaded (#251). It adds no
+//! persistence machinery — it is the "imperative shell" over the pure
+//! [`AggregateRoot::handle`](nexus::AggregateRoot::handle) and the atomic
+//! [`Repository::save`](crate::Repository::save).
+//!
+//! See `docs/plans/2026-07-02-execute-command-combinator-design.md`.
+
+use core::future::Future;
+
+use nexus::{Aggregate, AggregateRoot, EventOf, Events, Handle};
+
+use crate::conflict::ConflictPredicate;
+use crate::repository::Repository;
+
+/// Error from a command `execute`. Two failure domains kept distinct
+/// (CLAUDE.md rule 3 — one variant = one domain).
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum ExecuteError<DecideErr, StoreErr> {
+    /// The aggregate rejected the command (a domain invariant). Nothing persisted.
+    #[error("command rejected: {0}")]
+    Decide(#[source] DecideErr),
+
+    /// `save` failed (adapter / codec / conflict / version overflow).
+    #[error(transparent)]
+    Store(StoreErr),
+}
+
+impl<DecideErr, StoreErr: ConflictPredicate> ExecuteError<DecideErr, StoreErr> {
+    /// `true` iff the save failed on an optimistic-concurrency conflict.
+    /// `Decide` is never a conflict (rule 3 — rejection is not retryable).
+    #[must_use]
+    pub fn is_conflict(&self) -> bool {
+        matches!(self, Self::Store(e) if e.is_conflict())
+    }
+}
+
+#[cfg(test)]
+mod error_tests {
+    use super::ExecuteError;
+    use crate::error::StoreError;
+    use nexus::{ErrorId, Version};
+
+    type TestStoreError =
+        StoreError<std::io::Error, std::convert::Infallible, std::convert::Infallible>;
+    type TestExecuteError = ExecuteError<&'static str, TestStoreError>;
+
+    #[test]
+    fn conflict_store_error_is_conflict() {
+        let e: TestExecuteError = ExecuteError::Store(StoreError::Conflict {
+            stream_id: ErrorId::from_display(&"s"),
+            expected: Some(Version::INITIAL),
+            actual: None,
+        });
+        assert!(e.is_conflict());
+    }
+
+    #[test]
+    fn decide_error_is_not_conflict() {
+        let e: TestExecuteError = ExecuteError::Decide("rejected");
+        assert!(!e.is_conflict());
+    }
+}
+```
+
+> Note: `use nexus::{... Handle, ...}` and the `Repository`/future imports are unused until Task 3 adds the trait. To keep this task compiling clean under strict clippy, add the trait in Task 3 *before* running the full gate; for this task's isolated test run the `#[cfg(test)]` module compiles. If clippy's `unused_imports` bites during this task, trim the `use` line to just what `error_tests` needs (`thiserror` via derive, `ConflictPredicate`) and re-add the rest in Task 3. Simplest path: do Task 2 and Task 3 back-to-back, committing once at the end of Task 3.
+
+- [ ] **Step 2: Wire the module in `lib.rs`**
+
+Add `pub mod execute;` (after `pub mod error;`). Re-export near the saga line:
+
+```rust
+pub use execute::{CommandRepository, ExecuteError};
+```
+
+(`CommandRepository` lands in Task 3; if compiling Task 2 alone, temporarily export only `ExecuteError` and add `CommandRepository` in Task 3.)
+
+- [ ] **Step 3: Run the error unit tests**
+
+Run: `nix develop -c cargo test -p nexus-store -- execute::error_tests`
+Expected: PASS (2 tests).
+
+- [ ] **Step 4: (commit deferred to Task 3 — see note above)**
+
+---
+
+## Task 3: `CommandRepository` trait + blanket impl + `execute`
+
+**Files:**
+- Modify: `crates/nexus-store/src/execute.rs`
+
+- [ ] **Step 1: Add the trait and blanket impl above the test module**
+
+```rust
+/// The command-facing port: `decide → save` as one callable transaction.
+///
+/// Extends [`Repository<A>`] and inherits its `load`/`save` unchanged. The one
+/// provided method rides on every repository via the blanket impl below — bare
+/// [`EventStore`](crate::EventStore) and the
+/// [`Snapshotting`](crate::snapshot::Snapshotting) decorator alike.
+pub trait CommandRepository<A: Aggregate>: Repository<A> {
+    /// Decide `command` against `root`, persist the decided events atomically,
+    /// advance `root`, and return the decided events for inspection.
+    ///
+    /// - `Ok(events)` — the command was accepted and its events are durable.
+    /// - `Err(ExecuteError::Decide)` — the aggregate rejected it; nothing persisted.
+    /// - `Err(ExecuteError::Store)` — the save failed (see [`ExecuteError::is_conflict`]).
+    ///
+    /// On a version conflict this returns `Err(ExecuteError::Store(..))` with
+    /// `is_conflict() == true` and does **not** retry — retry is the runtime's
+    /// job (CLAUDE.md rule 5), matching `SagaRepository::react_and_save`.
+    ///
+    /// # Errors
+    /// See the variants above.
+    fn execute<C, const N: usize>(
+        &self,
+        root: &mut AggregateRoot<A>,
+        command: C,
+    ) -> impl Future<Output = Result<Events<EventOf<A>, N>, ExecuteError<A::Error, Self::Error>>> + Send
+    where
+        A: Handle<C, N>,
+    {
+        async move {
+            let decided = root.handle::<C, N>(command).map_err(ExecuteError::Decide)?;
+            self.save(root, &decided).await.map_err(ExecuteError::Store)?;
+            Ok(decided)
+        }
+    }
+}
+
+// Rides on every repository — bare `EventStore` AND the `Snapshotting`
+// decorator — with zero per-type code. Fully static dispatch.
+impl<A: Aggregate, R: Repository<A>> CommandRepository<A> for R {}
+```
+
+- [ ] **Step 2: Confirm the crate compiles and unit tests pass**
+
+Run: `nix develop -c cargo test -p nexus-store -- execute::`
+Expected: PASS. If `unused_imports` fired in Task 2, it clears now (`Handle`, `Repository`, `Future`, `Events`, `EventOf`, `AggregateRoot` are all used).
+
+- [ ] **Step 3: Commit Tasks 2+3 together**
+
+```bash
+git add crates/nexus-store/src/execute.rs crates/nexus-store/src/lib.rs
+git commit -m "feat(store): CommandRepository::execute — fuse decide and save (#251)"
+```
+
+---
+
+## Task 4: The 4 cross-cutting categories + equivalence, over `InMemoryStore`
+
+**Files:**
+- Create: `crates/nexus-store/tests/execute_tests.rs`
+
+Model the harness on `crates/nexus-store/tests/saga_repository_tests.rs` (same allows, same `InMemoryStore`/`Store` setup). Define a minimal **counter** aggregate with a `Handle` impl and a JSON-ish codec.
+
+- [ ] **Step 1: Write the test file with the aggregate, codec, and all assertions**
+
+```rust
+//! `CommandRepository::execute` integration tests — the 4 mandatory
+//! cross-cutting categories (CLAUDE.md rule 7) over `InMemoryStore`, plus the
+//! equivalence-with-manual-two-step proof.
+
+#![allow(clippy::unwrap_used, reason = "tests")]
+#![allow(clippy::expect_used, reason = "tests")]
+#![allow(clippy::panic, reason = "panic in test match arms is an assertion")]
+#![allow(
+    clippy::shadow_reuse,
+    reason = "the spawn-closure clone-and-shadow pattern is idiomatic for tokio tests"
+)]
+
+use std::convert::Infallible;
+use std::sync::Arc;
+
+use bytes::Bytes;
+use nexus::{
+    Aggregate, AggregateРoot, AggregateState, DomainEvent, Events, Handle, Message, Version, events,
+};
+use nexus_store::testing::InMemoryStore;
+use nexus_store::{
+    CommandRepository, Decode, Encode, ExecuteError, PersistedEnvelope, Repository, Store,
+};
+use tokio::sync::Barrier;
+
+// ── Aggregate identity ────────────────────────────────────────────────────
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct CtrId([u8; 8]);
+impl CtrId {
+    fn new(n: u64) -> Self {
+        Self(n.to_le_bytes())
+    }
+}
+impl core::fmt::Display for CtrId {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}", u64::from_le_bytes(self.0))
+    }
+}
+impl AsRef<[u8]> for CtrId {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+// ── Events ────────────────────────────────────────────────────────────────
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum CtrEvent {
+    Added(u64),
+}
+impl Message for CtrEvent {}
+impl DomainEvent for CtrEvent {
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Added(_) => "Added",
+        }
+    }
+}
+
+// ── State ─────────────────────────────────────────────────────────────────
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CtrState {
+    total: u64,
+}
+impl AggregateState for CtrState {
+    type Event = CtrEvent;
+    fn initial() -> Self {
+        Self { total: 0 }
+    }
+    fn apply(mut self, event: &CtrEvent) -> Self {
+        match event {
+            CtrEvent::Added(n) => self.total += n,
+        }
+        self
+    }
+}
+
+#[derive(Debug, thiserror::Error, PartialEq)]
+enum CtrError {
+    #[error("cannot add zero")]
+    Zero,
+}
+
+// ── Marker + Handle ───────────────────────────────────────────────────────
+struct Counter;
+impl Aggregate for Counter {
+    type State = CtrState;
+    type Error = CtrError;
+    type Id = CtrId;
+}
+struct Add(u64);
+impl Handle<Add> for Counter {
+    fn handle(_state: &CtrState, cmd: Add) -> Result<Events<CtrEvent>, CtrError> {
+        if cmd.0 == 0 {
+            return Err(CtrError::Zero);
+        }
+        Ok(events![CtrEvent::Added(cmd.0)])
+    }
+}
+
+// ── Minimal JSON-free codec (length-agnostic: encode the u64 LE) ──────────
+struct CtrCodec;
+impl Encode<CtrEvent> for CtrCodec {
+    type Error = Infallible;
+    fn encode(&self, event: &CtrEvent) -> Result<Bytes, Infallible> {
+        let CtrEvent::Added(n) = event;
+        Ok(Bytes::copy_from_slice(&n.to_le_bytes()))
+    }
+}
+impl Decode<CtrEvent> for CtrCodec {
+    type Output<'a> = CtrEvent;
+    type Error = Infallible;
+    fn decode<'a>(
+        &'a self,
+        env: &'a PersistedEnvelope,
+    ) -> Result<Self::Output<'a>, Infallible> {
+        let mut buf = [0u8; 8];
+        buf.copy_from_slice(&env.payload()[..8]);
+        Ok(CtrEvent::Added(u64::from_le_bytes(buf)))
+    }
+}
+
+fn repo() -> impl CommandRepository<Counter, Error = impl std::error::Error + Send + Sync + 'static>
+{
+    Store::new(InMemoryStore::new())
+        .repository::<Counter>()
+        .codec(CtrCodec)
+        .build()
+}
+
+// ── 1. Sequence/protocol ──────────────────────────────────────────────────
+#[tokio::test]
+async fn sequence_execute_chain_advances_version_and_state() {
+    let repo = repo();
+    let mut ctr = repo.load(CtrId::new(1)).await.unwrap();
+
+    let e1 = repo.execute(&mut ctr, Add(3)).await.unwrap();
+    assert_eq!(e1.as_slice(), &[CtrEvent::Added(3)]);
+    assert_eq!(ctr.version(), Version::new(1));
+    assert_eq!(ctr.state().total, 3);
+
+    let e2 = repo.execute(&mut ctr, Add(4)).await.unwrap();
+    assert_eq!(e2.as_slice(), &[CtrEvent::Added(4)]);
+    assert_eq!(ctr.version(), Version::new(2));
+    assert_eq!(ctr.state().total, 7);
+
+    // Reload from scratch — replays to identical state.
+    let reloaded = repo.load(CtrId::new(1)).await.unwrap();
+    assert_eq!(reloaded.state().total, 7);
+    assert_eq!(reloaded.version(), Version::new(2));
+}
+
+// ── 3. Defensive boundary: rejection persists nothing ─────────────────────
+#[tokio::test]
+async fn defensive_rejected_command_persists_nothing() {
+    let repo = repo();
+    let mut ctr = repo.load(CtrId::new(2)).await.unwrap();
+
+    let err = repo.execute(&mut ctr, Add(0)).await.unwrap_err();
+    assert!(matches!(err, ExecuteError::Decide(CtrError::Zero)));
+    assert!(!err.is_conflict());
+    assert_eq!(ctr.version(), None); // unchanged — never advanced
+    assert_eq!(ctr.state().total, 0);
+
+    let reloaded = repo.load(CtrId::new(2)).await.unwrap();
+    assert_eq!(reloaded.version(), None); // stream empty
+}
+
+// ── 3b. Defensive boundary: stale root → conflict ─────────────────────────
+#[tokio::test]
+async fn defensive_stale_root_conflicts() {
+    let repo = repo();
+    // Two roots at the same id; write with the first, then the stale second.
+    let mut a = repo.load(CtrId::new(3)).await.unwrap();
+    let mut b = repo.load(CtrId::new(3)).await.unwrap(); // both at version None
+
+    repo.execute(&mut a, Add(1)).await.unwrap(); // a → v1
+    let err = repo.execute(&mut b, Add(2)).await.unwrap_err(); // b still expects None
+    assert!(err.is_conflict());
+    assert!(matches!(err, ExecuteError::Store(_)));
+}
+
+// ── 4. Linearizability: concurrent execute, one wins ──────────────────────
+#[tokio::test]
+async fn linearizable_concurrent_execute_one_winner() {
+    let repo = Arc::new(repo());
+    let barrier = Arc::new(Barrier::new(2));
+
+    let mut handles = Vec::new();
+    for n in [10u64, 20u64] {
+        let repo = Arc::clone(&repo);
+        let barrier = Arc::clone(&barrier);
+        handles.push(tokio::spawn(async move {
+            let mut ctr = repo.load(CtrId::new(4)).await.unwrap();
+            barrier.wait().await; // ensure both loaded at version None before either writes
+            repo.execute(&mut ctr, Add(n)).await
+        }));
+    }
+
+    let mut wins = 0;
+    let mut conflicts = 0;
+    for h in handles {
+        match h.await.unwrap() {
+            Ok(_) => wins += 1,
+            Err(e) => {
+                assert!(e.is_conflict());
+                conflicts += 1;
+            }
+        }
+    }
+    assert_eq!(wins, 1);
+    assert_eq!(conflicts, 1);
+
+    // Exactly one event in the stream.
+    let final_ctr = repo.load(CtrId::new(4)).await.unwrap();
+    assert_eq!(final_ctr.version(), Version::new(1));
+}
+
+// ── Equivalence: execute == manual handle + save ──────────────────────────
+#[tokio::test]
+async fn equivalence_execute_matches_manual_two_step() {
+    // Manual two-step.
+    let manual = repo();
+    let mut m = manual.load(CtrId::new(5)).await.unwrap();
+    let decided = m.handle::<Add, 0>(Add(9)).unwrap();
+    manual.save(&mut m, &decided).await.unwrap();
+
+    // Combinator.
+    let fused = repo();
+    let mut f = fused.load(CtrId::new(5)).await.unwrap();
+    let returned = fused.execute(&mut f, Add(9)).await.unwrap();
+
+    // Same decided events, same resulting version + state.
+    assert_eq!(returned.as_slice(), decided.as_slice());
+    assert_eq!(f.version(), m.version());
+    assert_eq!(f.state(), m.state());
+}
+```
+
+> **Fix the typo before running:** `AggregateРoot` in the `use` line above contains a Cyrillic `Р` — retype it as ASCII `AggregateRoot`. (Guard against copy-paste.)
+
+- [ ] **Step 2: Verify `Events::as_slice`, `AggregateRoot::state`, and `Version::new` names**
+
+Run: `nix develop -c grep -rn "pub fn as_slice\|pub const fn state\|pub fn state\|pub const fn new" crates/nexus/src/events.rs crates/nexus/src/aggregate.rs crates/nexus/src/version.rs`
+Expected: confirms `Events::as_slice`, `AggregateRoot::state`, `Version::new` exist. If any name differs (e.g. state accessor), adjust the assertions to the real accessor before proceeding.
+
+- [ ] **Step 3: Run the integration tests**
+
+Run: `nix develop -c cargo test -p nexus-store --test execute_tests`
+Expected: PASS (5 tests). The lifecycle category is Task 5 (needs a persistent adapter).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/nexus-store/tests/execute_tests.rs
+git commit -m "test(store): execute — sequence, defensive, linearizability, equivalence (#251)"
+```
+
+---
+
+## Task 5: Lifecycle test over `FjallStore` (write → close → reopen → verify)
+
+**Files:**
+- Create: `crates/nexus-fjall/tests/execute_lifecycle_tests.rs`
+
+Model on the existing fjall integration tests and `examples/fjall-end-to-end` for the `FjallStore::builder(path).open()?.into_store()` open/reopen pattern. Reuse a counter-style aggregate + codec (copy the definitions from `execute_tests.rs`; a shared test-support module is overkill for one reuse — inline them).
+
+- [ ] **Step 1: Confirm the fjall open/reopen API**
+
+Run: `nix develop -c grep -rn "FjallStore::builder\|\.open()\|into_store\|tempdir\|TempDir" crates/nexus-fjall/tests/*.rs examples/fjall-end-to-end/src/*.rs | head`
+Expected: shows the builder→open→into_store sequence and the tempdir pattern to copy.
+
+- [ ] **Step 2: Write the lifecycle test**
+
+Using the confirmed API, write a test that:
+1. Opens a `FjallStore` at a `tempfile::TempDir` path, builds a `repository::<Counter>()`.
+2. `execute`s two `Add` commands; asserts durability of the returned events and version.
+3. **Drops** the store/keyspace (close), reopens at the same path, `load`s, and asserts `state().total` and `version()` survived.
+4. `execute`s a rejected `Add(0)`; reopens and asserts the stream is unchanged (rejection persisted nothing across a reopen).
+
+```rust
+// Skeleton — fill open/reopen with the API confirmed in Step 1.
+#[tokio::test]
+async fn lifecycle_execute_survives_reopen() {
+    let dir = tempfile::TempDir::new().unwrap();
+    {
+        let store = /* FjallStore::builder(dir.path()).open().unwrap().into_store() */;
+        let repo = store.repository::<Counter>().codec(CtrCodec).build();
+        let mut ctr = repo.load(CtrId::new(1)).await.unwrap();
+        repo.execute(&mut ctr, Add(3)).await.unwrap();
+        repo.execute(&mut ctr, Add(4)).await.unwrap();
+        assert_eq!(ctr.state().total, 7);
+    } // store dropped — closed
+
+    let store = /* reopen at dir.path() */;
+    let repo = store.repository::<Counter>().codec(CtrCodec).build();
+    let reloaded = repo.load(CtrId::new(1)).await.unwrap();
+    assert_eq!(reloaded.state().total, 7);
+    assert_eq!(reloaded.version(), Version::new(2));
+
+    // Rejection persists nothing across the open store.
+    let mut ctr = repo.load(CtrId::new(1)).await.unwrap();
+    let err = repo.execute(&mut ctr, Add(0)).await.unwrap_err();
+    assert!(matches!(err, ExecuteError::Decide(_)));
+    let after = repo.load(CtrId::new(1)).await.unwrap();
+    assert_eq!(after.version(), Version::new(2)); // unchanged
+}
+```
+
+- [ ] **Step 3: Confirm `nexus-fjall` has the test deps**
+
+Run: `nix develop -c grep -n "tempfile\|tokio\|nexus-store" crates/nexus-fjall/Cargo.toml`
+Expected: `tokio` (with `macros`/`rt`) and `tempfile` under `[dev-dependencies]`, plus `nexus-store` with the `testing` feature if the codec helpers need it. If `tempfile` is missing, add it: `nix develop -c cargo add --dev tempfile -p nexus-fjall` (never hand-edit versions — CLAUDE convention).
+
+- [ ] **Step 4: Run the lifecycle test**
+
+Run: `nix develop -c cargo test -p nexus-fjall --test execute_lifecycle_tests`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/nexus-fjall/tests/execute_lifecycle_tests.rs crates/nexus-fjall/Cargo.toml
+git commit -m "test(fjall): execute lifecycle — durable across reopen (#251)"
+```
+
+---
+
+## Task 6: Dogfood — migrate the fjall example, close #227's repetition
+
+**Files:**
+- Modify: `examples/fjall-end-to-end/src/lib.rs` (sites ~98-104, 140-141, 214-216)
+- Modify: `examples/fjall-end-to-end/README.md`, `examples/fjall-end-to-end/src/lib.rs:30` header prose
+
+- [ ] **Step 1: Add the import**
+
+In `examples/fjall-end-to-end/src/lib.rs`, add `CommandRepository` to the `nexus_store` import group.
+
+- [ ] **Step 2: Collapse each two-step into `execute`**
+
+Replace every pair of the form:
+
+```rust
+let decided = account.handle(SomeCmd { .. })?;
+repo.save(&mut account, &decided).await?;
+```
+
+with:
+
+```rust
+repo.execute(&mut account, SomeCmd { .. }).await?;
+```
+
+Concretely, in `seed_account` the `OpenAccount` pair (lines ~98-101) and the `Deposit` loop pair (lines ~103-104) each collapse to one `execute` line; likewise the `Withdraw` site (~140-141) and the `Deposit` site (~214-216). Where the returned events were bound and inspected, keep the binding: `let decided = repo.execute(&mut account, cmd).await?;`.
+
+- [ ] **Step 3: Update the prose**
+
+In the `lib.rs` header comment (line ~30) and `README.md` (line ~36), change the "`repo.load(id)` / `repo.save(..)`" description to present `repo.execute(&mut root, cmd)` as the sanctioned one-call command path, noting `handle` + `save` remains the escape hatch for inspecting events before they land.
+
+- [ ] **Step 4: Run the example's tests**
+
+Run: `nix develop -c cargo test -p fjall-end-to-end`
+Expected: PASS (behavior is identical; `execute` == `handle` + `save`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add examples/fjall-end-to-end/
+git commit -m "docs(example): use execute in fjall-end-to-end, closes #227 repetition (#251)"
+```
+
+---
+
+## Task 7: Final gate + issue close-out
+
+- [ ] **Step 1: Let the full gate run on a no-op commit or rely on the last commit's hook**
+
+The pre-commit hook already ran `nix flake check` on each commit above. If you want a clean final confirmation without a code change, run the manual all-targets clippy the flake's `--lib` gate skips (CLAUDE convention — the gate is `--lib` only):
+
+Run: `nix develop -c cargo clippy --all-targets --all-features -- -D warnings`
+Expected: clean (no warnings). Fix any lint in **non-test** code immediately; test-only lints get scoped `#[allow(.., reason = "..")]`.
+
+- [ ] **Step 2: Open the PR**
+
+Branch was created off `origin/main` at the start (see execution note). Push and open with the `joeldsouzax` gh account:
+
+```bash
+git push -u origin feat/execute-command-combinator
+gh pr create --title "feat(store): execute — one-call decide+save combinator (#251)" \
+  --body "$(cat <<'EOF'
+Closes #251. Resolves the #227 per-command two-step repetition.
+
+Adds `CommandRepository::execute(&mut root, cmd)` — a blanket-impl'd combinator
+that fuses the pure `AggregateRoot::handle` with the atomic `Repository::save`,
+mirroring `SagaRepository::react_and_save`. The decided events are never named
+by the caller, so the decide→save hand-off can't be forgotten or misthreaded.
+
+- `handle` and `save` unchanged; `execute` is a pure shell (equivalence-tested).
+- Two-domain `ExecuteError` (`Decide` | `Store`); conflict surfaced, never retried
+  (rule 5), consistent with the saga side.
+- `ConflictPredicate` extracted to a shared `conflict` module (saga behavior unchanged).
+- 4 cross-cutting test categories + equivalence over `InMemoryStore`; lifecycle over `FjallStore`.
+- `fjall-end-to-end` example migrated to `execute`.
+
+Design: docs/plans/2026-07-02-execute-command-combinator-design.md
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-Review Notes (author checklist — done)
+
+- **Spec coverage:** trait/blanket impl (T3) ✓, `ExecuteError` two domains + `is_conflict` (T2) ✓, return decided events (T3) ✓, conflict-not-retry (T3 docs + T4 test) ✓, `ConflictPredicate` shared move (T1) ✓, placement in `execute.rs` mirroring saga (T2/T3) ✓, all 4 test categories (T4 seq/defensive/linearizability + T5 lifecycle) ✓, equivalence test (T4) ✓, example migration/#227 (T6) ✓, `#[non_exhaustive]` freeze carve-out on the error (T2) ✓, scope-limited to `execute` only (no load+execute) ✓.
+- **Type consistency:** `CommandRepository`, `ExecuteError<DecideErr, StoreErr>`, `Decide`/`Store` variants, `execute<C, const N: usize>`, `Counter`/`CtrId`/`CtrEvent`/`CtrState`/`CtrError`/`Add`/`CtrCodec` used consistently across T2-T6.
+- **Watch-items flagged for the implementer:** (1) Task 2/3 commit-together to avoid transient `unused_imports`; (2) the Cyrillic-`Р` typo guard in T4; (3) verify `Events::as_slice`/`AggregateRoot::state`/`Version::new` accessor names in T4 Step 2 before trusting the assertions; (4) confirm fjall open/reopen + `tempfile` dep in T5 rather than assuming.

--- a/examples/fjall-end-to-end/README.md
+++ b/examples/fjall-end-to-end/README.md
@@ -36,3 +36,12 @@ then implements `Repository<BankAccount>` for exactly that aggregate, so
 `repo.load(id)` / `repo.save(..)` infer it with no per-call annotation. This
 example was the canary for #243 — with that landed, the former
 `let acct: AggregateRoot<BankAccount> = repo.load(id)…` annotations are gone.
+
+## Deciding and persisting (#227, #251)
+
+The sanctioned one-call command path is `repo.execute(&mut root, cmd)` — it
+fuses `AggregateRoot::handle` (decide) and `Repository::save` (persist) into
+one call, so the decided events can never be forgotten or misthreaded between
+the two steps. The manual two-step `root.handle(cmd)?` +
+`repo.save(&mut root, &decided).await?` remains available as the escape hatch
+when a caller needs to inspect the decided events before they land.

--- a/examples/fjall-end-to-end/src/lib.rs
+++ b/examples/fjall-end-to-end/src/lib.rs
@@ -31,6 +31,17 @@
 //! annotation. (This example was the canary for #243; with that landed, the
 //! former `let acct: AggregateRoot<BankAccount> = repo.load(id)…` annotations
 //! are gone.)
+//!
+//! ## Deciding and persisting (#227, #251)
+//!
+//! The sanctioned one-call command path is `repo.execute(&mut root, cmd)` —
+//! it fuses `AggregateRoot::handle` (decide) and `Repository::save` (persist)
+//! so the decided events can never be forgotten or misthreaded between the
+//! two steps, and returns them for inspection. The manual two-step
+//! `root.handle(cmd)?` + `repo.save(&mut root, &decided).await?` remains
+//! available as the escape hatch when a caller needs to inspect the decided
+//! events *before* they land (e.g. to log or transform them ahead of the
+//! save).
 
 // Example code relaxes a handful of strict lints locally (production crates do
 // NOT) — same posture as `examples/closing-the-books` and `examples/inmemory`.
@@ -75,7 +86,7 @@ use nexus_store::export::{EventExporter, StreamLister};
 use nexus_store::import::{Atomicity, EventImporter, StreamOutcome};
 use nexus_store::repository::Repository;
 use nexus_store::store::{RawEventStore, Store};
-use nexus_store::{PersistedEnvelope, StreamKey, Subscription};
+use nexus_store::{CommandRepository, PersistedEnvelope, StreamKey, Subscription};
 
 use domain::{AccountEvent, AccountId, AccountState, BankAccount, Deposit, OpenAccount, Withdraw};
 
@@ -95,13 +106,15 @@ async fn seed_account<R: Repository<BankAccount>>(
     deposits: &[u64],
 ) -> Result<AccountState, BoxErr> {
     let mut account = repo.load(id.clone()).await?;
-    let decided = account.handle(OpenAccount {
-        owner: owner.to_owned(),
-    })?;
-    repo.save(&mut account, &decided).await?;
+    repo.execute(
+        &mut account,
+        OpenAccount {
+            owner: owner.to_owned(),
+        },
+    )
+    .await?;
     for &amount in deposits {
-        let decided = account.handle(Deposit { amount })?;
-        repo.save(&mut account, &decided).await?;
+        repo.execute(&mut account, Deposit { amount }).await?;
     }
     Ok(account.state().clone())
 }
@@ -137,8 +150,7 @@ pub async fn run_persistence(path: &Path) -> Result<(AccountState, AccountState)
         // to `BankAccount` (named at `repository::<BankAccount>()`), so `load`
         // infers the aggregate — no annotation (#243).
         let mut account = repo.load(id.clone()).await?;
-        let decided = account.handle(Withdraw { amount: 300 })?;
-        repo.save(&mut account, &decided).await?;
+        repo.execute(&mut account, Withdraw { amount: 300 }).await?;
         account.state().clone()
     };
 
@@ -210,12 +222,9 @@ pub async fn run_subscription(path: &Path) -> Result<SubscriptionOutcome, BoxErr
         let repo = writer_store.repository::<BankAccount>().build();
         writer_barrier.wait().await;
         let mut account = repo.load(writer_id).await.expect("load for live append");
-        let decided = account
-            .handle(Deposit { amount: 250 })
-            .expect("live deposit decides");
-        repo.save(&mut account, &decided)
+        repo.execute(&mut account, Deposit { amount: 250 })
             .await
-            .expect("live append persists");
+            .expect("live deposit executes");
     });
 
     barrier.wait().await;


### PR DESCRIPTION
Closes #251. Resolves the #227 per-command two-step repetition.

## What

Adds `CommandRepository::execute(&mut root, cmd)` — a blanket-implemented combinator over `Repository<A>` that fuses the pure `AggregateRoot::handle` (decide) with the atomic `Repository::save` (persist), mirroring the saga side's `react_and_save`. The caller never names the decided events, so the `decide → save` hand-off can no longer be forgotten or misthreaded.

```rust
// before — two steps a dev can desync
let decided = account.handle(OpenAccount { owner })?;
repo.save(&mut account, &decided).await?;

// after — one call, misthreading unrepresentable
repo.execute(&mut account, OpenAccount { owner }).await?;
```

## Why a combinator (research resolved)

The card mandated cited prior art. The two-step is **not** the principled form: the Decider pattern ships a single runner, and Functional-Core/Imperative-Shell says the load→decide→persist stitching is the shell — written once, not leaked to every call site. Decisively, nexus already ruled this way twice from first principles — `commit_persisted` (#212) fused advance+apply so desync is unrepresentable, and `react_and_save` fused the saga shell. `handle` + `save` was the same bug one layer up. Full write-up: `docs/plans/2026-07-02-execute-command-combinator-design.md`.

The "safer two-step" move-token alternative was rejected: Rust is affine, not linear, so `#[must_use]` only *warns* on a dropped token — fusion makes desync *unrepresentable*.

## Design points

- `handle`, `save`, `commit_persisted`, and the fixtures are **unchanged** — `execute` is a pure shell (equivalence-tested against the manual two-step).
- Two-domain `ExecuteError` (`Decide` | `Store`), `#[non_exhaustive]`; conflicts are **surfaced, never retried** (rule 5), consistent with the saga side. `is_conflict()` is true only for a conflicting `Store`.
- `C: Send` bound is load-bearing (empirically verified — the `async move` captures `command` into the coroutine environment; without it the future isn't `Send`).
- `ConflictPredicate` extracted to a shared `conflict` module so `SagaError` and `ExecuteError` delegate to one `StoreError::is_conflict` (behavior-preserving; public root path unchanged).

## Test Plan

- [x] Sequence/protocol, defensive boundary (rejection persists nothing; stale-root conflict), and linearizability (genuine multi-thread, one-winner/one-conflict split) over `InMemoryStore`
- [x] Lifecycle over `FjallStore` — durable across a real close/reopen; rejection persists nothing
- [x] Equivalence — `execute` produces identical events/version/state to manual `handle` + `save`
- [x] `fjall-end-to-end` example migrated to `execute` (dogfoods the combinator, closes #227's repetition)
- [x] Full `nix flake check` gate green on every commit; adversarial whole-branch review: APPROVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)