### PR TITLE
feat(kernel): version! literal + Version::run (#253)

### DIFF
--- a/crates/nexus/src/version.rs
+++ b/crates/nexus/src/version.rs
@@ -1,6 +1,31 @@
 use std::fmt;
 use std::num::NonZeroU64;
 
+/// A compile-checked [`Version`] literal.
+///
+/// `version!(3)` evaluates to a `Version` (not `Option<Version>`) at compile
+/// time. `version!(0)` is a **compile error**, not a runtime panic — the check
+/// runs in an inline `const {}` block, so there is zero runtime cost even in
+/// debug builds.
+///
+/// ```
+/// use nexus::{Version, version};
+/// assert_eq!(version!(3), Version::new(3).unwrap());
+/// ```
+#[macro_export]
+macro_rules! version {
+    ($n:expr) => {
+        const {
+            match $crate::Version::new($n) {
+                ::core::option::Option::Some(v) => v,
+                ::core::option::Option::None => {
+                    ::core::panic!("version literal must be non-zero")
+                }
+            }
+        }
+    };
+}
+
 /// A monotonically increasing event version number.
 ///
 /// Wraps `NonZeroU64` — event versions are always >= 1.

--- a/crates/nexus/src/version.rs
+++ b/crates/nexus/src/version.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use std::iter::FusedIterator;
 use std::num::NonZeroU64;
 
 /// A compile-checked [`Version`] literal.
@@ -80,7 +81,75 @@ impl Version {
             None => None,
         }
     }
+
+    /// `len` consecutive versions `start, start+1, …, start+len-1`.
+    ///
+    /// The whole run is validated up front, so iteration is infallible and
+    /// never silently truncates on overflow — a lazy infinite iterator
+    /// zipped against a batch could drop items; this cannot. Returns `None`
+    /// if the run would overflow past `u64::MAX`, consistent with
+    /// [`Version::new`]/[`Version::next`] returning `Option`. `len == 0`
+    /// yields an empty run.
+    #[must_use]
+    pub fn run(start: Self, len: usize) -> Option<VersionRun> {
+        let Some(last_index) = len.checked_sub(1) else {
+            return Some(VersionRun {
+                next: start,
+                remaining: 0,
+            });
+        };
+        let last_offset = u64::try_from(last_index).ok()?;
+        let last_raw = start.as_u64().checked_add(last_offset)?;
+        // last_raw >= start.as_u64() >= 1, so it is a valid Version; this
+        // only confirms it does not exceed u64::MAX bounds (it always does
+        // not, by construction), keeping the overflow check symmetric with
+        // `new`/`next`.
+        Self::new(last_raw)?;
+        Some(VersionRun {
+            next: start,
+            remaining: len,
+        })
+    }
 }
