### PR TITLE
feat(store)!: envelope builder ergonomics — one fallible terminal + .event() (#254)

### DIFF
--- a/crates/nexus-fjall/benches/fjall_benchmarks.rs
+++ b/crates/nexus-fjall/benches/fjall_benchmarks.rs
@@ -31,8 +31,8 @@ fn make_envelope(version: u64, payload: &[u8]) -> nexus_store::PendingEnvelope {
     pending_envelope(Version::new(version).unwrap())
         .event_type("BenchEvent")
         .payload(payload.to_vec())
-        .expect("valid payload")
         .build()
+        .expect("valid envelope")
 }
 
 fn make_envelopes(count: u64, payload: &[u8]) -> Vec<nexus_store::PendingEnvelope> {

--- a/crates/nexus-fjall/src/plan.rs
+++ b/crates/nexus-fjall/src/plan.rs
@@ -155,8 +155,8 @@ mod tests {
         pending_envelope(Version::new(version).unwrap())
             .event_type("E")
             .payload(b"p".as_slice())
-            .unwrap()
             .build()
+            .unwrap()
     }
 
     // 1. Sequence/protocol — happy paths ------------------------------------

--- a/crates/nexus-fjall/src/scan.rs
+++ b/crates/nexus-fjall/src/scan.rs
@@ -280,8 +280,8 @@ mod tests {
             let env = pending_envelope(Version::new(v).unwrap())
                 .event_type("E")
                 .payload(format!("v{v}").into_bytes())
-                .unwrap()
-                .build();
+                .build()
+                .unwrap();
             store.append(id, Version::new(v - 1), &[env]).await.unwrap();
         }
     }

--- a/crates/nexus-fjall/src/store.rs
+++ b/crates/nexus-fjall/src/store.rs
@@ -573,8 +573,8 @@ pub mod read_test_helpers {
             let env = pending_envelope(Version::new(v).unwrap())
                 .event_type("E")
                 .payload(b"payload".to_vec())
-                .unwrap()
-                .build();
+                .build()
+                .unwrap();
             store.append(id, Version::new(v - 1), &[env]).await.unwrap();
         }
     }
@@ -599,8 +599,8 @@ mod tests {
         pending_envelope(Version::new(version).expect("test version must be > 0"))
             .event_type(event_type)
             .payload(payload.to_vec())
-            .expect("valid payload")
             .build()
+            .expect("valid envelope")
     }
 
     fn temp_store() -> (FjallStore, tempfile::TempDir) {
@@ -724,8 +724,8 @@ mod tests {
         let env = pending_envelope(Version::new(1).unwrap())
             .event_type("Created")
             .payload(b"x".to_vec())
-            .unwrap()
-            .build();
+            .build()
+            .unwrap();
         store.append(&id, None, &[env]).await.unwrap();
 
         // The index holds exactly one row, keyed by [global_seq=1][version=1].
@@ -889,8 +889,8 @@ mod tests {
             pending_envelope(Version::new(v).unwrap())
                 .event_type("E")
                 .payload(p.to_vec())
-                .unwrap()
                 .build()
+                .unwrap()
         };
         store.append(&a, None, &[mk(1, b"a1")]).await.unwrap();
         store.append(&b, None, &[mk(1, b"b1")]).await.unwrap();
@@ -929,8 +929,8 @@ mod tests {
             pending_envelope(Version::new(v).unwrap())
                 .event_type("E")
                 .payload(vec![v as u8])
-                .unwrap()
                 .build()
+                .unwrap()
         };
         store.append(&a, None, &[mk(1)]).await.unwrap();
         store
@@ -1164,8 +1164,8 @@ mod tests {
                 let env = nexus_store::envelope::pending_envelope(Version::new(v).unwrap())
                     .event_type("E")
                     .payload(vec![v as u8])
-                    .unwrap()
-                    .build();
+                    .build()
+                    .unwrap();
                 writer
                     .append(&wid, Version::new(v - 1), &[env])
                     .await
@@ -1213,8 +1213,8 @@ mod tests {
             let env = pending_envelope(Version::new(v).unwrap())
                 .event_type("Reading")
                 .payload(b"p".to_vec())
-                .unwrap()
-                .build();
+                .build()
+                .unwrap();
             store
                 .append(&id, Version::new(v - 1), &[env])
                 .await
@@ -1254,8 +1254,8 @@ mod tests {
         let env = pending_envelope(Version::new(1).unwrap())
             .event_type("E")
             .payload(b"p".to_vec())
-            .unwrap()
-            .build();
+            .build()
+            .unwrap();
         store.append(&id, None, &[env]).await.unwrap();
         // Default (Denormalized) writes the $all index and read_all works.
         assert_eq!(store.partitions.events_global().inner().iter().count(), 1);
@@ -1289,8 +1289,8 @@ mod atomic_append_tests {
         pending_envelope(Version::new(version).unwrap())
             .event_type("E")
             .payload(payload.to_vec())
-            .unwrap()
             .build()
+            .unwrap()
     }
 
     fn planned(target: &str, expected: Option<u64>, versions: &[u64]) -> PlannedAppend {

--- a/crates/nexus-fjall/tests/export_import_tests.rs
+++ b/crates/nexus-fjall/tests/export_import_tests.rs
@@ -59,12 +59,12 @@ async fn append_one(
 ) {
     let builder = pending_envelope(Version::new(version).expect("nonzero"))
         .event_type(event_type)
-        .payload(payload.to_vec())
-        .expect("valid payload");
+        .payload(payload.to_vec());
     let env = match metadata {
-        Some(m) => builder.with_metadata(m.to_vec()).expect("valid metadata"),
+        Some(m) => builder.metadata(m.to_vec()).build(),
         None => builder.build(),
-    };
+    }
+    .expect("valid envelope");
     let expected = Version::new(version - 1);
     store.append(id, expected, &[env]).await.expect("append");
 }

--- a/crates/nexus-fjall/tests/fjall_conformance.rs
+++ b/crates/nexus-fjall/tests/fjall_conformance.rs
@@ -75,16 +75,16 @@ async fn fjall_event_stream_conforms() {
                     let event_type: &'static str = Box::leak(r.event_type.into_boxed_str());
                     let with_payload = pending_envelope(Version::new(r.version).unwrap())
                         .event_type(event_type)
-                        .payload(r.payload)
-                        .expect("valid payload");
+                        .payload(r.payload);
                     if r.schema_version == 1 {
-                        with_payload.build()
+                        with_payload.build().expect("valid envelope")
                     } else {
                         with_payload
                             .schema_version(SchemaVersion::new(
                                 NonZeroU32::new(r.schema_version).unwrap(),
                             ))
                             .build()
+                            .expect("valid envelope")
                     }
                 })
                 .collect();

--- a/crates/nexus-fjall/tests/metadata_roundtrip_tests.rs
+++ b/crates/nexus-fjall/tests/metadata_roundtrip_tests.rs
@@ -42,9 +42,9 @@ async fn metadata_roundtrips_across_multiple_events() {
             pending_envelope(Version::new(i).unwrap())
                 .event_type("Test")
                 .payload(Bytes::from(format!("payload-{i}")))
-                .expect("valid payload")
-                .with_metadata(Bytes::from(format!("meta-{i}")))
-                .expect("valid metadata")
+                .metadata(Bytes::from(format!("meta-{i}")))
+                .build()
+                .expect("valid envelope")
         })
         .collect();
 
@@ -85,9 +85,9 @@ async fn metadata_survives_store_reopen() {
         let env = pending_envelope(Version::INITIAL)
             .event_type("X")
             .payload(Bytes::from_static(b"payload"))
-            .expect("valid payload")
-            .with_metadata(Bytes::from_static(b"important-meta"))
-            .expect("valid metadata");
+            .metadata(Bytes::from_static(b"important-meta"))
+            .build()
+            .expect("valid envelope");
         store
             .append(&sk("reopen-stream"), None, &[env])
             .await
@@ -119,8 +119,8 @@ async fn none_metadata_roundtrips_as_none() {
     let pending = pending_envelope(Version::INITIAL)
         .event_type("X")
         .payload(Bytes::from_static(b"payload"))
-        .expect("valid payload")
-        .build(); // no metadata
+        .build()
+        .expect("valid envelope"); // no metadata
     store.append(&id, None, &[pending]).await.unwrap();
 
     let mut cursor = store.read_stream(&id, Version::INITIAL).await.unwrap();

--- a/crates/nexus-fjall/tests/property_tests.rs
+++ b/crates/nexus-fjall/tests/property_tests.rs
@@ -77,8 +77,8 @@ fn make_envelope(version: u64, event_type: &'static str, payload: &[u8]) -> Pend
     pending_envelope(Version::new(version).unwrap())
         .event_type(event_type)
         .payload(payload.to_vec())
-        .expect("valid payload")
         .build()
+        .expect("valid envelope")
 }
 
 fn make_envelope_with_schema(
@@ -91,9 +91,9 @@ fn make_envelope_with_schema(
     pending_envelope(Version::new(version).unwrap())
         .event_type(event_type)
         .payload(payload.to_vec())
-        .expect("valid payload")
         .schema_version(SchemaVersion::new(sv))
         .build()
+        .expect("valid envelope")
 }
 
 fn build_envelopes(payloads: &[Vec<u8>]) -> Vec<PendingEnvelope> {
@@ -104,8 +104,8 @@ fn build_envelopes(payloads: &[Vec<u8>]) -> Vec<PendingEnvelope> {
             pending_envelope(Version::new(u64::try_from(i).unwrap() + 1).unwrap())
                 .event_type(leak("TestEvent"))
                 .payload(p.clone())
-                .expect("valid payload")
                 .build()
+                .expect("valid envelope")
         })
         .collect()
 }
@@ -118,8 +118,8 @@ fn build_envelopes_from(start_version: u64, payloads: &[Vec<u8>]) -> Vec<Pending
             pending_envelope(Version::new(start_version + u64::try_from(i).unwrap()).unwrap())
                 .event_type(leak("TestEvent"))
                 .payload(p.clone())
-                .expect("valid payload")
                 .build()
+                .expect("valid envelope")
         })
         .collect()
 }
@@ -999,9 +999,9 @@ async fn attack_schema_version_zero_clamped_by_builder() {
     let env = pending_envelope(Version::INITIAL)
         .event_type("BadSchema")
         .payload(b"data".to_vec())
-        .expect("valid payload")
         .schema_version(SchemaVersion::INITIAL) // Minimum valid schema version
-        .build();
+        .build()
+        .expect("valid envelope");
 
     // schema_version should be 1
     assert_eq!(

--- a/crates/nexus-fjall/tests/resilience_tests.rs
+++ b/crates/nexus-fjall/tests/resilience_tests.rs
@@ -65,8 +65,8 @@ fn make_envelope(version: u64, event_type: &'static str, payload: &[u8]) -> Pend
     pending_envelope(Version::new(version).unwrap())
         .event_type(event_type)
         .payload(payload.to_vec())
-        .expect("valid payload")
         .build()
+        .expect("valid envelope")
 }
 
 fn temp_store() -> (FjallStore, tempfile::TempDir) {
@@ -313,8 +313,8 @@ proptest! {
                                 pending_envelope(Version::new(ver).unwrap())
                                     .event_type(leak(&format!("Tick_{stream}_{}", existing + i)))
                                     .payload(payload.clone())
-                                    .expect("valid payload")
-                                    .build(),
+                                    .build()
+                                    .expect("valid envelope"),
                             );
                         }
 
@@ -572,8 +572,8 @@ async fn attack_concurrent_append_storm_50_tasks() {
             let env = pending_envelope(Version::INITIAL)
                 .event_type(leak(&format!("Created_{i}")))
                 .payload(i.to_le_bytes().to_vec())
-                .expect("valid payload")
-                .build();
+                .build()
+                .expect("valid envelope");
             store_clone.append(&sid_val, None, &[env]).await
         });
         handles.push(handle);
@@ -624,8 +624,8 @@ async fn attack_concurrent_append_same_stream_conflict() {
             let env = pending_envelope(Version::INITIAL)
                 .event_type(leak(&format!("Contested_{i}")))
                 .payload(i.to_le_bytes().to_vec())
-                .expect("valid payload")
-                .build();
+                .build()
+                .expect("valid envelope");
             store_clone.append(&sid_val, None, &[env]).await
         });
         handles.push(handle);

--- a/crates/nexus-fjall/tests/snapshot_tests.rs
+++ b/crates/nexus-fjall/tests/snapshot_tests.rs
@@ -40,8 +40,8 @@ async fn setup_stream(store: &FjallStore, id: &StreamKey, event_count: u64) {
             pending_envelope(Version::new(i).unwrap())
                 .event_type("TestEvent")
                 .payload(format!("payload-{i}").into_bytes())
-                .expect("valid payload")
-                .build(),
+                .build()
+                .expect("valid envelope"),
         );
     }
     store.append(id, None, &envs).await.unwrap();

--- a/crates/nexus-fjall/tests/state_machine_tests.rs
+++ b/crates/nexus-fjall/tests/state_machine_tests.rs
@@ -214,8 +214,8 @@ fn make_envelope(version: u64, event_type: &'static str, payload: &[u8]) -> Pend
     pending_envelope(Version::new(version).unwrap())
         .event_type(event_type)
         .payload(payload.to_vec())
-        .expect("valid payload")
         .build()
+        .expect("valid envelope")
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/nexus-fjall/tests/subscription_tests.rs
+++ b/crates/nexus-fjall/tests/subscription_tests.rs
@@ -30,8 +30,8 @@ fn make_envelope(version: u64, event_type: &'static str, payload: &[u8]) -> Pend
     pending_envelope(Version::new(version).expect("test version must be > 0"))
         .event_type(event_type)
         .payload(payload.to_vec())
-        .expect("valid payload")
         .build()
+        .expect("valid envelope")
 }
 
 fn temp_store() -> (FjallStore, tempfile::TempDir) {

--- a/crates/nexus-postgres/src/store.rs
+++ b/crates/nexus-postgres/src/store.rs
@@ -607,8 +607,8 @@ mod tests {
         pending_envelope(v)
             .event_type("TestEvent")
             .payload(b"{}".as_slice())
-            .unwrap()
             .build()
+            .unwrap()
     }
 
     /// Build a `PendingEnvelope` with an explicit `schema_version`.
@@ -620,9 +620,9 @@ mod tests {
         pending_envelope(v)
             .event_type("TestEvent")
             .payload(b"{}".as_slice())
-            .unwrap()
             .schema_version(schema)
             .build()
+            .unwrap()
     }
 
     // 1. Sequence/protocol — happy paths

--- a/crates/nexus-postgres/tests/all_noskip_tests.rs
+++ b/crates/nexus-postgres/tests/all_noskip_tests.rs
@@ -294,8 +294,8 @@ async fn all_noskip_via_store_api_ordering() {
         pending_envelope(Version::new(v).unwrap())
             .event_type(et)
             .payload(format!("{et}{v}").into_bytes())
-            .expect("valid")
             .build()
+            .expect("valid")
     };
 
     store

--- a/crates/nexus-postgres/tests/conformance_tests.rs
+++ b/crates/nexus-postgres/tests/conformance_tests.rs
@@ -66,16 +66,16 @@ fn row_to_envelope(r: &ConformanceRow) -> PendingEnvelope {
     let event_type: &'static str = Box::leak(r.event_type.clone().into_boxed_str());
     let with_payload = pending_envelope(version)
         .event_type(event_type)
-        .payload(r.payload.clone())
-        .expect("valid payload");
+        .payload(r.payload.clone());
     if r.schema_version == 1 {
-        with_payload.build()
+        with_payload.build().expect("valid envelope")
     } else {
         with_payload
             .schema_version(SchemaVersion::new(
                 NonZeroU32::new(r.schema_version).expect("schema_version > 0"),
             ))
             .build()
+            .expect("valid envelope")
     }
 }
 
@@ -164,8 +164,8 @@ async fn sequence_append_read_versions_123() {
         pending_envelope(Version::new(v).unwrap())
             .event_type("SeqEvent")
             .payload(payload)
-            .expect("valid payload")
             .build()
+            .expect("valid envelope")
     };
 
     let envs = [
@@ -208,8 +208,8 @@ async fn sequence_stale_expected_version_conflict() {
     let env1 = pending_envelope(Version::new(1).unwrap())
         .event_type("E")
         .payload(b"first".to_vec())
-        .expect("valid")
-        .build();
+        .build()
+        .expect("valid envelope");
     store
         .append(&id, None, &[env1])
         .await
@@ -219,8 +219,8 @@ async fn sequence_stale_expected_version_conflict() {
     let env2 = pending_envelope(Version::new(2).unwrap())
         .event_type("E")
         .payload(b"second".to_vec())
-        .expect("valid")
-        .build();
+        .build()
+        .expect("valid envelope");
     let result = store.append(&id, None, &[env2]).await;
     assert!(
         matches!(result, Err(AppendError::Conflict { .. })),
@@ -241,8 +241,8 @@ async fn sequence_multi_event_batch() {
             pending_envelope(Version::new(v).unwrap())
                 .event_type("BatchEvent")
                 .payload(vec![u8::try_from(v).unwrap()])
-                .expect("valid")
                 .build()
+                .expect("valid envelope")
         })
         .collect();
 
@@ -295,8 +295,8 @@ async fn lifecycle_write_close_reopen() {
         let env = pending_envelope(Version::new(1).unwrap())
             .event_type("LifecycleEvent")
             .payload(b"written-before-close".to_vec())
-            .expect("valid")
-            .build();
+            .build()
+            .expect("valid envelope");
         store
             .append(&id, None, &[env])
             .await
@@ -361,8 +361,8 @@ async fn defensive_read_stream_beyond_head_is_empty() {
     let env = pending_envelope(Version::new(1).unwrap())
         .event_type("E")
         .payload(b"only".to_vec())
-        .expect("valid")
-        .build();
+        .build()
+        .expect("valid envelope");
     store.append(&id, None, &[env]).await.expect("append");
 
     // Read from version 100 — beyond the head at version 1.
@@ -395,8 +395,8 @@ async fn defensive_corrupt_row_surfaces_error_not_panic() {
     let valid = pending_envelope(Version::new(1).unwrap())
         .event_type("GoodEvent")
         .payload(b"good".to_vec())
-        .expect("valid")
-        .build();
+        .build()
+        .expect("valid envelope");
     store
         .append(&id, None, &[valid])
         .await
@@ -468,8 +468,8 @@ async fn linearizability_concurrent_append_and_read() {
             let env = pending_envelope(Version::new(v).unwrap())
                 .event_type("LinEvent")
                 .payload(format!("p{v}").into_bytes())
-                .expect("valid")
-                .build();
+                .build()
+                .expect("valid envelope");
             writer_store
                 .append(&writer_id, expected, &[env])
                 .await

--- a/crates/nexus-postgres/tests/subscription_tests.rs
+++ b/crates/nexus-postgres/tests/subscription_tests.rs
@@ -69,8 +69,8 @@ fn make_envelope(version: u64, event_type: &'static str, payload: Vec<u8>) -> Pe
     pending_envelope(Version::new(version).expect("version > 0"))
         .event_type(event_type)
         .payload(payload)
-        .expect("valid payload")
         .build()
+        .expect("valid envelope")
 }
 
 async fn append_one(

--- a/crates/nexus-store-testing/src/lib.rs
+++ b/crates/nexus-store-testing/src/lib.rs
@@ -464,8 +464,8 @@ async fn all_append<S: RawEventStore>(store: &S, id: &str, version: u64, payload
     let env = pending_envelope(Version::new(version).expect("version must be > 0"))
         .event_type("E")
         .payload(payload.to_vec())
-        .expect("valid payload")
-        .build();
+        .build()
+        .expect("valid envelope");
     store
         .append(&StreamKey::from_slice(id.as_bytes()), expected, &[env])
         .await

--- a/crates/nexus-store/benches/store_bench.rs
+++ b/crates/nexus-store/benches/store_bench.rs
@@ -234,8 +234,8 @@ fn make_envelopes(n: usize) -> Vec<PendingEnvelope> {
             pending_envelope(Version::new(version).unwrap())
                 .event_type("BenchEvent")
                 .payload(vec![1, 2, 3, 4])
-                .expect("valid payload")
                 .build()
+                .expect("valid envelope")
         })
         .collect()
 }
@@ -251,8 +251,8 @@ fn bench_builder_throughput(c: &mut Criterion) {
                 pending_envelope(black_box(Version::INITIAL))
                     .event_type("UserCreated")
                     .payload(vec![1, 2, 3, 4])
-                    .expect("valid payload")
-                    .build(),
+                    .build()
+                    .expect("valid envelope"),
             )
         });
     });

--- a/crates/nexus-store/src/catchup.rs
+++ b/crates/nexus-store/src/catchup.rs
@@ -187,8 +187,8 @@ mod tests {
             let env = pending_envelope(Version::new(v).unwrap())
                 .event_type("E")
                 .payload(b"e".to_vec())
-                .unwrap()
-                .build();
+                .build()
+                .unwrap();
             store.append(id, Version::new(v - 1), &[env]).await.unwrap();
         }
     }
@@ -306,8 +306,8 @@ mod tests {
         let env = pending_envelope(Version::new(2).unwrap())
             .event_type("E")
             .payload(b"e".to_vec())
-            .unwrap()
-            .build();
+            .build()
+            .unwrap();
         store
             .append(&StreamKey::from_slice(b"a"), Version::new(1), &[env])
             .await

--- a/crates/nexus-store/src/cbor.rs
+++ b/crates/nexus-store/src/cbor.rs
@@ -1054,8 +1054,8 @@ mod tests {
                 let pe = pending_envelope(Version::new(v).expect("nonzero"))
                     .event_type("E")
                     .payload(format!("{sid}-{v}").into_bytes())
-                    .expect("valid payload")
-                    .build();
+                    .build()
+                    .expect("valid envelope");
                 src.append(
                     &StreamKey::from_slice(sid.as_bytes()),
                     Version::new(v - 1),

--- a/crates/nexus-store/src/envelope.rs
+++ b/crates/nexus-store/src/envelope.rs
@@ -1,7 +1,7 @@
 use std::ops::Range;
 
 use bytes::Bytes;
-use nexus::Version;
+use nexus::{DomainEvent, Version};
 use thiserror::Error;
 
 use crate::value::{
@@ -203,13 +203,14 @@ pub struct WithEventType {
     event_type: EventType,
 }
 
-/// Step 3: has all core fields; optional `schema_version` override; finalize via `build`/`with_metadata`.
+/// Step 3: has all core fields; optional `schema_version`/`metadata`; finalize via `build`.
 #[derive(Debug)]
 pub struct WithPayload {
     version: Version,
     event_type: EventType,
-    payload: Payload,
+    payload: Bytes,
     schema_version: SchemaVersion,
+    metadata: Option<Bytes>,
 }
 
 impl WithVersion {
@@ -220,6 +221,12 @@ impl WithVersion {
             version: self.version,
             event_type: EventType::from_static_str(event_type),
         }
+    }
+
+    /// Derive the event type from a [`DomainEvent`] — no restating `name()`.
+    #[must_use]
+    pub fn event<E: DomainEvent + ?Sized>(self, event: &E) -> WithEventType {
+        self.event_type(event.name())
     }
 
     /// Set the event type from arbitrary bytes; validates UTF-8 and size cap.
@@ -238,21 +245,17 @@ impl WithVersion {
 }
 
 impl WithEventType {
-    /// Set the payload from any `Into<Bytes>` source. Fallible: validates
-    /// the size cap.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`EnvelopeError::Value`] if the payload exceeds
-    /// [`MAX_PAYLOAD_LEN`](crate::value::MAX_PAYLOAD_LEN).
-    pub fn payload(self, payload: impl Into<Bytes>) -> Result<WithPayload, EnvelopeError> {
-        let validated = Payload::from_bytes(payload.into())?;
-        Ok(WithPayload {
+    /// Stash the payload bytes from any `Into<Bytes>` source. Infallible —
+    /// validated in [`WithPayload::build`].
+    #[must_use]
+    pub fn payload(self, payload: impl Into<Bytes>) -> WithPayload {
+        WithPayload {
             version: self.version,
             event_type: self.event_type,
-            payload: validated,
+            payload: payload.into(),
             schema_version: SchemaVersion::INITIAL,
-        })
+            metadata: None,
+        }
     }
 }
 
@@ -264,35 +267,30 @@ impl WithPayload {
         self
     }
 
-    /// Build with no metadata. Infallible.
+    /// Stash metadata bytes from any `Into<Bytes>` source. Infallible —
+    /// validated in [`build`](Self::build).
     #[must_use]
-    pub fn build(self) -> PendingEnvelope {
-        PendingEnvelope {
-            version: self.version,
-            event_type: self.event_type,
-            schema_version: self.schema_version,
-            payload: self.payload,
-            metadata: None,
-        }
+    pub fn metadata(mut self, metadata: impl Into<Bytes>) -> Self {
+        self.metadata = Some(metadata.into());
+        self
     }
 
-    /// Build with metadata; fallible (validates non-empty + size cap).
+    /// Validate and finalize — the one fallible step.
     ///
     /// # Errors
     ///
-    /// Returns [`EnvelopeError::Value`] if the metadata is empty or
-    /// exceeds [`MAX_METADATA_LEN`](crate::value::MAX_METADATA_LEN).
-    pub fn with_metadata(
-        self,
-        metadata: impl Into<Bytes>,
-    ) -> Result<PendingEnvelope, EnvelopeError> {
-        let validated = Metadata::from_bytes(metadata.into())?;
+    /// Returns [`EnvelopeError::Value`] if the payload exceeds
+    /// [`MAX_PAYLOAD_LEN`](crate::value::MAX_PAYLOAD_LEN), or the metadata is
+    /// empty or exceeds [`MAX_METADATA_LEN`](crate::value::MAX_METADATA_LEN).
+    pub fn build(self) -> Result<PendingEnvelope, EnvelopeError> {
+        let payload = Payload::from_bytes(self.payload)?;
+        let metadata = self.metadata.map(Metadata::from_bytes).transpose()?;
         Ok(PendingEnvelope {
             version: self.version,
             event_type: self.event_type,
             schema_version: self.schema_version,
-            payload: self.payload,
-            metadata: Some(validated),
+            payload,
+            metadata,
         })
     }
 }
@@ -303,9 +301,13 @@ impl WithPayload {
 /// pending_envelope(version)
 ///     .event_type("UserCreated")
 ///     .payload(bytes)
-///     .build()
-/// // or
-///     .with_metadata(meta_bytes)
+///     .build()?
+/// // or, deriving the event type from a `DomainEvent`:
+/// pending_envelope(version)
+///     .event(&my_event)
+///     .payload(bytes)
+///     .metadata(meta_bytes)
+///     .build()?
 /// ```
 #[must_use]
 pub const fn pending_envelope(version: Version) -> WithVersion {
@@ -609,14 +611,26 @@ mod tests {
     use bytes::Bytes;
     use nexus::Version;
 
+    /// A minimal `DomainEvent` for exercising `.event(&e)`.
+    #[derive(Debug)]
+    struct TestEvent;
+
+    impl nexus::Message for TestEvent {}
+
+    impl DomainEvent for TestEvent {
+        fn name(&self) -> &'static str {
+            "TestEvent"
+        }
+    }
+
     #[test]
     fn pending_envelope_builds_with_metadata() {
         let env = pending_envelope(Version::INITIAL)
             .event_type("UserCreated")
             .payload(Bytes::from_static(b"payload-bytes"))
-            .expect("valid payload")
-            .with_metadata(Bytes::from_static(b"meta-bytes"))
-            .expect("valid metadata");
+            .metadata(Bytes::from_static(b"meta-bytes"))
+            .build()
+            .expect("valid envelope");
 
         assert_eq!(env.event_type(), "UserCreated");
         assert_eq!(env.payload(), b"payload-bytes");
@@ -629,8 +643,8 @@ mod tests {
         let env = pending_envelope(Version::INITIAL)
             .event_type("X")
             .payload(Bytes::from_static(b"p"))
-            .expect("valid payload")
-            .build();
+            .build()
+            .expect("valid envelope");
 
         assert_eq!(env.metadata(), None);
     }
@@ -640,9 +654,9 @@ mod tests {
         let env = pending_envelope(Version::INITIAL)
             .event_type("UserCreated")
             .payload(Bytes::from_static(b"payload-bytes"))
-            .expect("valid payload")
-            .with_metadata(Bytes::from_static(b"meta-bytes"))
-            .expect("valid metadata");
+            .metadata(Bytes::from_static(b"meta-bytes"))
+            .build()
+            .expect("valid envelope");
 
         assert_eq!(env.event_type_value().as_str(), "UserCreated");
         assert_eq!(env.payload_value().as_slice(), b"payload-bytes");
@@ -659,6 +673,45 @@ mod tests {
         let err = pending_envelope(Version::INITIAL)
             .event_type_bytes(Bytes::from(oversized))
             .expect_err("oversized must be rejected");
+        assert!(matches!(err, EnvelopeError::Value(_)));
+    }
+
+    #[test]
+    fn event_derives_same_event_type_as_event_type_name() {
+        let via_event = pending_envelope(Version::INITIAL)
+            .event(&TestEvent)
+            .payload(Bytes::from_static(b"p"))
+            .build()
+            .expect("valid envelope");
+        let via_name = pending_envelope(Version::INITIAL)
+            .event_type(TestEvent.name())
+            .payload(Bytes::from_static(b"p"))
+            .build()
+            .expect("valid envelope");
+
+        assert_eq!(via_event.event_type(), via_name.event_type());
+        assert_eq!(via_event.event_type(), "TestEvent");
+    }
+
+    #[test]
+    fn build_rejects_oversize_payload() {
+        let oversized = vec![0u8; crate::value::MAX_PAYLOAD_LEN + 1];
+        let err = pending_envelope(Version::INITIAL)
+            .event_type("X")
+            .payload(Bytes::from(oversized))
+            .build()
+            .expect_err("oversized payload must be rejected");
+        assert!(matches!(err, EnvelopeError::Value(_)));
+    }
+
+    #[test]
+    fn build_rejects_empty_metadata() {
+        let err = pending_envelope(Version::INITIAL)
+            .event_type("X")
+            .payload(Bytes::from_static(b"p"))
+            .metadata(Bytes::new())
+            .build()
+            .expect_err("empty metadata must be rejected");
         assert!(matches!(err, EnvelopeError::Value(_)));
     }
 

--- a/crates/nexus-store/src/export.rs
+++ b/crates/nexus-store/src/export.rs
@@ -157,8 +157,8 @@ mod tests {
         pending_envelope(Version::new(v).expect("nonzero"))
             .event_type("E")
             .payload(payload.to_vec())
-            .expect("valid payload")
             .build()
+            .expect("valid envelope")
     }
 
     async fn append_one(store: &InMemoryStore, id: &StreamKey, v: u64, payload: &[u8]) {
@@ -259,10 +259,10 @@ mod tests {
         let pending = pending_envelope(Version::INITIAL)
             .event_type("Created")
             .payload(b"body".to_vec())
-            .expect("valid payload")
             .schema_version(crate::value::SchemaVersion::from_u32(7).expect("nonzero"))
-            .with_metadata(b"meta".to_vec())
-            .expect("valid metadata");
+            .metadata(b"meta".to_vec())
+            .build()
+            .expect("valid envelope");
         store.append(&id, None, &[pending]).await.expect("append");
 
         let exported = collect_export(&store, &id, Version::INITIAL).await;

--- a/crates/nexus-store/src/import.rs
+++ b/crates/nexus-store/src/import.rs
@@ -863,8 +863,8 @@ mod tests {
         pending_envelope(v(ver))
             .event_type("E")
             .payload(Bytes::copy_from_slice(payload))
-            .expect("valid payload")
             .build()
+            .expect("valid envelope")
     }
 
     fn planned(target: &str, expected: Option<u64>, versions: &[u64]) -> PlannedAppend {

--- a/crates/nexus-store/src/repository.rs
+++ b/crates/nexus-store/src/repository.rs
@@ -481,10 +481,10 @@ where
         let schema_nz32 = version_to_nz32(schema_version).ok_or(StoreError::VersionOverflow)?;
 
         let envelope = pending_envelope(next_version)
-            .event_type(event_name)
-            .payload(payload)?
+            .event(event)
+            .payload(payload)
             .schema_version(SchemaVersion::new(schema_nz32))
-            .build();
+            .build()?;
 
         last_version = next_version;
         envelopes.push(envelope);

--- a/crates/nexus-store/src/subscription_cursor.rs
+++ b/crates/nexus-store/src/subscription_cursor.rs
@@ -160,8 +160,8 @@ mod tests {
             let env = pending_envelope(Version::new(v).unwrap())
                 .event_type("E")
                 .payload(b"e".to_vec())
-                .unwrap()
-                .build();
+                .build()
+                .unwrap();
             store.append(id, Version::new(v - 1), &[env]).await.unwrap();
         }
     }
@@ -263,8 +263,8 @@ mod tests {
         let env = pending_envelope(Version::new(2).unwrap())
             .event_type("E")
             .payload(b"e".to_vec())
-            .unwrap()
-            .build();
+            .build()
+            .unwrap();
         store
             .append(&StreamKey::from_slice(b"a"), Version::new(1), &[env])
             .await
@@ -296,8 +296,8 @@ mod tests {
             let env = pending_envelope(Version::new(2).unwrap())
                 .event_type("E")
                 .payload(b"e".to_vec())
-                .unwrap()
-                .build();
+                .build()
+                .unwrap();
             writer
                 .append(&StreamKey::from_slice(b"b"), Version::new(1), &[env])
                 .await

--- a/crates/nexus-store/src/testing.rs
+++ b/crates/nexus-store/src/testing.rs
@@ -785,8 +785,8 @@ mod bounded_read_tests {
         pending_envelope(Version::new(v).unwrap())
             .event_type("E")
             .payload(vec![v as u8])
-            .unwrap()
             .build()
+            .unwrap()
     }
 
     async fn seed(store: &InMemoryStore, id: &StreamKey, count: u64) {
@@ -898,8 +898,8 @@ mod global_read_tests {
         let env = pending_envelope(Version::new(version).unwrap())
             .event_type("E")
             .payload(payload.to_vec())
-            .unwrap()
-            .build();
+            .build()
+            .unwrap();
         store
             .append(&sk(id), expected.and_then(Version::new), &[env])
             .await
@@ -1043,8 +1043,8 @@ mod bounded_subscription_tests {
         pending_envelope(Version::new(v).unwrap())
             .event_type("E")
             .payload(vec![v as u8])
-            .unwrap()
             .build()
+            .unwrap()
     }
 
     #[tokio::test]
@@ -1104,8 +1104,8 @@ mod wake_source_tests {
         let env = pending_envelope(Version::INITIAL)
             .event_type("E")
             .payload(b"x".to_vec())
-            .unwrap()
-            .build();
+            .build()
+            .unwrap();
         store.append(&id, None, &[env]).await.unwrap();
         timeout(Duration::from_secs(5), wait)
             .await

--- a/crates/nexus-store/tests/adversarial_property_tests.rs
+++ b/crates/nexus-store/tests/adversarial_property_tests.rs
@@ -243,8 +243,8 @@ fn build_envelopes(payloads: &[Vec<u8>]) -> Vec<PendingEnvelope> {
             pending_envelope(Version::new(u64::try_from(i).unwrap() + 1).unwrap())
                 .event_type(leak("TestEvent"))
                 .payload(p.clone())
-                .expect("valid payload")
                 .build()
+                .expect("valid envelope")
         })
         .collect()
 }
@@ -257,8 +257,8 @@ fn build_envelopes_from(start_version: u64, payloads: &[Vec<u8>]) -> Vec<Pending
             pending_envelope(Version::new(start_version + u64::try_from(i).unwrap()).unwrap())
                 .event_type(leak("TestEvent"))
                 .payload(p.clone())
-                .expect("valid payload")
                 .build()
+                .expect("valid envelope")
         })
         .collect()
 }
@@ -404,8 +404,8 @@ proptest! {
         let env = pending_envelope(ver)
             .event_type(leak("AnyType"))
             .payload(payload.clone())
-            .expect("valid payload")
-            .build();
+            .build()
+            .expect("valid envelope");
 
         prop_assert_eq!(env.version().as_u64(), version);
         prop_assert_eq!(env.event_type(), "AnyType");
@@ -573,8 +573,8 @@ proptest! {
                 pending_envelope(Version::new(v).unwrap())
                     .event_type(leak("E"))
                     .payload(vec![v as u8])
-                    .expect("valid payload")
                     .build()
+                    .expect("valid envelope")
             }).collect();
 
             let result = store.append(&stream_id, None, &envelopes).await;
@@ -604,8 +604,8 @@ proptest! {
                 pending_envelope(Version::INITIAL)
                     .event_type(leak("E"))
                     .payload(vec![1])
-                    .expect("valid payload")
                     .build()
+                    .expect("valid envelope")
             }).collect();
 
             let result = store.append(&stream_id, None, &envelopes).await;
@@ -641,8 +641,8 @@ proptest! {
                 pending_envelope(Version::new(v).unwrap())
                     .event_type(leak("E"))
                     .payload(vec![v as u8])
-                    .expect("valid payload")
                     .build()
+                    .expect("valid envelope")
             }).collect();
 
             let result = store.append(&stream_id, None, &envelopes).await;
@@ -1058,8 +1058,8 @@ async fn attack_event_store_transforms_applied_on_load() {
         pending_envelope(Version::INITIAL)
             .event_type(leak("Happened"))
             .payload(payload)
-            .expect("valid payload")
-            .build(),
+            .build()
+            .expect("valid envelope"),
     ];
     raw_store
         .append(
@@ -1249,8 +1249,8 @@ proptest! {
             let envelope = pending_envelope(Version::INITIAL)
                 .event_type(leak("E"))
                 .payload(vec![1, 2, 3])
-                .expect("valid payload")
-                .build();
+                .build()
+                .expect("valid envelope");
 
             // Append should not panic (may succeed or fail with error)
             let result = store.append(&stream_id, None, &[envelope]).await;
@@ -1680,8 +1680,8 @@ async fn attack_concurrent_writers_exactly_one_wins() {
             let envelope = pending_envelope(Version::INITIAL)
                 .event_type(Box::leak(format!("Writer{writer_id}").into_boxed_str()))
                 .payload(vec![writer_id as u8])
-                .expect("valid payload")
-                .build();
+                .build()
+                .expect("valid envelope");
 
             store
                 .append(

--- a/crates/nexus-store/tests/adversarial_tests.rs
+++ b/crates/nexus-store/tests/adversarial_tests.rs
@@ -56,8 +56,8 @@ fn max_version_envelope() {
     let envelope = pending_envelope(Version::new(u64::MAX).unwrap())
         .event_type("Event")
         .payload(vec![])
-        .expect("valid payload")
-        .build();
+        .build()
+        .expect("valid envelope");
 
     assert_eq!(envelope.version().as_u64(), u64::MAX);
 
@@ -75,8 +75,8 @@ fn empty_payload() {
     let envelope = pending_envelope(Version::INITIAL)
         .event_type("EmptyEvent")
         .payload(vec![])
-        .expect("valid payload")
-        .build();
+        .build()
+        .expect("valid envelope");
 
     assert!(envelope.payload().is_empty());
     assert_eq!(envelope.payload().len(), 0);
@@ -93,8 +93,8 @@ fn large_payload() {
     let envelope = pending_envelope(Version::INITIAL)
         .event_type("LargeEvent")
         .payload(payload)
-        .expect("valid payload")
-        .build();
+        .build()
+        .expect("valid envelope");
 
     assert_eq!(envelope.payload().len(), size);
     assert!(

--- a/crates/nexus-store/tests/bounded_batch_proptest.rs
+++ b/crates/nexus-store/tests/bounded_batch_proptest.rs
@@ -50,8 +50,8 @@ proptest! {
                 let env = pending_envelope(Version::new(v).unwrap())
                     .event_type("E")
                     .payload(vec![(v % 256) as u8])
-                    .unwrap()
-                    .build();
+                    .build()
+                    .unwrap();
                 store.append(&id, Version::new(v - 1), &[env]).await.unwrap();
             }
             let mut stream = store.read_stream(&id, Version::INITIAL).await.unwrap();

--- a/crates/nexus-store/tests/bug_hunt_tests.rs
+++ b/crates/nexus-store/tests/bug_hunt_tests.rs
@@ -243,18 +243,18 @@ async fn append_rejects_backwards_versions() {
         pending_envelope(Version::new(3).unwrap())
             .event_type("E")
             .payload(vec![3])
-            .expect("valid payload")
-            .build(),
+            .build()
+            .expect("valid envelope"),
         pending_envelope(Version::new(2).unwrap())
             .event_type("E")
             .payload(vec![2])
-            .expect("valid payload")
-            .build(),
+            .build()
+            .expect("valid envelope"),
         pending_envelope(Version::new(1).unwrap())
             .event_type("E")
             .payload(vec![1])
-            .expect("valid payload")
-            .build(),
+            .build()
+            .expect("valid envelope"),
     ];
 
     let result = store
@@ -295,8 +295,8 @@ proptest! {
         let envelope = pending_envelope(Version::INITIAL)
             .event_type("E")
             .payload(payload.clone())
-            .expect("valid payload")
-            .build();
+            .build()
+            .expect("valid envelope");
         prop_assert_eq!(envelope.payload(), payload.as_slice());
     }
 
@@ -315,8 +315,8 @@ proptest! {
                     pending_envelope(Version::new(v).unwrap())
                         .event_type("E")
                         .payload(vec![v as u8])
-                        .expect("valid payload")
                         .build()
+                        .expect("valid envelope")
                 })
                 .collect();
 
@@ -446,9 +446,9 @@ fn bug_probe_metadata_bytes_stored_correctly() {
     let envelope = pending_envelope(Version::INITIAL)
         .event_type("E")
         .payload(vec![])
-        .expect("valid payload")
-        .with_metadata(meta.clone())
-        .expect("valid metadata");
+        .metadata(meta.clone())
+        .build()
+        .expect("valid envelope");
 
     assert_eq!(envelope.version(), Version::INITIAL);
     assert_eq!(envelope.metadata(), Some(meta.as_slice()));

--- a/crates/nexus-store/tests/envelope_tests.rs
+++ b/crates/nexus-store/tests/envelope_tests.rs
@@ -29,8 +29,8 @@ fn pending_envelope_accessors() {
     let envelope = pending_envelope(Version::new(1).unwrap())
         .event_type("UserCreated")
         .payload(vec![1, 2, 3])
-        .expect("valid payload")
-        .build();
+        .build()
+        .expect("valid envelope");
 
     assert_eq!(envelope.version(), Version::new(1).unwrap());
     assert_eq!(envelope.event_type(), "UserCreated");
@@ -44,9 +44,9 @@ fn pending_envelope_with_metadata() {
     let envelope = pending_envelope(Version::new(1).unwrap())
         .event_type("OrderPlaced")
         .payload(vec![4, 5, 6])
-        .expect("valid payload")
-        .with_metadata(meta.clone())
-        .expect("valid metadata");
+        .metadata(meta.clone())
+        .build()
+        .expect("valid envelope");
 
     assert_eq!(envelope.metadata(), Some(meta.as_slice()));
 }
@@ -101,8 +101,8 @@ fn pending_envelope_debug_output() {
     let envelope = pending_envelope(Version::new(7).unwrap())
         .event_type("UserCreated")
         .payload(vec![1, 2, 3])
-        .expect("valid payload")
-        .build();
+        .build()
+        .expect("valid envelope");
     let debug = format!("{envelope:?}");
     assert!(
         debug.contains("PendingEnvelope"),
@@ -125,8 +125,8 @@ fn build_without_metadata_has_no_metadata() {
     let env = pending_envelope(Version::new(5).unwrap())
         .event_type("Evt")
         .payload(vec![9, 8, 7])
-        .expect("valid payload")
-        .build();
+        .build()
+        .expect("valid envelope");
 
     assert!(env.metadata().is_none());
     assert_eq!(env.version(), Version::new(5).unwrap());

--- a/crates/nexus-store/tests/inmemory_conformance.rs
+++ b/crates/nexus-store/tests/inmemory_conformance.rs
@@ -36,16 +36,16 @@ async fn inmemory_event_stream_conforms() {
                     let event_type: &'static str = Box::leak(r.event_type.into_boxed_str());
                     let with_payload = pending_envelope(Version::new(r.version).unwrap())
                         .event_type(event_type)
-                        .payload(r.payload)
-                        .expect("valid payload");
+                        .payload(r.payload);
                     if r.schema_version == 1 {
-                        with_payload.build()
+                        with_payload.build().expect("valid envelope")
                     } else {
                         with_payload
                             .schema_version(SchemaVersion::new(
                                 NonZeroU32::new(r.schema_version).unwrap(),
                             ))
                             .build()
+                            .expect("valid envelope")
                     }
                 })
                 .collect();

--- a/crates/nexus-store/tests/inmemory_store_tests.rs
+++ b/crates/nexus-store/tests/inmemory_store_tests.rs
@@ -18,8 +18,8 @@ async fn append_conflict_truncates_overlong_stream_id_with_ellipsis() {
     let env = pending_envelope(Version::new(1).unwrap())
         .event_type("E")
         .payload(b"p".to_vec())
-        .unwrap()
-        .build();
+        .build()
+        .unwrap();
     // New stream + Some(expected) → conflict carrying the truncated id label.
     let err = store
         .append(&long, Version::new(1), &[env])
@@ -45,8 +45,8 @@ async fn append_and_read_back() {
     let envelope = pending_envelope(Version::INITIAL)
         .event_type("TestEvent")
         .payload(b"hello".to_vec())
-        .expect("valid payload")
-        .build();
+        .build()
+        .expect("valid envelope");
     store
         .append(&StreamKey::from_slice(b"stream-1"), None, &[envelope])
         .await
@@ -72,18 +72,18 @@ async fn read_from_version_filters_correctly() {
         pending_envelope(Version::new(1).unwrap())
             .event_type("E1")
             .payload(b"one".to_vec())
-            .expect("valid payload")
-            .build(),
+            .build()
+            .expect("valid envelope"),
         pending_envelope(Version::new(2).unwrap())
             .event_type("E2")
             .payload(b"two".to_vec())
-            .expect("valid payload")
-            .build(),
+            .build()
+            .expect("valid envelope"),
         pending_envelope(Version::new(3).unwrap())
             .event_type("E3")
             .payload(b"three".to_vec())
-            .expect("valid payload")
-            .build(),
+            .build()
+            .expect("valid envelope"),
     ];
     store
         .append(&StreamKey::from_slice(b"s1"), None, &envelopes)
@@ -120,13 +120,13 @@ async fn append_assigns_monotonic_all_position_across_batches_and_streams() {
         pending_envelope(Version::new(1).unwrap())
             .event_type("A1")
             .payload(b"a1".to_vec())
-            .expect("valid payload")
-            .build(),
+            .build()
+            .expect("valid envelope"),
         pending_envelope(Version::new(2).unwrap())
             .event_type("A2")
             .payload(b"a2".to_vec())
-            .expect("valid payload")
-            .build(),
+            .build()
+            .expect("valid envelope"),
     ];
     store
         .append(&StreamKey::from_slice(b"a"), None, &batch_a)
@@ -139,8 +139,8 @@ async fn append_assigns_monotonic_all_position_across_batches_and_streams() {
         pending_envelope(Version::new(1).unwrap())
             .event_type("B1")
             .payload(b"b1".to_vec())
-            .expect("valid payload")
-            .build(),
+            .build()
+            .expect("valid envelope"),
     ];
     store
         .append(&StreamKey::from_slice(b"b"), None, &batch_b)

--- a/crates/nexus-store/tests/integration_tests.rs
+++ b/crates/nexus-store/tests/integration_tests.rs
@@ -33,8 +33,8 @@ fn make_envelopes(start: u64, count: u64) -> Vec<nexus_store::envelope::PendingE
             pending_envelope(Version::new(v).unwrap())
                 .event_type("Event")
                 .payload(v.to_le_bytes().to_vec())
-                .expect("valid payload")
                 .build()
+                .expect("valid envelope")
         })
         .collect()
 }

--- a/crates/nexus-store/tests/property_tests.rs
+++ b/crates/nexus-store/tests/property_tests.rs
@@ -60,8 +60,8 @@ fn build_envelopes(payloads: &[Vec<u8>]) -> Vec<PendingEnvelope> {
             pending_envelope(Version::new(version_num).unwrap())
                 .event_type(leak_event_type("TestEvent"))
                 .payload(p.clone())
-                .expect("valid payload")
                 .build()
+                .expect("valid envelope")
         })
         .collect()
 }

--- a/crates/nexus-store/tests/repository_qa_tests.rs
+++ b/crates/nexus-store/tests/repository_qa_tests.rs
@@ -853,8 +853,8 @@ async fn d4_zero_copy_event_store_with_payload_mutating_upcaster() {
     let legacy = pending_envelope(Version::INITIAL)
         .event_type("Delta")
         .payload(5_i32.to_le_bytes().to_vec())
-        .expect("valid payload")
-        .build(); // schema_version defaults to 1
+        .build()
+        .expect("valid envelope"); // schema_version defaults to 1
     raw_store
         .append(
             &nexus_store::StreamKey::from_slice(b"counter-1"),
@@ -891,8 +891,8 @@ async fn d4_upcaster_must_not_double_apply_to_new_events() {
     let legacy = pending_envelope(Version::INITIAL)
         .event_type("Delta")
         .payload(5_i32.to_le_bytes().to_vec())
-        .expect("valid payload")
-        .build(); // schema_version defaults to 1
+        .build()
+        .expect("valid envelope"); // schema_version defaults to 1
     raw_store
         .append(
             &nexus_store::StreamKey::from_slice(b"counter-1"),
@@ -1470,13 +1470,13 @@ async fn d11_schema_version_always_one() {
         pending_envelope(Version::INITIAL)
             .event_type("Incremented")
             .payload(b"inc".to_vec())
-            .expect("valid payload")
-            .build(),
+            .build()
+            .expect("valid envelope"),
         pending_envelope(Version::new(2).unwrap())
             .event_type("Set")
             .payload(b"set:42".to_vec())
-            .expect("valid payload")
-            .build(),
+            .build()
+            .expect("valid envelope"),
     ];
     store
         .append(

--- a/crates/nexus-store/tests/security_tests.rs
+++ b/crates/nexus-store/tests/security_tests.rs
@@ -52,8 +52,8 @@ fn c2_builder_accepts_empty_event_type() {
     let envelope = pending_envelope(Version::INITIAL)
         .event_type("")
         .payload(vec![1])
-        .expect("valid payload")
-        .build();
+        .build()
+        .expect("valid envelope");
     assert_eq!(envelope.event_type(), "");
 }
 
@@ -101,18 +101,18 @@ async fn h5_append_with_non_sequential_versions() {
         pending_envelope(Version::new(3).unwrap())
             .event_type("E")
             .payload(vec![])
-            .expect("valid payload")
-            .build(),
+            .build()
+            .expect("valid envelope"),
         pending_envelope(Version::new(1).unwrap())
             .event_type("E")
             .payload(vec![])
-            .expect("valid payload")
-            .build(),
+            .build()
+            .expect("valid envelope"),
         pending_envelope(Version::new(5).unwrap())
             .event_type("E")
             .payload(vec![])
-            .expect("valid payload")
-            .build(),
+            .build()
+            .expect("valid envelope"),
     ];
 
     // This should fail — versions must be sequential
@@ -139,13 +139,13 @@ async fn h5_append_with_duplicate_versions() {
         pending_envelope(Version::INITIAL)
             .event_type("E")
             .payload(vec![])
-            .expect("valid payload")
-            .build(),
+            .build()
+            .expect("valid envelope"),
         pending_envelope(Version::INITIAL)
             .event_type("E")
             .payload(vec![])
-            .expect("valid payload")
-            .build(), // dup!
+            .build()
+            .expect("valid envelope"), // dup!
     ];
 
     let result = store
@@ -181,13 +181,13 @@ fn m2_pending_envelope_no_partial_eq() {
     let e1 = pending_envelope(Version::INITIAL)
         .event_type("E")
         .payload(vec![1])
-        .expect("valid payload")
-        .build();
+        .build()
+        .expect("valid envelope");
     let e2 = pending_envelope(Version::INITIAL)
         .event_type("E")
         .payload(vec![1])
-        .expect("valid payload")
-        .build();
+        .build()
+        .expect("valid envelope");
     // Can't do assert_eq!(e1, e2) — no PartialEq
     // So we compare field by field
     assert_eq!(e1.version(), e2.version());
@@ -227,15 +227,15 @@ async fn streams_are_isolated() {
         pending_envelope(Version::INITIAL)
             .event_type("EventA")
             .payload(vec![1])
-            .expect("valid payload")
-            .build(),
+            .build()
+            .expect("valid envelope"),
     ];
     let e2 = vec![
         pending_envelope(Version::INITIAL)
             .event_type("EventB")
             .payload(vec![2])
-            .expect("valid payload")
-            .build(),
+            .build()
+            .expect("valid envelope"),
     ];
 
     store

--- a/crates/nexus-store/tests/subscription_tests.rs
+++ b/crates/nexus-store/tests/subscription_tests.rs
@@ -37,8 +37,8 @@ fn make_envelope(version: u64, event_type: &'static str) -> nexus_store::Pending
     pending_envelope(Version::new(version).unwrap())
         .event_type(event_type)
         .payload(format!("payload-{version}").into_bytes())
-        .expect("valid payload")
         .build()
+        .expect("valid envelope")
 }
 
 /// Helper: append a single event to a stream, with expected version.

--- a/crates/nexus-store/tests/wire_alignment_tests.rs
+++ b/crates/nexus-store/tests/wire_alignment_tests.rs
@@ -36,8 +36,8 @@ fn build_envelope(version: u64, event_type: &'static str, payload_len: usize) ->
     pending_envelope(Version::new(version).expect("version > 0"))
         .event_type(event_type)
         .payload(payload)
-        .expect("valid payload")
         .build()
+        .expect("valid envelope")
 }
 
 fn assert_payload_aligned(env: &nexus_store::PersistedEnvelope) {

--- a/docs/plans/2026-07-02-envelope-builder-ergonomics-design.md
+++ b/docs/plans/2026-07-02-envelope-builder-ergonomics-design.md
@@ -1,0 +1,115 @@
+# Envelope builder: one fallible terminal + derive `event_type`
+
+**Issue:** #254 — `pending_envelope` builder returns a `Result` mid-chain and makes you restate `event_type`/version.
+**Status:** design — research settled (approach A).
+**Date:** 2026-07-02
+
+---
+
+## The three frictions
+
+```rust
+pending_envelope(ver)              // 3. version threaded by hand
+    .event_type(event.name())      // 2. restate the name the event already knows
+    .payload(payload).expect(...)  // 1. Result in the MIDDLE of the chain
+    .build()
+```
+
+Confirmed in the code: `WithEventType::payload() -> Result<WithPayload, EnvelopeError>` (validates the size cap at the setter), and `with_metadata()` / `event_type_bytes()` are fallible too — so the fluent chain breaks with a `?`/`.expect()` before `.build()`.
+
+## Prior art (rule 0)
+
+The idiomatic Rust convention is **validation at the terminal `build()`**, not mid-chain. `bon`: "validations are deferred until you invoke the finishing `build()`" — mid-chain setter validation exists but is the documented exception. `derive_builder` runs its `validate` fn inside `build()`. ([bon fallible builders](https://bon-rs.com/guide/patterns/fallible-builders), [typed-builder](https://github.com/idanarye/rust-typed-builder), [derive_builder](https://docs.rs/derive_builder)). ES frameworks derive the event *type* from the event (EventStoreDB `EventData` type, Axon/Marten from the class) and let the append **position own the version** — you never restate either.
+
+## Design (approach A)
+
+Three targeted changes to the `pending_envelope` typestate builder in `crates/nexus-store/src/envelope.rs`. Keep the typestate ordering (`version → event_type → payload → build`); make every intermediate step **infallible** and move validation to a single fallible `build()`.
+
+### 1. Single fallible terminal — `build() -> Result`
+
+Setters stash raw bytes; `build()` validates payload (and metadata) once.
+
+```rust
+impl WithEventType {
+    /// Stash the payload bytes. Infallible — validation happens in `build`.
+    #[must_use]
+    pub fn payload(self, payload: impl Into<Bytes>) -> WithPayload { /* store Bytes, no check */ }
+}
+
+impl WithPayload {
+    #[must_use]
+    pub const fn schema_version(mut self, v: SchemaVersion) -> Self { /* unchanged */ }
+
+    /// Stash metadata bytes. Infallible — validation happens in `build`.
+    #[must_use]
+    pub fn metadata(mut self, metadata: impl Into<Bytes>) -> Self { /* store Some(Bytes) */ }
+
+    /// Validate and finalize. The **one** fallible step.
+    ///
+    /// # Errors
+    /// [`EnvelopeError::Value`] if the payload exceeds `MAX_PAYLOAD_LEN`, or
+    /// metadata is empty / exceeds `MAX_METADATA_LEN`.
+    pub fn build(self) -> Result<PendingEnvelope, EnvelopeError> {
+        let payload = Payload::from_bytes(self.payload)?;
+        let metadata = self.metadata.map(Metadata::from_bytes).transpose()?;
+        Ok(PendingEnvelope { /* … */ })
+    }
+}
+```
+
+`WithPayload` now holds `payload: Bytes` and `metadata: Option<Bytes>` (raw) instead of the pre-validated newtypes. `with_metadata` is **deleted** — folded into the `.metadata()` setter + fallible `build()`. The old infallible `build()` becomes fallible; that is the accepted single terminal.
+
+### 2. Derive `event_type` from the event — `.event(&e)`
+
+```rust
+impl WithVersion {
+    /// Set the event type from a `&'static str` literal. Infallible. (unchanged)
+    pub fn event_type(self, event_type: &'static str) -> WithEventType { /* … */ }
+
+    /// Derive the event type from a `DomainEvent` — no restating `name()`.
+    #[must_use]
+    pub fn event<E: DomainEvent + ?Sized>(self, event: &E) -> WithEventType {
+        self.event_type(event.name())   // name() is &'static str → EventType::from_static_str, infallible
+    }
+}
+```
+
+`DomainEvent` is already a dependency of `nexus-store` (via `nexus`). `event_type_bytes(Bytes) -> Result<..>` (the raw-bytes escape hatch) **stays fallible** — it's the rare "I have arbitrary bytes, not a `&'static str` or a `DomainEvent`" path, and it is not part of the fluent common chain; keeping its check at the setter is acceptable (it is itself a near-terminal branch). *Alternatively fold it into `build()` too — decide during implementation from whether any caller uses it mid-chain.*
+
+### 3. Version — lean on #253, don't re-solve
+
+The card's "no hand-computed version" is already delivered by #253's `Version::run` (yields the contiguous versions to zip with events). The builder simply **takes** a `Version` at `pending_envelope(ver)` — stating it, not computing it. No new version machinery here.
+
+### Result
+
+```rust
+pending_envelope(ver)
+    .event(&event)        // derives type from name()
+    .payload(bytes)       // infallible
+    .build()?             // the single fallible terminal
+```
+
+One `?`, at the end. Nothing restated. The internal `save_events` (repository.rs) and the raw-path examples collapse to this shape.
+
+## Migration surface (this is the cost)
+
+The API change touches **every** caller (`.payload(x)?.build()` → `.payload(x).build()?`, `.with_metadata(m)` → `.metadata(m).build()?`):
+- **Internal:** `save_events` in `repository.rs` (uses `.payload(payload)?`).
+- **Tests (~8 files):** `inmemory_conformance`, `property_tests`, `bounded_batch_proptest`, `subscription_tests`, `bug_hunt_tests`, `inmemory_store_tests`, `adversarial_property_tests`, plus the envelope.rs unit tests. Note `bug_hunt_tests` has builder-specific probes (`bug_probe_cannot_construct_pending_envelope_without_builder`, `attack_pending_envelope_builder_preserves_all_fields`) — update, don't delete.
+- **Examples:** the `store-inmemory`/`store-and-kernel` raw-path seeds, and any `encode_decided`-style helper (also adopt `.event(&e)` to drop the restated `event.name()`).
+
+A wide but mechanical sed-like change. The typestate still forbids illegal orderings, so most misconversions won't compile.
+
+## Testing (rule 7 first)
+
+1. **Sequence/protocol:** the full chain `pending_envelope(v).event(&e).payload(p).metadata(m).build()?` yields an envelope with the right version/type/payload/metadata; `.event(&e)` produces the same `event_type` as `.event_type(e.name())`.
+2. **Boundary/defensive:** `build()` returns `Err(EnvelopeError::Value)` for an oversize payload and for empty / oversize metadata — the check moved to the terminal, so prove it still fires there. Payload at exactly `MAX_PAYLOAD_LEN` builds; `+1` errors.
+3. **Typestate (compile-fail or existing probe):** you still cannot `build()` without version/event_type/payload; `metadata` is optional. Keep `bug_probe_cannot_construct_pending_envelope_without_builder`.
+4. **Equivalence:** an envelope built the new way is byte-identical (same wire frame) to the old way for the same inputs — the refactor is behavior-preserving except for *where* the `Result` surfaces.
+
+## What this does not do (approach A scope)
+
+- No `VersionedEvent<&E>`-rooted builder (that was option B — rejected as over-machinery).
+- No change to `PersistedEnvelope` (read path) or the wire frame.
+- No new version API — #253 owns that.
+- `event_type_bytes` may stay fallible (rare escape hatch); the *common* chain is Result-free until `build()`.

--- a/docs/plans/2026-07-02-envelope-builder-ergonomics-plan.md
+++ b/docs/plans/2026-07-02-envelope-builder-ergonomics-plan.md
@@ -1,0 +1,180 @@
+# Envelope Builder Ergonomics (#254) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development or superpowers:executing-plans. Steps use `- [ ]` checkboxes.
+
+**Goal:** Make `pending_envelope` a clean chain — one fallible terminal `build() -> Result`, an `.event(&e)` that derives `event_type` from `DomainEvent::name()`, and no mid-chain `Result` (#254).
+
+**Architecture:** Refactor the typestate builder in `crates/nexus-store/src/envelope.rs`: infallible setters that stash raw `Bytes`, validation moved into a single fallible `build()`; add `WithVersion::event(&e)`; delete `with_metadata` (fold into a `.metadata()` setter). Because this is an API break, the builder change and **every** call-site migration land in ONE commit.
+
+**Design doc:** `docs/plans/2026-07-02-envelope-builder-ergonomics-design.md`
+
+**Conventions:** run tests `nix develop -c cargo test -p nexus-store -- <name>`. Don't run `nix flake check` by hand — the pre-commit hook runs it (Bash `timeout: 600000` on `git commit`; if it times out with exit 143, check `git log` and re-run, up to 3×). All `use` at top. Strict clippy (pedantic/nursery denied); examples/tests need `--all-targets --all-features` (not covered by the `--lib` flake gate).
+
+---
+
+## Task 1: Atomic builder refactor + all call-site migrations (ONE commit)
+
+**Files:**
+- Modify: `crates/nexus-store/src/envelope.rs` (the builder + its unit tests)
+- Modify: `crates/nexus-store/src/repository.rs` (`save_events` uses `.payload(payload)?`)
+- Modify test callers: `crates/nexus-store/tests/{inmemory_conformance,property_tests,bounded_batch_proptest,subscription_tests,bug_hunt_tests,inmemory_store_tests,adversarial_property_tests}.rs`
+- Modify examples: `examples/store-inmemory/src/main.rs`, `examples/store-and-kernel/src/main.rs`, and any other example using `pending_envelope` (grep to confirm).
+
+### Step 1: Refactor the builder in `envelope.rs`
+
+Change the three intermediate states so setters are infallible and `build()` is the single fallible terminal. Target shape:
+
+- `WithVersion` gains `event`:
+```rust
+impl WithVersion {
+    #[must_use]
+    pub fn event_type(self, event_type: &'static str) -> WithEventType { /* unchanged: EventType::from_static_str */ }
+
+    /// Derive the event type from a `DomainEvent` — no restating `name()`.
+    #[must_use]
+    pub fn event<E: DomainEvent + ?Sized>(self, event: &E) -> WithEventType {
+        self.event_type(event.name())
+    }
+
+    // event_type_bytes(Bytes) -> Result<WithEventType, EnvelopeError> stays as-is
+    // (rare raw-bytes escape hatch, not part of the fluent common chain).
+}
+```
+Add `use nexus::DomainEvent;` to the top imports if not already present.
+
+- `WithEventType::payload` becomes infallible and `WithPayload` holds raw `Bytes`:
+```rust
+#[derive(Debug)]
+pub struct WithPayload {
+    version: Version,
+    event_type: EventType,
+    payload: Bytes,                 // raw — validated in build()
+    schema_version: SchemaVersion,
+    metadata: Option<Bytes>,        // raw — validated in build()
+}
+
+impl WithEventType {
+    /// Stash the payload bytes. Infallible — validated in `build`.
+    #[must_use]
+    pub fn payload(self, payload: impl Into<Bytes>) -> WithPayload {
+        WithPayload {
+            version: self.version,
+            event_type: self.event_type,
+            payload: payload.into(),
+            schema_version: SchemaVersion::INITIAL,
+            metadata: None,
+        }
+    }
+}
+```
+
+- `WithPayload`: keep `schema_version`, add a `metadata` setter, make `build()` the fallible terminal, delete `with_metadata`:
+```rust
+impl WithPayload {
+    #[must_use]
+    pub const fn schema_version(mut self, schema_version: SchemaVersion) -> Self {
+        self.schema_version = schema_version;
+        self
+    }
+
+    /// Stash metadata bytes. Infallible — validated in `build`.
+    #[must_use]
+    pub fn metadata(mut self, metadata: impl Into<Bytes>) -> Self {
+        self.metadata = Some(metadata.into());
+        self
+    }
+
+    /// Validate and finalize — the one fallible step.
+    ///
+    /// # Errors
+    /// [`EnvelopeError::Value`] if the payload exceeds `MAX_PAYLOAD_LEN`, or the
+    /// metadata is empty or exceeds `MAX_METADATA_LEN`.
+    pub fn build(self) -> Result<PendingEnvelope, EnvelopeError> {
+        let payload = Payload::from_bytes(self.payload)?;
+        let metadata = self.metadata.map(Metadata::from_bytes).transpose()?;
+        Ok(PendingEnvelope {
+            version: self.version,
+            event_type: self.event_type,
+            schema_version: self.schema_version,
+            payload,
+            metadata,
+        })
+    }
+}
+```
+Delete the old `with_metadata` method entirely. Update the `pending_envelope` doc example to `.build()?`.
+
+### Step 2: Update `envelope.rs`'s own unit tests
+
+The existing `pending_envelope_builds_with_metadata` / `_without_metadata` tests use the old API. Convert them: `.payload(p)?` → `.payload(p)`, `.with_metadata(m)` → `.metadata(m)`, terminal `.build()` → `.build()?` (or `.build().unwrap()` in tests). Add:
+```rust
+#[test]
+fn event_derives_type_from_domain_event_name() { /* .event(&e) event_type == e.name() */ }
+
+#[test]
+fn build_rejects_oversize_payload() { /* payload > MAX_PAYLOAD_LEN → Err(EnvelopeError::Value) at build() */ }
+
+#[test]
+fn build_rejects_empty_metadata() { /* .metadata(empty).build() → Err */ }
+```
+(Define a tiny local `DomainEvent` impl for the `.event()` test, or reuse an existing test event in the crate.)
+
+### Step 3: Fix `save_events` in `repository.rs`
+
+Current:
+```rust
+let envelope = pending_envelope(next_version)
+    .event_type(event_name)
+    .payload(payload)?
+    .schema_version(SchemaVersion::new(schema_nz32))
+    .build();
+```
+becomes:
+```rust
+let envelope = pending_envelope(next_version)
+    .event(event)                 // derive type from the DomainEvent — drops `event.name()`
+    .payload(payload)
+    .schema_version(SchemaVersion::new(schema_nz32))
+    .build()?;
+```
+`event` is the `&EventOf<A>` in scope (it's a `DomainEvent`). The `?` now folds `EnvelopeError` into the function's error — confirm `StoreError` has a `From<EnvelopeError>` or map it (`save_events` returns `StoreError`; check how it currently converts — there may already be an `EnvelopeError` arm/`From`. If not, add a `map_err`). Keep `event_name`/`schema` logic; only the builder call changes. If `event.name()` is still needed for `current_version(event_name)`, keep that line.
+
+### Step 4: Migrate every remaining call site (compiler-driven)
+
+Build the crate: `nix develop -c cargo build -p nexus-store --all-targets` (timeout 600000). The compiler now errors at every old call site. Apply the mechanical transform at each:
+- `.payload(x)?` → `.payload(x)`
+- terminal `.build()` → `.build()?` (or `.build().unwrap()` in tests where a panic is the intended assertion)
+- `.with_metadata(m)` → `.metadata(m)` then ensure the terminal is `.build()?`
+- Where a `DomainEvent` is in scope and the code does `.event_type(e.name())`, switch to `.event(&e)` (examples' encode helpers).
+
+Repeat build until clean. Do the same for examples: `nix develop -c cargo build -p nexus-example-store-inmemory -p nexus-example-store-and-kernel --all-targets` (confirm real package names via `grep -h '^name' examples/*/Cargo.toml`), plus any other example the grep in Step 5 flags.
+
+### Step 5: Verify
+
+- `nix develop -c grep -rn "with_metadata\|\.payload([^)]*)?" crates/ examples/` — no surviving `with_metadata` calls; no `.payload(...)?` (the `?` should be gone).
+- `nix develop -c cargo test -p nexus-store` (timeout 600000) → all pass.
+- Run the affected example tests (per-package) → pass.
+- `nix develop -c cargo clippy --all-targets --all-features` (timeout 600000) → clean.
+
+### Step 6: Commit (Bash timeout 600000)
+```bash
+git add crates/nexus-store/src/envelope.rs crates/nexus-store/src/repository.rs crates/nexus-store/tests/ examples/
+git commit -m "feat(store)!: envelope builder — one fallible terminal + .event() derives type (#254)"
+```
+(The `!` marks the breaking API change. Include any other files the compiler forced you to touch — `git add -u` after building to catch them all, then review `git status` before committing.)
+
+---
+
+## Task 2: Whole-branch review + PR
+
+- [ ] **Step 1: Review** `git diff origin/main..HEAD`: confirm (a) no mid-chain `Result` remains in the builder (only `build()`/`event_type_bytes` are fallible), (b) `.event(&e)` derives the same `event_type` as `.event_type(e.name())`, (c) payload/metadata validation genuinely still fires — at `build()` now (an oversize payload must still error), (d) `save_events` error conversion is correct (`EnvelopeError` → `StoreError`, no domain blurring — rule 3), (e) no call site silently dropped a validation.
+- [ ] **Step 2: Open PR** (`joeldsouzax` account), title `feat(store)!: envelope builder ergonomics (#254)`, body summarizing the one-terminal + `.event()` change and noting the breaking API (mid-chain `?` moves to `.build()?`). `Closes #254`. Squash-merge on green (`--delete-branch`).
+
+---
+
+## Self-Review Notes (author checklist — done)
+- **Coverage:** single fallible `build()` (T1 S1), `.event(&e)` derive (T1 S1), delete `with_metadata` → `.metadata()` setter (T1 S1), internal + all-caller migration (T1 S3-4), version left to #253 (no-op here) ✓.
+- **Consistency:** `WithPayload` now holds raw `Bytes`/`Option<Bytes>`; `build() -> Result<PendingEnvelope, EnvelopeError>`; `.metadata()`/`.event()` infallible; `event_type_bytes` stays fallible — used consistently across steps.
+- **Rule adherence:** rule 3 — `EnvelopeError` stays its own domain, `save_events` maps it into `StoreError` without blurring; validation not silently dropped (moved, not removed) — the boundary tests prove it still fires at `build()`.
+- **Watch-items:** (1) `save_events` may already have an `EnvelopeError → StoreError` conversion — check before adding one; (2) `bug_hunt_tests` builder probes must be updated not deleted; (3) confirm no example/test relied on `build()` being infallible (it's now `Result`); (4) `event_type_bytes` fallibility — leave as-is unless a caller uses it mid-chain.
+```

--- a/examples/projection-tokio/tests/loop_tests.rs
+++ b/examples/projection-tokio/tests/loop_tests.rs
@@ -196,10 +196,10 @@ async fn append_events(store: &Store<InMemoryStore>, stream_id: &TestId, events:
         .map(|(ver, event)| {
             let payload = codec.encode(event).unwrap();
             pending_envelope(ver)
-                .event_type(event.name())
+                .event(event)
                 .payload(payload)
-                .expect("valid payload")
                 .build()
+                .expect("valid envelope")
         })
         .collect();
 
@@ -820,8 +820,8 @@ async fn runner_returns_event_codec_error_on_bad_payload() {
     let bad_envelope = pending_envelope(version!(1))
         .event_type("Added")
         .payload(vec![0xFF]) // invalid: too short
-        .expect("valid payload")
-        .build();
+        .build()
+        .expect("valid envelope");
     store
         .raw()
         .append(

--- a/examples/store-and-kernel/src/main.rs
+++ b/examples/store-and-kernel/src/main.rs
@@ -226,10 +226,10 @@ fn encode_decided(
         .map(|(ver, event)| {
             let payload = codec.encode(event).expect("encode should succeed");
             pending_envelope(ver)
-                .event_type(event.name())
+                .event(event)
                 .payload(payload)
-                .expect("valid payload")
                 .build()
+                .expect("valid envelope")
         })
         .collect()
 }

--- a/examples/store-inmemory/src/main.rs
+++ b/examples/store-inmemory/src/main.rs
@@ -221,8 +221,8 @@ async fn main() {
         let envelope = pending_envelope(version)
             .event_type(event_type)
             .payload(payload.clone())
-            .expect("valid payload")
-            .build();
+            .build()
+            .expect("valid envelope");
         println!(
             "  Envelope: version={}, type={}",
             envelope.version(),
@@ -266,8 +266,8 @@ async fn main() {
         let legacy_envelope = pending_envelope(version!(4))
             .event_type("TaskCreated")
             .payload(old_json.into_bytes())
-            .expect("valid payload")
-            .build();
+            .build()
+            .expect("valid envelope");
 
         store
             .append(
@@ -354,8 +354,8 @@ async fn main() {
     let envelope = pending_envelope(Version::INITIAL)
         .event_type("TodoCreated")
         .payload(payload)
-        .expect("valid payload")
-        .build();
+        .build()
+        .expect("valid envelope");
     typed_store
         .raw()
         .append(&StreamKey::from_slice(b"todo-2"), None, &[envelope])


### PR DESCRIPTION
Closes #254.

## What

Reshapes the `pending_envelope` typestate builder so constructing an envelope is a clean chain:

```rust
// before — Result in the middle, restated event name
pending_envelope(ver)
    .event_type(event.name())
    .payload(payload).expect("valid")   // ← mid-chain Result
    .build();

// after — infallible setters, one fallible terminal, type derived
pending_envelope(ver)
    .event(&event)                       // ← derives event_type from DomainEvent::name()
    .payload(payload)                    // ← infallible
    .build()?;                           // ← the single fallible step
```

- **One fallible terminal.** Setters stash raw `Bytes`; payload + metadata validation moved into `build() -> Result` (idiomatic bon/derive_builder convention). No more `?`/`.expect()` mid-chain.
- **`.event(&e)` derives `event_type`** from `DomainEvent::name()` — no restating the name the event already knows.
- **`with_metadata` deleted**, folded into an infallible `.metadata()` setter validated at `build()`.
- Version is stated, not computed — #253's `Version::run` already removed the hand-arithmetic.

## Breaking

This is a breaking API change (`!`): mid-chain `.payload(x)?` becomes `.payload(x)` + terminal `.build()?`; `.with_metadata(m)` becomes `.metadata(m)`. All call sites across `nexus-store`, `nexus-fjall`, `nexus-postgres`, `nexus-store-testing`, and the examples are migrated in this PR (~40 sites). Pre-freeze ergonomics — intended.

## Research

Rule-0 prior art: validation belongs at the terminal `build()` (bon: "validations are deferred until you invoke the finishing `build()`"); ES frameworks derive event type from the event and let the append position own the version. Full write-up: `docs/plans/2026-07-02-envelope-builder-ergonomics-design.md`.

## Test Plan

- [x] `.event(&e)` yields the same `event_type` as `.event_type(e.name())`
- [x] `build()` returns `Err(EnvelopeError::Value)` for oversize payload / empty metadata — validation still fires, at the terminal now
- [x] Typestate still forbids building without version/event_type/payload (builder probe retained)
- [x] Full `nix flake check` green (nextest + clippy across the workspace)

🤖 Generated with [Claude Code](https://claude.com/claude-code)