+
+/// Iterator over a checked run of consecutive [`Version`]s.
+///
+/// Constructed by [`Version::run`], which validates up front that the whole
+/// run fits — so iteration is infallible and never silently truncates on
+/// overflow (a lazy infinite iterator zipped against a batch could drop
+/// items; this cannot).
+#[derive(Debug, Clone)]
+pub struct VersionRun {
+    next: Version,
+    remaining: usize,
+}
+
+impl Iterator for VersionRun {
+    type Item = Version;
+
+    fn next(&mut self) -> Option<Version> {
+        let remaining = self.remaining.checked_sub(1)?;
+        let current = self.next;
+        self.remaining = remaining;
+        // Advance only while more remain. On the final item the successor
+        // could overflow past MAX, but `run` length-checked the range so we
+        // never need it — this guard prevents ever computing it.
+        if remaining > 0
+            && let Some(n) = self.next.next()
+        {
+            self.next = n;
+        }
+        Some(current)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.remaining, Some(self.remaining))
+    }
+}
+
+impl ExactSizeIterator for VersionRun {}
+
+impl FusedIterator for VersionRun {}
 
 impl fmt::Display for Version {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/crates/nexus/tests/compile_fail/version_literal/nonzero.rs
+++ b/crates/nexus/tests/compile_fail/version_literal/nonzero.rs
@@ -1,0 +1,4 @@
+fn main() {
+    let v = nexus::version!(3);
+    assert_eq!(v.as_u64(), 3);
+}

--- a/crates/nexus/tests/compile_fail/version_literal/zero.rs
+++ b/crates/nexus/tests/compile_fail/version_literal/zero.rs
@@ -1,0 +1,3 @@
+fn main() {
+    let _ = nexus::version!(0);
+}

--- a/crates/nexus/tests/compile_fail/version_literal/zero.stderr
+++ b/crates/nexus/tests/compile_fail/version_literal/zero.stderr
@@ -1,0 +1,15 @@
+error[E0080]: evaluation panicked: version literal must be non-zero
+ --> tests/compile_fail/version_literal/zero.rs:2:13
+  |
+2 |     let _ = nexus::version!(0);
+  |             ^^^^^^^^^^^^^^^^^^ evaluation of `main::{constant#0}` failed here
+  |
+  = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `nexus::version` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+note: erroneous constant encountered
+ --> tests/compile_fail/version_literal/zero.rs:2:13
+  |
+2 |     let _ = nexus::version!(0);
+  |             ^^^^^^^^^^^^^^^^^^
+  |
+  = note: this note originates in the macro `nexus::version` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/nexus/tests/compile_tests.rs
+++ b/crates/nexus/tests/compile_tests.rs
@@ -3,3 +3,20 @@ fn compile_fail_tests() {
     let t = trybuild::TestCases::new();
     t.compile_fail("tests/compile_fail/*.rs");
 }
+
+/// `version!(0)` fails via a `panic!` evaluated inside an inline `const {}`
+/// block. `cargo check` — which is what trybuild runs above, since that
+/// `TestCases` has no `pass` case — type-checks without fully evaluating an
+/// anonymous inline-const expression, so it does not observe the panic and
+/// the case would wrongly report "compiled successfully". Registering a
+/// `pass` case flips trybuild to `cargo build` (trybuild only picks `build`
+/// over `check` when at least one `pass` case is present), which does run
+/// codegen-time const evaluation and correctly fails. Kept in its own
+/// subdirectory (not matched by the `*.rs` glob above) and its own
+/// `TestCases` so the cheaper `check` mode above is unaffected.
+#[test]
+fn compile_fail_version_zero() {
+    let t = trybuild::TestCases::new();
+    t.pass("tests/compile_fail/version_literal/nonzero.rs");
+    t.compile_fail("tests/compile_fail/version_literal/zero.rs");
+}

--- a/crates/nexus/tests/kernel_tests/version_tests.rs
+++ b/crates/nexus/tests/kernel_tests/version_tests.rs
@@ -207,3 +207,33 @@ fn versioned_event_equality() {
     assert_ne!(a, c); // different version
     assert_ne!(a, d); // different event
 }
+
+// ---------------------------------------------------------------------------
+// Version::run
+// ---------------------------------------------------------------------------
+
+#[test]
+fn run_yields_exactly_len_consecutive_versions() {
+    let run = Version::run(version!(5), 3).expect("no overflow");
+    let got: Vec<u64> = run.map(Version::as_u64).collect();
+    assert_eq!(got, vec![5, 6, 7]);
+}
+
+#[test]
+fn run_len_zero_is_empty() {
+    let run = Version::run(version!(1), 0).expect("no overflow");
+    assert_eq!(run.count(), 0);
+}
+
+#[test]
+fn run_overflow_past_max_is_none() {
+    let max = Version::new(u64::MAX).unwrap();
+    assert!(Version::run(max, 2).is_none());
+    assert_eq!(Version::run(max, 1).map(Iterator::count), Some(1));
+}
+
+#[test]
+fn run_is_exact_size() {
+    let run = Version::run(version!(1), 4).unwrap();
+    assert_eq!(run.len(), 4);
+}

--- a/crates/nexus/tests/kernel_tests/version_tests.rs
+++ b/crates/nexus/tests/kernel_tests/version_tests.rs
@@ -1,4 +1,4 @@
-use nexus::Version;
+use nexus::{Version, version};
 
 // ---------------------------------------------------------------------------
 // Construction
@@ -176,6 +176,22 @@ fn versioned_event_clone() {
     let ve2 = ve.clone();
 
     assert_eq!(ve, ve2);
+}
+
+// ---------------------------------------------------------------------------
+// version! macro
+// ---------------------------------------------------------------------------
+
+#[test]
+fn version_macro_matches_new_unwrap() {
+    assert_eq!(version!(1), Version::new(1).unwrap());
+    assert_eq!(version!(3), Version::new(3).unwrap());
+    assert_eq!(version!(u64::MAX), Version::new(u64::MAX).unwrap());
+}
+
+#[test]
+fn version_macro_equals_initial_at_one() {
+    assert_eq!(version!(1), Version::INITIAL);
 }
 
 #[test]

--- a/docs/plans/2026-07-02-version-ergonomics-design.md
+++ b/docs/plans/2026-07-02-version-ergonomics-design.md
@@ -1,0 +1,127 @@
+# `version!` literal + checked version runs
+
+**Issue:** #253 — construct/advance `Version` with no `.unwrap()` on literals and no hand-rolled `base + i + 1` math.
+**Status:** design — research settled, build two small kernel additions.
+**Date:** 2026-07-02
+
+---
+
+## The two problems
+
+Every example pays one of these:
+
+```rust
+// 1. Literal: a known-nonzero constant, forced through Option → unwrap.
+Version::new(3).unwrap()
+Version::new(3).ok_or("v3 is nonzero")?
+
+// 2. Sequence: hand-assigning contiguous versions to a batch.
+let ver = Version::new(base + u64::try_from(i).unwrap() + 1).unwrap();   // per event, in a loop
+let new_version = Version::new(base + u64::try_from(decided.len()).unwrap()).unwrap();
+```
+
+Bucket 1 is everywhere (tests, asserts, `commit_persisted` calls). Bucket 2 lives only on the **manual-drive path** — examples calling `commit_persisted`/`replay` by hand for no-store event sourcing. The real `save`/`append` path already stamps contiguous versions internally (`nexus-store`'s `first_persisted_version` + `next()`), so a normal app never writes bucket-2 math. That scopes bucket 2 as a genuine but **narrow** API gap, not a universal tax.
+
+## Fix 1 — `version!(N)`: a compile-checked literal
+
+A declarative macro that evaluates at compile time and rejects `0` as a **compile error**, zero runtime cost even in debug. This is settled prior art — `nonzero_lit`, `nonzero_ext::nonzero!` ([nonzero_lit](https://docs.rs/nonzero_lit/latest/nonzero_lit/)) — built on stable inline `const {}` blocks (RFC 2920; stable since 1.79, we pin 1.95).
+
+```rust
+/// A compile-checked `Version` literal. `version!(3)` is `Version` (not
+/// `Option<Version>`), evaluated at compile time; `version!(0)` is a
+/// *compile error*, not a runtime panic. Zero runtime cost.
+#[macro_export]
+macro_rules! version {
+    ($n:expr) => {
+        const {
+            match $crate::Version::new($n) {
+                ::core::option::Option::Some(v) => v,
+                ::core::option::Option::None => ::core::panic!("version literal must be non-zero"),
+            }
+        }
+    };
+}
+```
+
+Why a `macro_rules!`, not a proc-macro or a const-generic `Version::lit::<3>()`:
+- **No proc-macro** — it's a one-liner over the existing `const fn new`; `nexus-macros` stays untouched. `no_std`-clean, IoT-friendly.
+- **A const-generic `lit::<N>()` doesn't force the check.** A `const fn` called in a *non-const* position runs at runtime, so `Version::lit::<0>()` would panic at runtime, not compile time. The `const {}` block is what guarantees compile-time rejection. The macro wraps that; a bare fn can't.
+- **`match`, not `.unwrap()`** — avoids any dependency on `const Option::unwrap` stability and gives a clear message.
+
+Call site: `version!(3)` replaces `Version::new(3).unwrap()` / `.ok_or(...)?` everywhere.
+
+## Fix 2 — `Version::run`: a checked contiguous run
+
+A length-checked iterator over consecutive versions. **Checked once, up front** — not a lazy infinite iterator, because a lazy one silently ends on overflow, and zipping it against a batch would drop events (a silent-truncation correctness bug, rule 2/3). Pre-validating the whole run makes the iterator infallible and the overflow explicit.
+
+```rust
+/// Iterator over `len` consecutive versions starting at `start`.
+/// Named (not RPIT) so it is a nameable return type and can carry the
+/// checked-run invariant. Infallible: the overflow check happened in `run`.
+pub struct VersionRun { /* next: Option<Version>, remaining: usize */ }
+
+impl Iterator for VersionRun {
+    type Item = Version;
+    fn next(&mut self) -> Option<Version> { /* yields start, start.next(), … len times */ }
+}
+impl ExactSizeIterator for VersionRun { /* remaining */ }
+
+impl Version {
+    /// `len` consecutive versions `start, start+1, …, start+len-1`.
+    /// `None` if the run would overflow past `u64::MAX` (consistent with
+    /// `new`/`next` returning `Option`). `len == 0` yields an empty run.
+    #[must_use]
+    pub const fn run(start: Version, len: usize) -> Option<VersionRun> { /* checked add up front */ }
+}
+```
+
+The `base + i + 1` loop collapses to a `zip`:
+
+```rust
+// before
+let base = account.version().map_or(0, |v| v.as_u64());
+for (i, event) in decided.iter().enumerate() {
+    let ver = Version::new(base + u64::try_from(i).unwrap() + 1).unwrap();
+    stream.push(VersionedEvent::new(ver, event.clone()));
+}
+let new_version = Version::new(base + u64::try_from(decided.len()).unwrap()).unwrap();
+account.commit_persisted(new_version, decided);
+
+// after
+let first = account.version().map_or(Version::INITIAL, |v| v.next().expect("version overflow"));
+let run = Version::run(first, decided.len()).expect("version overflow");
+let last = run.clone().last().unwrap_or(first);
+for (ver, event) in run.zip(decided.iter()) {
+    stream.push(VersionedEvent::new(ver, event.clone()));
+}
+account.commit_persisted(last, decided);
+```
+
+No cast, no `+ 1`, no per-event unwrap. The one remaining `first` line (INITIAL-or-`next`) is the honest "where does the run start" question, not arithmetic noise.
+
+> Open refinement for implementation: if every manual site computes `first` the same way, add `Version::run_after(current: Option<Version>, len)` folding the INITIAL/`next` step in. Decide from the actual call sites — don't add it speculatively.
+
+## Placement
+
+Both land in `crates/nexus/src/version.rs` (kernel — `Version` is kernel). `version!` is `#[macro_export]` at the crate root; re-export/confirm it's reachable as `nexus::version!`. `VersionRun` + `Version::run` are inherent. No new module, no proc-macro, no `nexus-store` change.
+
+## Scope — and where to stop
+
+- `version!(N)` literal macro.
+- `Version::run(start, len) -> Option<VersionRun>` + `VersionRun` iterator.
+- Migrate the example/test sites that hand-roll the math: `store-and-kernel`, `inmemory`, `closing-the-books`, `projection-tokio`, `fjall-end-to-end`.
+- **Not** in scope: touching the `save`/`append` internal stamping (already correct), or a `run_after` unless the call sites prove it earns its place.
+
+## Tests (rule 7 first)
+
+1. **Sequence/protocol:** `version!(1)`/`version!(u64::MAX)` equal their `Version::new(_).unwrap()` counterparts; `Version::run(v, 3)` yields exactly `[v, v+1, v+2]` in order; `run` then `commit_persisted` advances a root identically to the old loop.
+2. **Boundary/defensive:** `Version::run(near_max, 2)` where the run overflows → `None` (no panic, no silent short run); `Version::run(v, 0)` → empty run; `version!` at `1` and `u64::MAX` (min/max literals).
+3. **Compile-fail:** `version!(0)` must **fail to compile** — add a `trybuild` compile-fail case (the whole point is a compile error, so a runtime test can't prove it). Confirm `nexus` already has a `trybuild`/`compile_fail` harness; if not, this is the one place to add a minimal one.
+4. **Equivalence:** an example migrated to `run`/`version!` produces byte-identical persisted state / versions to the pre-migration loop.
+
+## What this does not do
+
+- No proc-macro; `nexus-macros` untouched.
+- No `Result` (stays `Option`, consistent with `new`/`next`).
+- No silent-truncating lazy iterator — overflow is surfaced up front.
+- No change to the store's internal version stamping.

--- a/docs/plans/2026-07-02-version-ergonomics-plan.md
+++ b/docs/plans/2026-07-02-version-ergonomics-plan.md
@@ -1,0 +1,267 @@
+# Version Ergonomics (`version!` + `Version::run`) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development or superpowers:executing-plans. Steps use `- [ ]` checkboxes.
+
+**Goal:** Kill `Version::new(n).unwrap()` on literals and `base + i + 1` sequence math (#253) via a compile-checked `version!(n)` macro and a checked `Version::run(start, len)` iterator.
+
+**Architecture:** Two additions to `crates/nexus/src/version.rs`: a `#[macro_export] macro_rules! version` built on a stable inline `const {}` block (compile-time nonzero check, zero runtime cost), and an inherent `Version::run(start, len) -> Option<VersionRun>` returning a named, length-checked `VersionRun: Iterator`. No proc-macro, no store change.
+
+**Design doc:** `docs/plans/2026-07-02-version-ergonomics-design.md`
+
+**Conventions:** run one test `nix develop -c cargo test -p nexus -- <name>`. Do NOT run `nix flake check` by hand — the pre-commit hook runs it (pass Bash `timeout: 600000` to `git commit`). `git add` new files before committing. All `use` at top. Strict clippy (pedantic/nursery denied). Toolchain is 1.95.0 (inline `const{}` and const `Option` are available).
+
+---
+
+## Task 1: `version!(N)` compile-checked literal macro
+
+**Files:** Modify `crates/nexus/src/version.rs`; verify export in `crates/nexus/src/lib.rs`.
+
+- [ ] **Step 1: Add the macro** near the top of `version.rs` (after the imports, before or after `struct Version` — a `#[macro_export]` macro is visible crate-wide regardless of position):
+
+```rust
+/// A compile-checked [`Version`] literal.
+///
+/// `version!(3)` evaluates to a `Version` (not `Option<Version>`) at compile
+/// time. `version!(0)` is a **compile error**, not a runtime panic — the check
+/// runs in an inline `const {}` block, so there is zero runtime cost even in
+/// debug builds.
+///
+/// ```
+/// use nexus::{version, Version};
+/// assert_eq!(version!(3), Version::new(3).unwrap());
+/// ```
+#[macro_export]
+macro_rules! version {
+    ($n:expr) => {
+        const {
+            match $crate::Version::new($n) {
+                ::core::option::Option::Some(v) => v,
+                ::core::option::Option::None => {
+                    ::core::panic!("version literal must be non-zero")
+                }
+            }
+        }
+    };
+}
+```
+
+- [ ] **Step 2: Confirm it's reachable as `nexus::version!`.** `#[macro_export]` puts it at the crate root automatically. Check `crates/nexus/src/lib.rs` — if the crate uses `pub use` grouping for macros or has `#![no_std]` concerns, ensure nothing shadows it. Run: `nix develop -c grep -n "macro_export\|pub use.*version\|no_std" crates/nexus/src/lib.rs crates/nexus/src/version.rs`.
+
+- [ ] **Step 3: Add unit tests** in `version.rs`'s test module:
+
+```rust
+#[test]
+fn version_macro_matches_new_unwrap() {
+    assert_eq!(version!(1), Version::new(1).unwrap());
+    assert_eq!(version!(3), Version::new(3).unwrap());
+    assert_eq!(version!(u64::MAX), Version::new(u64::MAX).unwrap());
+}
+
+#[test]
+fn version_macro_equals_initial_at_one() {
+    assert_eq!(version!(1), Version::INITIAL);
+}
+```
+(Import the macro in the test module if needed — `use crate::version;` or rely on `#[macro_export]` crate-root visibility; adjust to what compiles.)
+
+- [ ] **Step 4: Run tests.** `nix develop -c cargo test -p nexus -- version_macro` → expect PASS. `nix develop -c cargo clippy -p nexus --lib` → clean.
+
+- [ ] **Step 5: Commit** (Bash timeout 600000):
+```bash
+git add crates/nexus/src/version.rs crates/nexus/src/lib.rs
+git commit -m "feat(kernel): version! compile-checked Version literal (#253)"
+```
+
+---
+
+## Task 2: `Version::run` + `VersionRun` checked iterator
+
+**Files:** Modify `crates/nexus/src/version.rs`.
+
+- [ ] **Step 1: Write the failing test first** in the test module:
+
+```rust
+#[test]
+fn run_yields_exactly_len_consecutive_versions() {
+    let run = Version::run(version!(5), 3).expect("no overflow");
+    let got: Vec<u64> = run.map(Version::as_u64).collect();
+    assert_eq!(got, vec![5, 6, 7]);
+}
+
+#[test]
+fn run_len_zero_is_empty() {
+    let run = Version::run(version!(1), 0).expect("no overflow");
+    assert_eq!(run.count(), 0);
+}
+
+#[test]
+fn run_overflow_past_max_is_none() {
+    // start at MAX, asking for 2 versions overflows.
+    let max = Version::new(u64::MAX).unwrap();
+    assert!(Version::run(max, 2).is_none());
+    // exactly 1 at MAX is fine (just the start).
+    assert_eq!(Version::run(max, 1).map(|r| r.count()), Some(1));
+}
+
+#[test]
+fn run_is_exact_size() {
+    let run = Version::run(version!(1), 4).unwrap();
+    assert_eq!(run.len(), 4);
+}
+```
+
+- [ ] **Step 2: Run to confirm it fails.** `nix develop -c cargo test -p nexus -- run_` → FAIL (`Version::run` not found).
+
+- [ ] **Step 3: Implement `VersionRun` + `Version::run`:**
+
+```rust
+/// Iterator over a checked run of consecutive [`Version`]s.
+///
+/// Constructed by [`Version::run`], which validates up front that the whole
+/// run fits — so iteration is infallible and never silently truncates on
+/// overflow (a lazy infinite iterator zipped against a batch could drop
+/// items; this cannot).
+#[derive(Debug, Clone)]
+pub struct VersionRun {
+    next: Version,
+    remaining: usize,
+}
+
+impl Iterator for VersionRun {
+    type Item = Version;
+
+    fn next(&mut self) -> Option<Version> {
+        if self.remaining == 0 {
+            return None;
+        }
+        let current = self.next;
+        self.remaining -= 1;
+        // Only advance when more remain; on the last item `next()` might
+        // overflow past MAX, but we never use that successor (run was
+        // length-checked at construction), so guard it.
+        if self.remaining > 0 {
+            // SAFETY of unwrap avoided: run() guaranteed `remaining-1` more
+            // successors exist, so `next()` is Some here.
+            if let Some(n) = self.next.next() {
+                self.next = n;
+            }
+        }
+        Some(current)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.remaining, Some(self.remaining))
+    }
+}
+
+impl ExactSizeIterator for VersionRun {}
+impl core::iter::FusedIterator for VersionRun {}
+
+impl Version {
+    /// `len` consecutive versions `start, start+1, …, start+len-1`.
+    ///
+    /// Returns `None` if the run would overflow past `u64::MAX` (consistent
+    /// with [`Version::new`]/[`Version::next`] returning `Option`). `len == 0`
+    /// yields an empty run.
+    #[must_use]
+    pub fn run(start: Version, len: usize) -> Option<VersionRun> {
+        if len == 0 {
+            return Some(VersionRun { next: start, remaining: 0 });
+        }
+        // Last version is start + (len - 1). Check it fits.
+        let last_offset = u64::try_from(len - 1).ok()?;
+        let last_raw = start.as_u64().checked_add(last_offset)?;
+        // last_raw >= start.as_u64() >= 1, so it's a valid Version.
+        Version::new(last_raw)?;
+        Some(VersionRun { next: start, remaining: len })
+    }
+}
+```
+
+> Note: `run` is not `const fn` because `u64::try_from`/`checked_add` chains and struct construction are fine in a normal fn, and no caller needs it const. If a const need appears, revisit — don't force it now (YAGNI).
+
+- [ ] **Step 4: Run tests.** `nix develop -c cargo test -p nexus -- run_` → PASS (4 tests). `nix develop -c cargo clippy -p nexus --lib` → clean. Fix any nursery lint (e.g. `checked_add` is already rule-2-correct; no bare arithmetic — note `len - 1` is guarded by the `len == 0` early return above).
+
+- [ ] **Step 5: Commit** (Bash timeout 600000):
+```bash
+git add crates/nexus/src/version.rs
+git commit -m "feat(kernel): Version::run — checked contiguous version iterator (#253)"
+```
+
+---
+
+## Task 3: Compile-fail test — `version!(0)` must not compile
+
+**Files:** Create/extend a `trybuild` compile-fail harness for `nexus`.
+
+- [ ] **Step 1: Check for an existing harness.** Run: `nix develop -c bash -c 'ls crates/nexus/tests/ 2>/dev/null; grep -rn "trybuild" crates/nexus/Cargo.toml'`. `nexus-store` has `tests/compile_fail_tests.rs` + `tests/compile_fail/` — mirror that pattern. If `trybuild` isn't a `nexus` dev-dep, add it: `nix develop -c cargo add --dev trybuild -p nexus` (never hand-write the version).
+
+- [ ] **Step 2: Add the compile-fail case.** Create `crates/nexus/tests/compile_fail/version_zero.rs`:
+```rust
+fn main() {
+    let _ = nexus::version!(0);
+}
+```
+And the harness `crates/nexus/tests/compile_fail_tests.rs` (or extend the existing one):
+```rust
+#[test]
+fn compile_fail_cases() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/compile_fail/version_zero.rs");
+}
+```
+
+- [ ] **Step 3: Generate the expected stderr.** Run: `nix develop -c cargo test -p nexus --test compile_fail_tests` once; trybuild writes a `.stderr` on first run (or run with `TRYBUILD=overwrite`). Confirm the error mentions the non-zero panic / const-eval failure. Commit the `.stderr` alongside.
+
+- [ ] **Step 4: Verify it actually fails to compile** (the test PASSES because compilation FAILED as expected). Re-run: `nix develop -c cargo test -p nexus --test compile_fail_tests` → PASS.
+
+- [ ] **Step 5: Commit** (Bash timeout 600000):
+```bash
+git add crates/nexus/tests/compile_fail/ crates/nexus/tests/compile_fail_tests.rs crates/nexus/Cargo.toml Cargo.lock
+git commit -m "test(kernel): version!(0) is a compile error (#253)"
+```
+
+---
+
+## Task 4: Migrate the examples/tests off the hand-rolled math
+
+**Files:** `examples/inmemory/src/main.rs`, `examples/store-and-kernel/src/main.rs`, `examples/closing-the-books/src/main.rs`, `examples/projection-tokio/tests/loop_tests.rs`, `examples/fjall-end-to-end/src/lib.rs`.
+
+- [ ] **Step 1: Replace literal unwraps.** Across the listed files, replace `Version::new(N).unwrap()` and `Version::new(N).ok_or(...)?` (for **literal** `N`) with `version!(N)`. Add `version` (and keep `Version`) to each file's `nexus` import. Do NOT touch `Version::new(x)` where `x` is a runtime variable — that stays fallible.
+
+- [ ] **Step 2: Replace the sequence loops.** In `inmemory`, `store-and-kernel`, `closing-the-books`, and `projection-tokio` (the `base + u64::try_from(i).unwrap() + 1` sites), rewrite using `Version::run`:
+```rust
+let first = account.version().map_or(Version::INITIAL, |v| v.next().expect("version overflow"));
+let run = Version::run(first, decided.len()).expect("version overflow");
+let last = run.clone().last().unwrap_or(first);
+for (ver, event) in run.zip(decided.iter()) {
+    stream.push(VersionedEvent::new(ver, event.clone()));
+}
+account.commit_persisted(last, decided);
+```
+Adapt to each site's exact locals (some compute `base` as `u64`, some track `new_version` separately — the `run`/`last` pair replaces both). These are examples, so `.expect(...)` on the provably-unreachable overflow is acceptable (matches existing example style), but prefer surfacing over silent defaults.
+
+- [ ] **Step 3: Build + test each crate.** For each: `nix develop -c cargo test -p <crate>` (foreground, timeout 600000). Expect PASS — behavior is identical. Confirm `examples/inmemory`, `store-and-kernel`, `closing-the-books`, `projection-tokio`, `fjall-end-to-end` all green.
+
+- [ ] **Step 4: Clippy the examples.** `nix develop -c cargo clippy --all-targets` (the examples aren't covered by the `--lib` flake gate). Fix any lint in non-test code.
+
+- [ ] **Step 5: Commit** (Bash timeout 600000):
+```bash
+git add examples/
+git commit -m "refactor(examples): use version! and Version::run, delete manual version math (#253)"
+```
+
+---
+
+## Task 5: Final review + PR
+
+- [ ] **Step 1: Whole-branch review** — dispatch a reviewer over `git diff origin/main..HEAD`: check the macro is genuinely compile-time (const block), `run`'s overflow is checked not silent, `VersionRun::next` never panics, examples produce identical versions, no `Version::new(literal).unwrap()` survives (grep: `nix develop -c grep -rn "Version::new([0-9]" examples/ crates/` should be empty for literals).
+- [ ] **Step 2: Open PR** (`joeldsouzax` account) titled `feat(kernel): version! literal + Version::run (#253)`, body summarizing both additions + the compile-fail proof, `Closes #253`. Squash-merge after green.
+
+---
+
+## Self-Review Notes (author checklist — done)
+- **Coverage:** `version!` macro (T1) ✓, compile-fail proof (T3) ✓, `Version::run`/`VersionRun` checked (T2) ✓, examples migrated (T4) ✓, both buckets from the design addressed ✓.
+- **Type consistency:** `version!`, `Version::run(start, len) -> Option<VersionRun>`, `VersionRun: Iterator + ExactSizeIterator + FusedIterator` used consistently T1-T4.
+- **Rule adherence:** `run` uses `checked_add`/`try_from` (rule 2, no bare arithmetic); `len - 1` guarded by the `len == 0` early return; overflow → `None` not silent truncation (rule 3); `Option` not `Result` (API consistency); `#[must_use]` on `run`.
+- **Watch-items:** (1) confirm `nexus` has/needs a `trybuild` dev-dep (T3 S1); (2) `VersionRun::next` last-item overflow guard — the `if self.remaining > 0` prevents calling `.next()` past the checked range; (3) macro visibility as `nexus::version!` (T1 S2).

--- a/examples/closing-the-books/src/main.rs
+++ b/examples/closing-the-books/src/main.rs
@@ -34,13 +34,15 @@ fn record<A: Aggregate, const N: usize>(
 ) where
     EventOf<A>: Clone,
 {
-    let base = root.version().map_or(0, |v| v.as_u64());
-    for (i, event) in decided.iter().enumerate() {
-        let version = Version::new(base + u64::try_from(i).unwrap() + 1).unwrap();
+    let first = root
+        .version()
+        .map_or(Version::INITIAL, |v| v.next().expect("version overflow"));
+    let run = Version::run(first, decided.len()).expect("version overflow");
+    let last = run.clone().last().unwrap_or(first);
+    for (version, event) in run.zip(decided.iter()) {
         history.push(VersionedEvent::new(version, event.clone()));
     }
-    let new_version = Version::new(base + u64::try_from(decided.len()).unwrap()).unwrap();
-    root.commit_persisted(new_version, decided);
+    root.commit_persisted(last, decided);
 }
 
 /// Rebuild current state from one stream by replaying every event, returning

--- a/examples/fjall-end-to-end/src/lib.rs
+++ b/examples/fjall-end-to-end/src/lib.rs
@@ -79,7 +79,7 @@ use std::time::Duration;
 
 use futures::StreamExt;
 use futures::TryStreamExt;
-use nexus::Version;
+use nexus::{Version, version};
 use nexus_fjall::{AllIndex, FjallStore};
 use nexus_store::cbor::{ChunkWriter, decode_chunk};
 use nexus_store::export::{EventExporter, StreamLister};
@@ -238,7 +238,7 @@ pub async fn run_subscription(path: &Path) -> Result<SubscriptionOutcome, BoxErr
         .map_err(|e| format!("writer task panicked: {e}"))?;
 
     // Strict-after resume: a fresh cursor from Some(v3) must begin at v4.
-    let v3 = Version::new(3).ok_or("v3 is nonzero")?;
+    let v3 = version!(3);
     let resume = subscription.subscribe(&id, Some(v3))?;
     tokio::pin!(resume);
     let first = timeout_next(&mut resume, "resume").await?;

--- a/examples/inmemory/src/main.rs
+++ b/examples/inmemory/src/main.rs
@@ -222,13 +222,15 @@ impl InMemoryStore {
     /// directly — the aggregate marker (`BankAccount`) carries no state.
     fn save(&mut self, account: &mut AggregateRoot<BankAccount>, decided: &Events<AccountEvent>) {
         let stream = self.streams.entry(account.id().clone()).or_default();
-        let base = account.version().map_or(0, |v| v.as_u64());
-        for (i, event) in decided.iter().enumerate() {
-            let ver = Version::new(base + u64::try_from(i).unwrap() + 1).unwrap();
+        let first = account
+            .version()
+            .map_or(Version::INITIAL, |v| v.next().expect("version overflow"));
+        let run = Version::run(first, decided.len()).expect("version overflow");
+        let last = run.clone().last().unwrap_or(first);
+        for (ver, event) in run.zip(decided.iter()) {
             stream.push(VersionedEvent::new(ver, event.clone()));
         }
-        let new_version = Version::new(base + u64::try_from(decided.len()).unwrap()).unwrap();
-        account.commit_persisted(new_version, decided);
+        account.commit_persisted(last, decided);
     }
 
     fn load(&self, id: &AccountId) -> Option<AggregateRoot<BankAccount>> {

--- a/examples/projection-tokio/tests/loop_tests.rs
+++ b/examples/projection-tokio/tests/loop_tests.rs
@@ -36,7 +36,7 @@ use std::fmt;
 use std::num::{NonZeroU32, NonZeroU64};
 
 use futures::StreamExt;
-use nexus::{DomainEvent, Message, Version};
+use nexus::{DomainEvent, Message, Version, version};
 use nexus_example_projection_tokio::run_projection;
 use nexus_store::testing::InMemoryStore;
 use nexus_store::{
@@ -187,12 +187,13 @@ async fn append_events(store: &Store<InMemoryStore>, stream_id: &TestId, events:
         stream.count().await
     };
     let base_version = u64::try_from(current_len).unwrap();
+    let first = Version::new(base_version)
+        .map_or(Version::INITIAL, |v| v.next().expect("version overflow"));
+    let run = Version::run(first, events.len()).expect("version overflow");
 
-    let envelopes: Vec<_> = events
-        .iter()
-        .enumerate()
-        .map(|(i, event)| {
-            let ver = Version::new(base_version + u64::try_from(i).unwrap() + 1).unwrap();
+    let envelopes: Vec<_> = run
+        .zip(events.iter())
+        .map(|(ver, event)| {
             let payload = codec.encode(event).unwrap();
             pending_envelope(ver)
                 .event_type(event.name())
@@ -257,7 +258,7 @@ async fn runner_processes_events_and_checkpoints() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(position, Version::new(3).unwrap());
+    assert_eq!(position, version!(3));
     assert_eq!(
         state,
         CountState {
@@ -330,7 +331,7 @@ async fn runner_resumes_from_checkpoint() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(position, Version::new(5).unwrap());
+    assert_eq!(position, version!(5));
     assert_eq!(
         state,
         CountState {
@@ -383,7 +384,7 @@ async fn runner_trigger_controls_checkpoint_frequency() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(position, Version::new(5).unwrap());
+    assert_eq!(position, version!(5));
     assert_eq!(
         state,
         CountState {
@@ -469,7 +470,7 @@ async fn runner_resumes_normally_after_rebuild_completes() {
             total: 60
         }
     );
-    assert_eq!(position, Version::new(3).unwrap());
+    assert_eq!(position, version!(3));
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -549,7 +550,7 @@ async fn runner_rebuild_is_idempotent_after_crash_before_trigger() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(position, Version::new(3).unwrap());
+    assert_eq!(position, version!(3));
 
     // Phase 2: start with schema v2 but immediate shutdown.
     // tokio::select! is non-deterministic — the runner may process 0..N
@@ -651,7 +652,7 @@ async fn runner_graceful_shutdown_flushes_dirty_state() {
             total: 30
         }
     );
-    assert_eq!(position, Version::new(2).unwrap());
+    assert_eq!(position, version!(2));
 }
 
 #[tokio::test]
@@ -665,7 +666,7 @@ async fn runner_stale_state_falls_back_to_initial() {
         .commit(
             &stream_id,
             NonZeroU32::MIN,
-            Version::new(5).unwrap(),
+            version!(5),
             &CountState {
                 count: 99,
                 total: 999,
@@ -816,7 +817,7 @@ async fn runner_returns_event_codec_error_on_bad_payload() {
     let stream_id = TestId("stream-1".into());
 
     // Append a raw event with garbage payload
-    let bad_envelope = pending_envelope(Version::new(1).unwrap())
+    let bad_envelope = pending_envelope(version!(1))
         .event_type("Added")
         .payload(vec![0xFF]) // invalid: too short
         .expect("valid payload")
@@ -900,7 +901,7 @@ async fn runner_catches_up_and_processes_all_existing_events() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(position, Version::new(5).unwrap());
+    assert_eq!(position, version!(5));
     assert_eq!(
         state,
         CountState {
@@ -951,7 +952,7 @@ async fn runner_resumes_from_checkpoint_on_second_run() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(cp1, Version::new(1).unwrap());
+    assert_eq!(cp1, version!(1));
     assert_eq!(
         state1,
         CountState {
@@ -984,7 +985,7 @@ async fn runner_resumes_from_checkpoint_on_second_run() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(cp2, Version::new(2).unwrap());
+    assert_eq!(cp2, version!(2));
     // count:2, total:15 — not count:1/total:5 (fresh) or count:2/total:20 (double-fold)
     assert_eq!(
         state2,
@@ -1051,7 +1052,7 @@ async fn schema_bump_resolves_to_fresh() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(pos2, Version::new(1).unwrap());
+    assert_eq!(pos2, version!(1));
     assert_eq!(
         state2,
         CountState {

--- a/examples/store-and-kernel/src/main.rs
+++ b/examples/store-and-kernel/src/main.rs
@@ -219,11 +219,11 @@ fn encode_decided(
     decided: &Events<AccountEvent>,
     base_version: u64,
 ) -> Vec<nexus_store::envelope::PendingEnvelope> {
-    decided
-        .iter()
-        .enumerate()
-        .map(|(i, event)| {
-            let ver = Version::new(base_version + u64::try_from(i).unwrap() + 1).unwrap();
+    let first = Version::new(base_version)
+        .map_or(Version::INITIAL, |v| v.next().expect("version overflow"));
+    let run = Version::run(first, decided.len()).expect("version overflow");
+    run.zip(decided.iter())
+        .map(|(ver, event)| {
             let payload = codec.encode(event).expect("encode should succeed");
             pending_envelope(ver)
                 .event_type(event.name())
@@ -276,17 +276,17 @@ async fn main() {
             owner: "Alice Smith".to_owned(),
         })
         .expect("open should succeed");
-    account.commit_persisted(Version::new(1).unwrap(), &decided);
+    account.commit_persisted(version!(1), &decided);
 
     let decided = account
         .handle(Deposit { amount: 1000 })
         .expect("deposit should succeed");
-    account.commit_persisted(Version::new(2).unwrap(), &decided);
+    account.commit_persisted(version!(2), &decided);
 
     let decided = account
         .handle(Deposit { amount: 500 })
         .expect("deposit should succeed");
-    account.commit_persisted(Version::new(3).unwrap(), &decided);
+    account.commit_persisted(version!(3), &decided);
 
     println!(
         "State: owner={}, balance={}, version={:?}",
@@ -310,12 +310,12 @@ async fn main() {
         })
         .expect("open");
     let envelopes = encode_decided(&codec, &decided, 0);
-    fresh.commit_persisted(Version::new(1).unwrap(), &decided);
+    fresh.commit_persisted(version!(1), &decided);
 
     let decided = fresh.handle(Deposit { amount: 1000 }).expect("deposit");
     let mut more = encode_decided(&codec, &decided, 1);
     envelopes.len(); // keep envelopes alive
-    fresh.commit_persisted(Version::new(2).unwrap(), &decided);
+    fresh.commit_persisted(version!(2), &decided);
 
     let decided = fresh.handle(Deposit { amount: 500 }).expect("deposit");
     let mut even_more = encode_decided(&codec, &decided, 2);
@@ -377,7 +377,8 @@ async fn main() {
         .await
         .expect("append should succeed");
 
-    let new_ver = Version::new(base + 1).unwrap();
+    let new_ver =
+        expected_version.map_or(Version::INITIAL, |v| v.next().expect("version overflow"));
     account.commit_persisted(new_ver, &decided);
 
     println!(

--- a/examples/store-inmemory/src/main.rs
+++ b/examples/store-inmemory/src/main.rs
@@ -24,7 +24,7 @@
 )]
 
 use futures::{StreamExt, TryStreamExt};
-use nexus::Version;
+use nexus::{Version, version};
 use nexus_store::Store;
 use nexus_store::store::RawEventStore;
 use nexus_store::testing::InMemoryStore;
@@ -160,7 +160,7 @@ fn rename_upcast(morsel: EventMorsel<'_>) -> Result<EventMorsel<'_>, std::conver
     let upgraded = json.replace("TaskCreated", "TodoCreated");
     Ok(EventMorsel::new(
         "TodoCreated",
-        Version::new(2).expect("2 is non-zero"),
+        version!(2),
         upgraded.into_bytes(),
     ))
 }
@@ -216,9 +216,9 @@ async fn main() {
     // --- Step 3: Build PendingEnvelopes ---
     println!("Step 3: Build PendingEnvelopes (typestate builder)");
     let mut envelopes: Vec<nexus_store::envelope::PendingEnvelope> = Vec::new();
-    for (i, (payload, event_type)) in encoded.iter().enumerate() {
-        let version_num = u64::try_from(i + 1).expect("version should fit in u64");
-        let envelope = pending_envelope(Version::new(version_num).expect("version > 0"))
+    let versions = Version::run(Version::INITIAL, encoded.len()).expect("version overflow");
+    for (version, (payload, event_type)) in versions.zip(encoded.iter()) {
+        let envelope = pending_envelope(version)
             .event_type(event_type)
             .payload(payload.clone())
             .expect("valid payload")
@@ -263,7 +263,7 @@ async fn main() {
         let old_json = legacy_str.replace("TodoCreated", "TaskCreated");
         println!("  Raw JSON (old schema): {old_json}");
 
-        let legacy_envelope = pending_envelope(Version::new(4).expect("version > 0"))
+        let legacy_envelope = pending_envelope(version!(4))
             .event_type("TaskCreated")
             .payload(old_json.into_bytes())
             .expect("valid payload")
@@ -272,7 +272,7 @@ async fn main() {
         store
             .append(
                 &StreamKey::from_slice(stream_id.as_ref()),
-                Version::new(3),
+                Some(version!(3)),
                 &[legacy_envelope],
             )
             .await


### PR DESCRIPTION
Closes #253.

## What

Two small kernel additions that delete hand-rolled `Version` construction and sequencing from every example:

- **`version!(N)`** — a compile-checked `Version` literal. `version!(3)` is a `Version` (not `Option`), evaluated in an inline `const {}` block, so `version!(0)` is a **compile error**, not a runtime panic, at zero runtime cost. Replaces `Version::new(3).unwrap()` / `.ok_or(...)?`.
- **`Version::run(start, len) -> Option<VersionRun>`** — an iterator over `len` consecutive versions, overflow-checked **once up front** so iteration is infallible and never silently truncates (a lazy infinite iterator zipped against a batch could drop events; this cannot). Replaces `base + u64::try_from(i).unwrap() + 1` sequence math.

## Why this shape

Research card — cited prior art: `version!` follows the established `nonzero_lit` / `nonzero_ext::nonzero!` pattern on stable inline `const {}` (RFC 2920). The sequence math turned out to be a **narrow API gap** — only the manual-drive path (no-store event sourcing in examples) writes it; the real `save`/`append` path already stamps versions internally. So `Version::run` is small by design. Full write-up: `docs/plans/2026-07-02-version-ergonomics-design.md`.

## Design points

- No proc-macro (`nexus-macros` untouched); plain `macro_rules!`, `no_std`-clean.
- `Option` return (not `Result`), consistent with `Version::new`/`next`.
- Fully checked arithmetic (`checked_add`/`checked_sub`/`try_from`) — rule 2; overflow → `None`, never silent truncation.
- `version!(0)` compile-failure is **proven** by a trybuild case paired with a `pass` case (trybuild runs `cargo check` — which skips const-eval — unless a pass case forces `cargo build`; verified the guard actually fails when the `const {}` wrapper is removed).

## Test Plan

- [x] `version!` equals `Version::new(_).unwrap()` at 1 / u64::MAX / INITIAL
- [x] `Version::run` yields exactly `[start..start+len]`; `len==0` empty; overflow past MAX → `None`; `ExactSizeIterator`
- [x] `version!(0)` fails to compile (trybuild, regression-checked)
- [x] All 6 examples migrated; output version numbers unchanged; acceptance grep for literal `Version::new(N)` in examples is empty
- [x] Full `nix flake check` green on every commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)